### PR TITLE
Penalize indexers for unattestable responses

### DIFF
--- a/src/query_engine/mod.rs
+++ b/src/query_engine/mod.rs
@@ -500,6 +500,8 @@ where
                     &[&deployment_id, &indexer_id],
                     |counter| counter.inc(),
                 );
+                tracing::info!("penalizing for unattestable error");
+                self.indexers.penalize(&indexer_query.indexing, 35).await;
                 return Err(IndexerError::UnattestableError);
             }
         }


### PR DESCRIPTION
We are taking on the duty of the fisherman in this case, so we should be applying penalties.