### PR TITLE
Release 9.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "graph-gateway"
-version = "8.1.2"
+version = "9.0.0"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "8.1.2"
+version = "9.0.0"
 
 [dependencies]
 actix-cors = "=0.6.0-beta.4"


### PR DESCRIPTION
# Release Notes
- Fix metric initialization (910b5d0, 4bd8196)
- Check for indexer reporting missing block by number (4d05292)
- Shift GRT fees on commit (949618c)
- Add special API keys (e982390)
- Refactor block cache, chain clients, & GQL parsing (#214)
- Remove Timescale DB (#222)