### PR TITLE
Fix network subgraph queries

### DIFF
--- a/graph-gateway/src/network_subgraph.rs
+++ b/graph-gateway/src/network_subgraph.rs
@@ -186,6 +186,7 @@ impl Client {
                       where: {subgraph_: {active: true, entityVersion: 2}}
                     ) {
                         subgraph {
+                            id
                             currentVersion {
                                 subgraphDeployment {
                                     ipfsHash
@@ -354,7 +355,7 @@ struct PaginatedQueryResponse<T> {
 struct Allocation {
     id: Address,
     allocated_tokens: GRTWei,
-    subgraph_deployment: SubgraphDeployment,
+    subgraph_deployment: SubgraphDeploymentIdOnly,
     indexer: Indexer,
 }
 
@@ -367,10 +368,10 @@ struct Indexer {
 }
 
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Subgraph {
-    id: SubgraphID,
-    current_version: SubgraphCurrentVersion,
+struct SubgraphDeployment {
+    #[serde(rename = "ipfsHash")]
+    id: SubgraphDeploymentID,
+    versions: Vec<SubgraphVersion>,
 }
 
 #[derive(Deserialize)]
@@ -381,15 +382,15 @@ struct SubgraphVersion {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct SubgraphCurrentVersion {
-    subgraph_deployment: SubgraphDeploymentIdOnly,
+struct Subgraph {
+    id: SubgraphID,
+    current_version: SubgraphCurrentVersion,
 }
 
 #[derive(Deserialize)]
-struct SubgraphDeployment {
-    #[serde(rename = "ipfsHash")]
-    id: SubgraphDeploymentID,
-    versions: Vec<SubgraphVersion>,
+#[serde(rename_all = "camelCase")]
+struct SubgraphCurrentVersion {
+    subgraph_deployment: SubgraphDeploymentIdOnly,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
- Add missing subgraph `id` in `subgraphDeployments` query
- Change deployment id struct to `SubgraphDeploymentIdOnly` in `allocations` query
- Reorder structs at the bottom, since I found the previous order hard to traverse while debugging (completely non-functional)