### PR TITLE
Release 9.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1110,7 +1110,7 @@ checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "graph-gateway"
-version = "9.0.0"
+version = "9.1.0"
 dependencies = [
  "actix-cors",
  "actix-http",
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libloading"
@@ -2179,9 +2179,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.44"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd7356a8122b6c4a24a82b278680c73357984ca2fc79a0f9fa6dea7dced7c58"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "9.0.0"
+version = "9.1.0"
 
 [dependencies]
 actix-cors = "=0.6.0-beta.4"
@@ -9,7 +9,7 @@ actix-http = "=3.0.0-beta.14"
 actix-web = "=4.0.0-beta.13"
 actix-router = "=0.5.0-beta.4"
 async-trait = "0.1"
-clap = { version = "3.2.22", features = ["derive", "env"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 futures = "0.3"
 futures-util = "0.3"
 graphql-parser = { git = "https://github.com/graphql-rust/graphql-parser", rev = "8a759df" }


### PR DESCRIPTION
# Release Notes
- Migrate from structopt to clap (8898f9b)
- Make UDecimal parsing more explicit (f547ebc)
- Replace MIPs config with restricted deployments (#230)