### PR TITLE
Utility: Overhaul performance utility

### DIFF
--- a/src/indexer_selection/mod.rs
+++ b/src/indexer_selection/mod.rs
@@ -647,14 +647,14 @@ const UTILITY_CONFIGS_ECONOMIC_SECURITY: (UtilityParameters, UtilityParameters) 
         weight: 1.5,
     },
 );
-// https://www.desmos.com/calculator/reykkamaje
+// https://www.desmos.com/calculator/w6pxajuuve
 const UTILITY_CONFIGS_PERFORMANCE: (UtilityParameters, UtilityParameters) = (
     UtilityParameters {
-        a: 0.0032,
+        a: 1.1,
         weight: 1.0,
     },
     UtilityParameters {
-        a: 0.0016,
+        a: 1.2,
         weight: 1.5,
     },
 );
@@ -673,22 +673,17 @@ const UTILITY_CONFIGS_DATA_FRESHNESS: (UtilityParameters, UtilityParameters) = (
 // Note: This is only a weight.
 const UTILITY_CONFIGS_PRICE_EFFICIENCY: (f64, f64) = (0.5, 1.0);
 
-// TODO: For the user experience we should turn these into 0-1 values,
-// and from those calculate both a utility parameter and a weight
-// which should be used when combining utilities.
 impl UtilityConfig {
     pub fn from_preferences(preferences: &IndexerPreferences) -> Self {
-        fn interp(min: f64, max: f64, mut x: f64) -> f64 {
-            debug_assert!(max > min);
-            x = x.max(0.0).min(1.0);
-            min + ((max - min) * x)
+        fn interp(a: f64, b: f64, x: f64) -> f64 {
+            a + ((b - a) * x)
         }
         fn interp_utility(
             bounds: (UtilityParameters, UtilityParameters),
             x: f64,
         ) -> UtilityParameters {
             UtilityParameters {
-                a: interp(bounds.1.a, bounds.0.a, 1.0 - x),
+                a: interp(bounds.0.a, bounds.1.a, x),
                 weight: interp(bounds.0.weight, bounds.1.weight, x),
             }
         }

--- a/src/indexer_selection/price_efficiency.rs
+++ b/src/indexer_selection/price_efficiency.rs
@@ -193,12 +193,7 @@ mod test {
         eventuals::idle().await;
         let mut context = Context::new(BASIC_QUERY, "").unwrap();
         // Expected values based on https://www.desmos.com/calculator/kxd4kpjxi5
-        let tests = [
-            (0.01, 0.0),
-            (0.02, 0.487960),
-            (0.1, 0.64419),
-            (1.0, 0.68216),
-        ];
+        let tests = [(0.01, 0.0), (0.02, 0.27304), (0.1, 0.50615), (1.0, 0.55769)];
         for (budget, expected_utility) in tests {
             let (fee, utility) = efficiency
                 .get_price(


### PR DESCRIPTION
This change removes the confusing conversion of latency to "performance". Instead, we use a sigmoid curve to map our preferences from latency to utility directly. The resulting utility reflects our values much better than the old curve. For example, using the "lax" consumer preferences (no points spent on performance) the old curve yielded these latency -> utility conversions:

```
  30ms => 0.9592
  50ms => 0.1921
 250ms => 0.0151
 750ms => 0.0045
1500ms => 0.0021
```

Note that there is a huge falloff between 30ms and 50ms even though the result is not very differentiable to the users.

Under the new method:

```
  30ms => 0.9717
  50ms => 0.9512
 250ms => 0.5897
 750ms => 0.0389
1500ms => 0.0001
```

This would result in the following selections for this exact set assuming all else is equal:

```
  30ms => 42%
  50ms => 39%
 250ms => 19%
 750ms =>  1%
1500ms =>  0%
```

Graph of latency(ms) -> utility for high and low consumer preferences:
[https://www.desmos.com/calculator/iig6hydwdu](https://www.desmos.com/calculator/iig6hydwdu)