### PR TITLE
Remove /network route

### DIFF
--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -20,14 +20,14 @@ mod unattestable_errors;
 mod vouchers;
 use crate::{
     chains::*, fisherman_client::*, geoip::GeoIP, indexer_client::IndexerClient,
-    indexer_status::IndexingStatus, ipfs_client::*, kafka_client::KafkaClient, metrics::*, opt::*,
+    indexer_status::IndexingStatus, ipfs_client::*, kafka_client::KafkaClient, opt::*,
     price_automation::QueryBudgetFactors, rate_limiter::*, receipts::ReceiptPools,
 };
 use actix_cors::Cors;
 use actix_web::{
     dev::ServiceRequest,
     http::{header, StatusCode},
-    web, App, HttpRequest, HttpResponse, HttpResponseBuilder, HttpServer,
+    web, App, HttpResponse, HttpResponseBuilder, HttpServer,
 };
 use anyhow::{self, anyhow};
 use clap::Parser as _;
@@ -203,11 +203,6 @@ async fn main() {
         isa_state,
         special_api_keys,
     };
-    let network_subgraph_query_data = NetworkSubgraphQueryData {
-        http_client,
-        network_subgraph: opt.network_subgraph,
-        network_subgraph_auth_token: opt.network_subgraph_auth_token,
-    };
     let ready_data = ReadyData {
         start_time: Instant::now(),
         block_caches,
@@ -270,11 +265,6 @@ async fn main() {
                 web::resource("/ready")
                     .app_data(web::Data::new(ready_data.clone()))
                     .route(web::get().to(handle_ready)),
-            )
-            .service(
-                web::resource("/network")
-                    .app_data(web::Data::new(network_subgraph_query_data.clone()))
-                    .route(web::post().to(handle_network_query)),
             )
             .service(
                 web::resource("/collect-receipts")
@@ -457,47 +447,6 @@ async fn handle_ready(data: web::Data<ReadyData>) -> HttpResponse {
     } else {
         // Respond with 425 Too Early
         HttpResponseBuilder::new(StatusCode::from_u16(425).unwrap()).body("Not ready")
-    }
-}
-
-#[derive(Clone)]
-struct NetworkSubgraphQueryData {
-    http_client: reqwest::Client,
-    network_subgraph: URL,
-    network_subgraph_auth_token: String,
-}
-
-async fn handle_network_query(
-    _: HttpRequest,
-    payload: String,
-    data: web::Data<NetworkSubgraphQueryData>,
-) -> HttpResponse {
-    let _timer = METRICS.network_subgraph.duration.start_timer();
-    let post_request = |body: String| async {
-        let response = data
-            .http_client
-            .post(data.network_subgraph.0.clone())
-            .body(body)
-            .header(header::CONTENT_TYPE.as_str(), "application/json")
-            .header(
-                "Authorization",
-                format!("Bearer {}", data.network_subgraph_auth_token),
-            )
-            .send()
-            .await?;
-        tracing::info!(network_subgraph_response = %response.status());
-        response.text().await
-    };
-    match post_request(payload).await {
-        Ok(result) => {
-            METRICS.network_subgraph.ok.inc();
-            HttpResponseBuilder::new(StatusCode::OK).body(result)
-        }
-        Err(network_subgraph_post_err) => {
-            tracing::error!(%network_subgraph_post_err);
-            METRICS.network_subgraph.err.inc();
-            graphql_error_response("Failed to process network subgraph query")
-        }
     }
 }
 

--- a/graph-gateway/src/metrics.rs
+++ b/graph-gateway/src/metrics.rs
@@ -13,7 +13,6 @@ lazy_static! {
 pub struct Metrics {
     pub client_query: ResponseMetricVecs,
     pub indexer_query: ResponseMetricVecs,
-    pub network_subgraph: ResponseMetrics,
     pub collect_receipts: ResponseMetrics,
     pub partial_voucher: ResponseMetrics,
     pub voucher: ResponseMetrics,
@@ -37,7 +36,6 @@ impl Metrics {
                 "indexer query",
                 &["deployment"],
             ),
-            network_subgraph: ResponseMetrics::new("gw_network_subgraph", "network subgraph query"),
             collect_receipts: ResponseMetrics::new(
                 "gw_collect_receipts",
                 "collect-receipts request",

--- a/graph-gateway/src/opt.rs
+++ b/graph-gateway/src/opt.rs
@@ -32,8 +32,6 @@ pub struct Opt {
     pub ethereum_providers: EthereumProviders,
     #[clap(long, env, help = "Network subgraph URL")]
     pub network_subgraph: URL,
-    #[clap(long, env, help = "Network subgraph auth token")]
-    pub network_subgraph_auth_token: String,
     #[clap(
         long,
         env,


### PR DESCRIPTION
This route is no longer served by the gateway. And the non-IPFS version of the core network subgraph will be published to the network and served like any other.