### PR TITLE
Fix tests

### DIFF
--- a/src/indexer_selection/tests.rs
+++ b/src/indexer_selection/tests.rs
@@ -3,7 +3,7 @@ use crate::{
         test_utils::{default_cost_model, gen_blocks, TEST_KEY},
         Indexers, Indexing, UtilityConfig,
     },
-    prelude::{test_utils::bytes_from_id, *},
+    prelude::{test_utils::*, *},
 };
 use rand::{thread_rng, Rng as _};
 use std::collections::{BTreeMap, HashMap};
@@ -26,7 +26,7 @@ struct IndexerResults {
 
 #[tokio::test]
 async fn battle_high_and_low() {
-    init_tracing(false);
+    init_test_tracing();
     let (mut input_writers, inputs) = Indexers::inputs();
     let indexers = Indexers::new(inputs);
     input_writers

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -11,24 +11,21 @@ pub use prometheus::{
     self,
     core::{MetricVec, MetricVecBuilder},
 };
-pub use std::{convert::TryInto, str::FromStr, sync::Once};
+pub use std::{convert::TryInto, str::FromStr};
 pub use tokio::sync::{mpsc, oneshot};
 pub use tracing::{self, Instrument};
 use tracing_subscriber::{self, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 pub fn init_tracing(json: bool) {
-    static ONCE: Once = Once::new();
-    ONCE.call_once(|| {
-        let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
-            .unwrap_or(tracing_subscriber::EnvFilter::try_new("info,graph_gateway=debug").unwrap());
-        let defaults = tracing_subscriber::registry().with(filter_layer);
-        let fmt_layer = tracing_subscriber::fmt::layer();
-        if json {
-            defaults.with(fmt_layer.json()).init();
-        } else {
-            defaults.with(fmt_layer).init();
-        }
-    })
+    let filter_layer = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or(tracing_subscriber::EnvFilter::try_new("info,graph_gateway=debug").unwrap());
+    let defaults = tracing_subscriber::registry().with(filter_layer);
+    let fmt_layer = tracing_subscriber::fmt::layer();
+    if json {
+        defaults.with(fmt_layer.json()).init();
+    } else {
+        defaults.with(fmt_layer).init();
+    }
 }
 
 pub fn with_metric<T, F, B>(metric_vec: &MetricVec<B>, label_values: &[&str], f: F) -> Option<T>

--- a/src/prelude/test_utils.rs
+++ b/src/prelude/test_utils.rs
@@ -1,4 +1,6 @@
+use crate::prelude::*;
 use std::io::{Cursor, Write as _};
+use std::sync::Once;
 
 pub const BASIC_QUERY: &'static str = "{ entities { id } }";
 
@@ -7,4 +9,9 @@ pub fn bytes_from_id<const N: usize>(id: usize) -> [u8; N] {
     let mut cursor = Cursor::new(buf.as_mut());
     let _ = cursor.write(&id.to_le_bytes());
     buf
+}
+
+pub fn init_test_tracing() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| init_tracing(false))
 }

--- a/src/query_engine/tests.rs
+++ b/src/query_engine/tests.rs
@@ -3,11 +3,7 @@ use crate::{
         self,
         test_utils::{default_cost_model, TEST_KEY},
     },
-    prelude::{
-        decimal,
-        test_utils::{bytes_from_id, BASIC_QUERY},
-        *,
-    },
+    prelude::{decimal, test_utils::*, *},
     query_engine::*,
 };
 use async_trait::async_trait;
@@ -594,7 +590,7 @@ impl fmt::Debug for Topology {
 
 #[tokio::test]
 async fn test() {
-    init_tracing(false);
+    init_test_tracing();
     let seed = env::vars()
         .find(|(k, _)| k == "TEST_SEED")
         .and_then(|(_, v)| v.parse::<u64>().ok())


### PR DESCRIPTION
This PR fixes the tests, since they were broken in recent updates. The `init_tracing` function is also updated to only init the logger once, since concurrent attempts (which sometimes occurs while tests are running concurrently) will panic.