### PR TITLE
Use snmalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1775,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "siphasher",
+ "snmalloc-rs",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2435,6 +2445,24 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snmalloc-rs"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bbab242a22c735dcd4c1441fffbe7004ea91f7d8fe7902cf283d72405ef978"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80756c9f5dacaa9ff49afddb77ea18e80013228128ced3c2162f13306a225dd7"
+dependencies = [
+ "cmake",
+]
 
 [[package]]
 name = "socket2"

--- a/prelude/Cargo.toml
+++ b/prelude/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 sha3 = "0.10"
 siphasher = "0.3"
+snmalloc-rs = "0.3"
 tokio = { version = "1.20", features = [
     "macros",
     "parking_lot",

--- a/prelude/src/lib.rs
+++ b/prelude/src/lib.rs
@@ -20,6 +20,9 @@ pub use tokio::{
 };
 pub use tracing::{self, Instrument};
 
+#[global_allocator]
+static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
 use serde::Deserialize;
 use siphasher::sip::SipHasher24;
 use std::{


### PR DESCRIPTION
# Destop Benchmarks

Manjaro Linux (kernel 6.0.2-2-MANJARO), AMD Ryzen 5 3600 (12) @ 3.6GHz, ~16 GB RAM

```bash
$ hyperfine --runs 5 --warmup 3 './sim-main <indexer-selection/tools/contrived-characteristics.csv' './sim-snmalloc <indexer-selection/tools/contrived-characteristics.csv'
Benchmark 1: ./sim-main <indexer-selection/tools/contrived-characteristics.csv
  Time (mean ± σ):     819.7 ms ±   3.2 ms    [User: 814.8 ms, System: 5.2 ms]
  Range (min … max):   815.2 ms … 823.2 ms    5 runs

Benchmark 2: ./sim-snmalloc <indexer-selection/tools/contrived-characteristics.csv
  Time (mean ± σ):     716.1 ms ±   2.2 ms    [User: 702.7 ms, System: 15.0 ms]
  Range (min … max):   713.6 ms … 719.5 ms    5 runs

Summary
  './sim-snmalloc <indexer-selection/tools/contrived-characteristics.csv' ran
    1.14 ± 0.01 times faster than './sim-main <indexer-selection/tools/contrived-characteristics.csv'
```

# 1u Benchmarks

- Rocky Linux 8.6 (kernel 4.18.0-372.19.1.el8_6.x86_64), Intel Xeon E5-2697 v2 (24) @ 3.5GHz, ~64 GB RAM

```bash
[theodus@dc2-node0 graph-gateway]$ hyperfine --runs 5 --warmup 3 './sim-main <indexer-selection/tools/contrived-characteristics.csv' './sim-snmalloc <indexer-selection/tools/contrived-characteristics.csv'
Benchmark 1: ./sim-main <indexer-selection/tools/contrived-characteristics.csv
  Time (mean ± σ):      1.632 s ±  0.017 s    [User: 1.601 s, System: 0.032 s]
  Range (min … max):    1.613 s …  1.649 s    5 runs

Benchmark 2: ./sim-snmalloc <indexer-selection/tools/contrived-characteristics.csv
  Time (mean ± σ):      1.386 s ±  0.010 s    [User: 1.361 s, System: 0.026 s]
  Range (min … max):    1.378 s …  1.404 s    5 runs

Summary
  './sim-snmalloc <indexer-selection/tools/contrived-characteristics.csv' ran
    1.18 ± 0.01 times faster than './sim-main <indexer-selection/tools/contrived-characteristics.csv'
```