### PR TITLE
Catch more query processing panics returned by indexers

### DIFF
--- a/src/query_engine/mod.rs
+++ b/src/query_engine/mod.rs
@@ -546,7 +546,7 @@ impl Metrics {
 }
 
 /// Returns true if the GraphQL response includes at least one error whose
-/// message beings with the given message.
+/// message begins with the given message.
 fn indexer_response_has_error(response: &Response<Box<RawValue>>, msg: &'static str) -> bool {
     response
         .errors


### PR DESCRIPTION
This expands the temporary indexer error handling a little bit to catch more issues, in this case https://www.notion.so/edgeandnode/panic-processing-query-Once-instance-has-previously-been-poisoned-c361f517f3ce428b86a16efa8be6424c.