### PR TITLE
remove unnecessary abstraction between SubgraphDeployments and its inputs

### DIFF
--- a/graph-gateway/src/manifest_client.rs
+++ b/graph-gateway/src/manifest_client.rs
@@ -51,7 +51,7 @@ pub fn create(
                 let eventual_subgraph_info = Eventual::spawn(move |mut writer| async move {
                     loop {
                         let manifest_fetch_err =
-                            match subgraph_deployments.deployment_subgraph(&deployment).await {
+                            match subgraph_deployments.deployment_subgraphs(&deployment).await {
                                 None => anyhow!("deployment missing subgraph"),
                                 Some(subgraph) => {
                                     match fetch_manifest(&client, subgraph, deployment).await {

--- a/graph-gateway/src/subgraph_deployments.rs
+++ b/graph-gateway/src/subgraph_deployments.rs
@@ -1,45 +1,24 @@
-use eventuals::EventualExt;
 use prelude::*;
 use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct SubgraphDeployments {
-    inputs: Eventual<Ptr<Inputs>>,
+    pub inputs: Eventual<Ptr<Inputs>>,
 }
 
 #[derive(Clone)]
-struct Inputs {
+pub struct Inputs {
     // TODO: latest deployments may not be fully indexed, but the prior deployment might be.
-    current_deployments: HashMap<SubgraphID, SubgraphDeploymentID>,
+    pub current_deployments: HashMap<SubgraphID, SubgraphDeploymentID>,
     // A SubgraphDeploymentID is the Qm hash representation of the Subgraph manifest uploaded to decentralized storage (currently IPFS).
     // A SubgraphID is a hash of the owning user address and an incrementing integer owned by the GNS contract.
     // It is possible that multiple users could create the same Subgraph manifest, and therefore get the same Qm hash SubgraphDeploymentID.
     //  And then these multiple users could publish the Subgraph.
     // This creates a scenario where a single SubgraphDeploymentID could be linked with multiple SubgraphIDs.
-    deployment_to_subgraphs: HashMap<SubgraphDeploymentID, Vec<SubgraphID>>,
+    pub deployment_to_subgraphs: HashMap<SubgraphDeploymentID, Vec<SubgraphID>>,
 }
 
 impl SubgraphDeployments {
-    pub fn new(
-        subgraph_deployments: Eventual<(
-            Ptr<Vec<(SubgraphID, SubgraphDeploymentID)>>,
-            Ptr<Vec<(SubgraphDeploymentID, Vec<SubgraphID>)>>,
-        )>,
-    ) -> Self {
-        let inputs = subgraph_deployments.map(
-            |(current_deployments, deployment_to_subgraphs)| async move {
-                let current_deployments = HashMap::from_iter(current_deployments.iter().cloned());
-                let deployment_to_subgraphs =
-                    HashMap::from_iter(deployment_to_subgraphs.iter().cloned());
-                Ptr::new(Inputs {
-                    current_deployments,
-                    deployment_to_subgraphs,
-                })
-            },
-        );
-        Self { inputs }
-    }
-
     pub async fn current_deployment(&self, subgraph: &SubgraphID) -> Option<SubgraphDeploymentID> {
         self.inputs
             .value()
@@ -50,7 +29,7 @@ impl SubgraphDeployments {
             .cloned()
     }
 
-    pub async fn deployment_subgraph(
+    pub async fn deployment_subgraphs(
         &self,
         deployment: &SubgraphDeploymentID,
     ) -> Option<Vec<SubgraphID>> {


### PR DESCRIPTION
- Unfortunately this is a situation where code speaks faster than words. Mostly, the structure & inputs of `SubgraphDeployments` is unnecessarily obscured. So I just removed that and did the necessary tidying up.
- On the topic of lifetimes for parsing through the response. We can just walk a reference to the response in `parse_current_deployments` to build up the map, since copying the data we're trying to extract is fairly cheap (just 32-byte copies everywhere). Then on the second function we can move the response and therefore move the data we want to extract, since we might as well avoid the copy at this point.