### PR TITLE
Add support for unattestable query responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -492,7 +492,7 @@ struct NetworkResolver {
 pub struct IndexerResponsePayload {
     #[serde(rename(deserialize = "graphQLResponse"))]
     pub graphql_response: String,
-    pub attestation: Attestation,
+    pub attestation: Option<Attestation>,
 }
 
 #[async_trait]


### PR DESCRIPTION
Add support for [GIP 20](https://hackmd.io/@CGmldHLrTRaYRnAva-HoPQ/S1W2vMjEt) (Unattestable Indexer Responses). If the response contains no attestation or the `Graph-Attestable` header is not set to `true`, then the query will be considered failed and will not trigger a possible dispute.