### PR TITLE
Utility: Lower economic security

### DIFF
--- a/src/indexer_selection/mod.rs
+++ b/src/indexer_selection/mod.rs
@@ -627,14 +627,14 @@ impl Indexers {
     }
 }
 
-// https://www.desmos.com/calculator/lzlii17feb
+// https://www.desmos.com/calculator/cwgj4ne5ow
 const UTILITY_CONFIGS_ECONOMIC_SECURITY: (UtilityParameters, UtilityParameters) = (
     UtilityParameters {
-        a: 0.000008,
+        a: 0.0008,
         weight: 1.0,
     },
     UtilityParameters {
-        a: 0.000004,
+        a: 0.0004,
         weight: 1.5,
     },
 );


### PR DESCRIPTION
For the "lax" economic security configuration and given the set of indexers with the **min, median, 10th, and 1st stakes** for the existing network participants, slashing percentage, and GRT conversion rate the previous selection rates would have been as so:

GRT Stake -> Selection Rate
```
159M => 80%
 34M => 19%
1.3M => 0%
100K => 0%
```

After the change, it would be this:
```
159M => 35%
 34M => 35%
1.3M => 26%
100K => 03%
```

This makes more intuitive sense, increases the priority of other utilities, and may even result in higher overall security due to more cross-checking.