### PR TITLE
Change Docker base image from Alpine to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN cargo build --release
 FROM debian:buster-slim
 
 RUN apt-get update && apt-get install -y \
-  libssl-dev \
+  libssl1.1 \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /opt/gateway/target/release/graph-gateway /opt/gateway/target/release/graph-gateway


### PR DESCRIPTION
The Alpine base image would result in a segfault, probably on an attempt to dynamically load libssl.