### PR TITLE
fix(subsidized queries): retrieve isSubsidized from gateway-agent gql

### DIFF
--- a/graphql/api_keys.gql
+++ b/graphql/api_keys.gql
@@ -5,6 +5,7 @@ query APIKeys($lastUpdateId: String!) {
       apiKey {
         id
         key
+        isSubsidized
         queryBudgetUSD
         queryBudgetSelectionType
       }

--- a/graphql/sync_agent_schema.gql
+++ b/graphql/sync_agent_schema.gql
@@ -81,6 +81,7 @@ type Transfer {
 type ApiKeyInfo {
   id: Int!
   key: String!
+  isSubsidized: Boolean!
   queryBudgetUSD: String!
   queryBudgetSelectionType: String!
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -456,7 +456,10 @@ async fn handle_subgraph_query_inner(
             return Err("Invalid API key".into());
         }
     };
-    if !api_key.queries_activated {
+    // to handle the subsidized queries feature.
+    // if a user does not have queries_activated true, check if the api_key is subsidized.
+    // if the api key is subsidized, allow the query through
+    if !api_key.queries_activated && !api_key.is_subsidized {
         return Err(
             "Querying not activated yet; make sure to add some GRT to your balance in the studio"
                 .into(),

--- a/src/query_engine/mod.rs
+++ b/src/query_engine/mod.rs
@@ -127,6 +127,7 @@ impl fmt::Debug for QueryID {
 pub struct APIKey {
     pub id: i64,
     pub key: String,
+    pub is_subsidized: bool,
     pub user_id: i64,
     pub user_address: Address,
     pub queries_activated: bool,

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -406,6 +406,7 @@ fn parse_api_keys(
                         usage: usage.get(&value.api_key.key),
                         id: value.api_key.id,
                         key: value.api_key.key,
+                        is_subsidized: value.api_key.is_subsidized,
                         user_id: value.user.id,
                         user_address: value.user.eth_address.parse().ok()?,
                         queries_activated: value.user.queries_activated,


### PR DESCRIPTION
# Description

Check if the api key is subsidized, if it is, allow the user to query through it

[Ticket](https://app.asana.com/0/1200063886028203/1202185196307753/f)
[Studio PR](https://github.com/edgeandnode/subgraph-studio/pull/512)
[Gateway Agent PR](https://github.com/edgeandnode/gateway/pull/38)