### PR TITLE
Release v5.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1091,7 +1091,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "graph-gateway"
-version = "5.4.4"
+version = "5.5.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "5.4.4"
+version = "5.5.0"
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
# Release Notes
- Walk back latest block when indexers fail to resolve it (#158)
- fix(subsidized queries): retrieve isSubsidized from gateway-agent gql (#159)