### PR TITLE
Improve error responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -420,6 +420,7 @@ async fn handle_subgraph_query(
                 match err {
                     QueryEngineError::MalformedQuery => "Invalid query",
                     QueryEngineError::SubgraphNotFound => "Subgraph deployment not found",
+                    QueryEngineError::NoIndexers => "No indexers found for subgraph deployment",
                     QueryEngineError::NoIndexerSelected => {
                         "No suitable indexer found for subgraph deployment"
                     }

--- a/src/query_engine/mod.rs
+++ b/src/query_engine/mod.rs
@@ -72,6 +72,7 @@ pub struct Attestation {
 #[derive(Debug)]
 pub enum QueryEngineError {
     SubgraphNotFound,
+    NoIndexers,
     NoIndexerSelected,
     APIKeySubgraphNotAuthorized,
     MalformedQuery,
@@ -265,6 +266,9 @@ impl<R: Clone + Resolver + Send + 'static> QueryEngine<R> {
             .and_then(|map| map.get(&deployment).cloned())
             .unwrap_or_default();
         tracing::debug!(?deployment, deployment_indexers = indexers.len());
+        if indexers.is_empty() {
+            return Err(NoIndexers);
+        }
         let _execution_timer = with_metric(
             &METRICS.query_execution_duration,
             &[&deployment_ipfs],


### PR DESCRIPTION
This PR adds error responses similar to those in the TS gateway. JSON parsing errors for API routes now result in a graphql-compatible error.