### PR TITLE
Remove unnecessary indexer status query restriction

### DIFF
--- a/src/indexer_status.rs
+++ b/src/indexer_status.rs
@@ -188,7 +188,7 @@ impl Actor {
                 subgraph
                 chains {
                     network
-                    ... on EthereumIndexingStatus { latestBlock { number hash } }
+                    latestBlock { number hash }
                 }
             }
         }"# });


### PR DESCRIPTION
This field is provided on indexing statuses other than Ethereum.
See [the schema](https://github.com/graphprotocol/graph-node/blob/113e269fc63e381bf8a62ffdf19ede570b32821a/server/index-node/src/schema.graphql#L63)