### PR TITLE
Resolve block heads in query engine tests

### DIFF
--- a/src/alchemy_client.rs
+++ b/src/alchemy_client.rs
@@ -1,7 +1,6 @@
 use crate::{
     indexer_selection::{Indexers, UnresolvedBlock},
     prelude::*,
-    query_engine::BlockHead,
     ws_client,
 };
 use prometheus;
@@ -215,10 +214,7 @@ impl Client {
         if latest {
             self.metrics.head_block.set(head.block.number as i64);
         }
-        self.indexers.set_block(&self.network, head.block).await;
-        for uncle in head.uncles {
-            self.indexers.remove_block(&self.network, &uncle).await;
-        }
+        self.indexers.set_block_head(&self.network, head).await;
     }
 
     fn post_body(method: &str, params: &[JSON]) -> JSON {

--- a/src/indexer_selection/mod.rs
+++ b/src/indexer_selection/mod.rs
@@ -219,6 +219,13 @@ impl Indexers {
             .remove_block(network, block_hash);
     }
 
+    pub async fn set_block_head(&self, network: &str, head: BlockHead) {
+        self.set_block(&network, head.block).await;
+        for uncle in head.uncles {
+            self.remove_block(&network, &uncle).await;
+        }
+    }
+
     pub async fn latest_block(&self, network: &str) -> Result<BlockPointer, UnresolvedBlock> {
         self.network_cache.read().await.latest_block(network, 0)
     }

--- a/src/indexer_selection/network_cache.rs
+++ b/src/indexer_selection/network_cache.rs
@@ -609,7 +609,7 @@ mod tests {
 
     #[test]
     fn block_number_gte_determinism() {
-        let mut cache = cache_with("mainnet", &gen_blocks(&[0, 1, 2, 3, 4, 5, 6, 7]));
+        let cache = cache_with("mainnet", &gen_blocks(&[0, 1, 2, 3, 4, 5, 6, 7]));
         let context = Context::new("query { a(block: { number_gte: 4 }) }", "").unwrap();
         let result = cache.make_query_deterministic("mainnet", context, 2);
         assert_eq!(

--- a/src/prelude/mod.rs
+++ b/src/prelude/mod.rs
@@ -66,6 +66,12 @@ pub struct BlockPointer {
     pub hash: Bytes32,
 }
 
+#[derive(Debug, Clone)]
+pub struct BlockHead {
+    pub block: BlockPointer,
+    pub uncles: Vec<Bytes32>,
+}
+
 pub trait Reader {
     type Writer;
     fn new() -> (Self::Writer, Self);

--- a/src/query_engine/mod.rs
+++ b/src/query_engine/mod.rs
@@ -78,12 +78,6 @@ pub enum QueryEngineError {
     MissingBlocks(Vec<UnresolvedBlock>),
 }
 
-#[derive(Debug, Clone)]
-pub struct BlockHead {
-    pub block: BlockPointer,
-    pub uncles: Vec<Bytes32>,
-}
-
 struct Metrics {
     block_resolution_duration: prometheus::HistogramVec,
     block_resolution_requests_failed: prometheus::IntCounterVec,

--- a/src/query_engine/tests.rs
+++ b/src/query_engine/tests.rs
@@ -534,7 +534,7 @@ impl Resolver for TopologyResolver {
             Some(network) => &network.blocks,
             None => return vec![],
         };
-        let resolved = unresolved
+        let resolved: Vec<BlockHead> = unresolved
             .into_iter()
             .filter_map(|unresolved| {
                 let block = match unresolved {
@@ -545,7 +545,14 @@ impl Resolver for TopologyResolver {
                 Some(BlockHead { block, uncles })
             })
             .collect();
-        tracing::warn!(?resolved);
+        tracing::info!(?resolved);
+        for head in &resolved {
+            topology
+                .inputs
+                .indexers
+                .set_block_head(network, head.clone())
+                .await;
+        }
         resolved
     }
 


### PR DESCRIPTION
A recent change moved the role of setting block heads out of the query engine, but the tests were not modified to reflect this.