### PR TITLE
Fix mnemonic private key derivation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,14 +105,10 @@ async fn main() {
             .expect("Invalid mnemonic"),
         "",
     );
-    let key_path = std::iter::once("m".to_string())
-        .chain("scalar/allocations".bytes().map(|b| b.to_string()))
-        .collect::<Vec<String>>()
-        .join("/");
     let signer_key = hdwallet::DefaultKeyChain::new(
         hdwallet::ExtendedPrivKey::with_seed(wallet_seed.as_bytes()).expect("Invalid mnemonic"),
     )
-    .derive_private_key(key_path.into())
+    .derive_private_key(key_path("scalar/allocations").into())
     .expect("Failed to derive signer key")
     .0
     .private_key;

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -39,6 +39,14 @@ where
         .map(f)
 }
 
+/// Encode the given name into a valid BIP-32 key chain path.
+pub fn key_path(name: &str) -> String {
+    std::iter::once("m".to_string())
+        .chain(name.bytes().map(|b| b.to_string()))
+        .collect::<Vec<String>>()
+        .join("/")
+}
+
 /// Decimal Parts-Per-Million with 6 fractional digits
 pub type PPM = UDecimal<6>;
 /// Decimal USD with 18 fractional digits


### PR DESCRIPTION
`m/scalar/allocations` is not a valid chain path. The previous gateway used `'m/' + [...Buffer.from('scalar/allocations')].join('/')` to create this path. So the resulting string should actually be `m/115/99/97/108/97/114/47/97/108/108/111/99/97/116/105/111/110/115`.