### PR TITLE
Release v5.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "5.4.0"
+version = "5.4.1"
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
# Release Notes
- Add metric for failed updates to stats DB (#140)
- Treat indexer store error as unattestable (#143)