### PR TITLE
Fix Docker build on main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.55-buster AS build
+FROM rust:1.56-buster AS build
 
 ARG GH_USER
 ARG GH_TOKEN

--- a/src/stats_db.rs
+++ b/src/stats_db.rs
@@ -83,9 +83,7 @@ pub async fn create(
         "host={} port={} user={} password={} dbname={} sslmode=prefer",
         host, port, user, password, dbname
     );
-    let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
-    ssl_builder.set_verify(SslVerifyMode::NONE);
-    let ssl_connector = ssl_builder.build();
+    let ssl_connector = SslConnector::builder(SslMethod::tls()).unwrap().build();
     let (client, connection) =
         tokio_postgres::connect(&config, MakeTlsConnector::new(ssl_connector)).await?;
     // The connection object performs the actual communication with the database and is intended to


### PR DESCRIPTION
Update the build image to support Rust 2021 edition. Also enforce SSL cert verification for the timescale DB.
Closes #51