### PR TITLE
Add support for restricted networks

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -84,6 +84,7 @@ pub struct Context {
     pub block_caches: Arc<HashMap<String, BlockCache>>,
     pub subgraph_info: SubgraphInfoMap,
     pub subgraph_deployments: SubgraphDeployments,
+    pub restricted_networks: Arc<HashMap<String, HashSet<SubgraphDeploymentID>>>,
     pub deployment_indexers: Eventual<Ptr<HashMap<SubgraphDeploymentID, Vec<Address>>>>,
     pub receipt_pools: ReceiptPools,
     pub isa_state: DoubleBufferReader<indexer_selection::State>,
@@ -301,6 +302,18 @@ async fn handle_client_query_inner(
         .get(&subgraph_info.network)
         .cloned()
         .ok_or_else(|| anyhow!("Network not supported: {}", &subgraph_info.network))?;
+
+    if ctx
+        .restricted_networks
+        .get(&subgraph_info.network)
+        .map(|deployments| !deployments.contains(&subgraph_info.deployment))
+        .unwrap_or(false)
+    {
+        bail!(
+            "Subgraph not yet supported on network ({})",
+            subgraph_info.network
+        );
+    }
 
     let block_constraints = block_constraints(&context).ok_or(anyhow!("Invalid query"))?;
     let resolved_blocks = join_all(

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -190,6 +190,7 @@ async fn main() {
         },
         subgraph_info,
         subgraph_deployments: network_subgraph_data.subgraph_deployments,
+        restricted_networks: Arc::new(opt.restricted_networks.0),
         deployment_indexers: network_subgraph_data.deployment_indexers,
         api_keys: studio_data.api_keys,
         api_key_payment_required: opt.api_key_payment_required,

--- a/graph-gateway/src/opt.rs
+++ b/graph-gateway/src/opt.rs
@@ -5,7 +5,10 @@ use indexer_selection::SecretKey;
 use prelude::*;
 use rdkafka::config::ClientConfig as KafkaConfig;
 use semver::Version;
-use std::path::PathBuf;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 // TODO: Consider the security implications of passing mnemonics, passwords, etc. via environment variables or CLI arguments.
 
@@ -40,6 +43,8 @@ pub struct Opt {
         use_delimiter = true
     )]
     pub special_api_keys: Vec<String>,
+    #[clap(long, env, default_value = "")]
+    pub restricted_networks: RestrictedNetworks,
     #[clap(long, env)]
     pub restricted_deployments: Option<PathBuf>,
     #[clap(long, env, parse(try_from_str), help = "Format log output as JSON")]
@@ -211,6 +216,30 @@ impl FromStr for EthereumProviders {
             })
             .collect::<Option<Vec<ethereum::Provider>>>()
             .map(EthereumProviders)
+            .ok_or(err_usage)
+    }
+}
+
+#[derive(Debug)]
+pub struct RestrictedNetworks(pub HashMap<String, HashSet<SubgraphDeploymentID>>);
+
+impl FromStr for RestrictedNetworks {
+    type Err = &'static str;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let err_usage = "restricted_networks syntax: <network>=<deployment>(,<deployment>)*;...";
+        s.split_terminator(';')
+            .map(|network| {
+                let kv = network.splitn(2, '=').collect::<Vec<&str>>();
+                let network = kv.get(0)?.to_string();
+                let deployments = kv
+                    .get(1)?
+                    .split_terminator(',')
+                    .map(|deployment| deployment.parse::<SubgraphDeploymentID>().ok())
+                    .collect::<Option<HashSet<SubgraphDeploymentID>>>()?;
+                Some((network, deployments))
+            })
+            .collect::<Option<HashMap<String, HashSet<SubgraphDeploymentID>>>>()
+            .map(Self)
             .ok_or(err_usage)
     }
 }


### PR DESCRIPTION
This implements a last-minute feature for the gnosis migration to allowlist deployments on mainnet until the foundation gives the go-ahead to open it up to any deployment.