### PR TITLE
Revert "Use rustls"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,14 @@ hex = "0.4"
 im = "15.0" # Good vector implementation, CHAMP encoding should be added if we use a hash map/set
 lazy_static = "1.4"
 num-traits = "0.2"
+openssl = "0.10"
 ordered-float = "2.5"
+postgres-openssl = "0.5"
 primitive-types = "0.8"
 prometheus = "0.13"
 rand = { version = "0.8", features = ["small_rng"] }
 receipts = { git = "ssh://git@github.com/edgeandnode/receipts.git", rev = "02d09da" }
-reqwest = { version = "0.11", default-features = false, features = [
-  "json",
-  "rustls-tls",
-] }
-rustls = "0.20"
+reqwest = { version = "0.11", features = ["json"] }
 secp256k1 = "0.20"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value"] }
@@ -51,8 +49,7 @@ tokio = { version = "1.14", features = [
   "parking_lot",
 ] }
 tokio-postgres = { version = "0.7", features = ["runtime"] }
-tokio-postgres-rustls = "0.9"
-tokio-tungstenite = { version = "0.16", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.16", features = ["native-tls"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
   "env-filter",

--- a/src/stats_db.rs
+++ b/src/stats_db.rs
@@ -1,5 +1,6 @@
 use crate::{prelude::*, query_engine::APIKey};
-use rustls;
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use postgres_openssl::MakeTlsConnector;
 use std::{
     collections::{hash_map::Entry, HashMap},
     error::Error,
@@ -11,7 +12,6 @@ use tokio::{
     time::{interval, Interval},
 };
 use tokio_postgres::{self, types::Type};
-use tokio_postgres_rustls;
 
 pub enum Msg {
     AddQuery {
@@ -83,13 +83,11 @@ pub async fn create(
         "postgres://{}:{}@{}:{}/{}?sslmode=prefer",
         user, password, host, port, dbname,
     );
-    let tls = tokio_postgres_rustls::MakeRustlsConnect::new(
-        rustls::ClientConfig::builder()
-            .with_safe_defaults()
-            .with_root_certificates(rustls::RootCertStore::empty())
-            .with_no_client_auth(),
-    );
-    let (client, connection) = tokio_postgres::connect(&config, tls).await?;
+    let mut ssl_builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    ssl_builder.set_verify(SslVerifyMode::NONE);
+    let ssl_connector = ssl_builder.build();
+    let (client, connection) =
+        tokio_postgres::connect(&config, MakeTlsConnector::new(ssl_connector)).await?;
     // The connection object performs the actual communication with the database and is intended to
     // be executed on its own spawned task.
     tokio::spawn(async move {


### PR DESCRIPTION
This change is not practical until the Timescale DB connection is removed entirely.

This reverts commit e9e6f1a610e65e534563aa64631aa2afcbe3161b.