### PR TITLE
ISA: Add scoring cutoff before multi-selection

### DIFF
--- a/indexer-selection/src/score.rs
+++ b/indexer-selection/src/score.rs
@@ -19,6 +19,7 @@ pub struct SelectionFactors {
     pub perf_failure: f64,
     pub blocks_behind: u64,
     pub slashable_usd: f64,
+    pub expected_score: NotNan<f64>,
     pub fee: GRT,
     pub last_use: Instant,
     pub sybil: NotNan<f64>,
@@ -212,6 +213,23 @@ impl MetaIndexer<'_> {
 
         score
     }
+}
+
+pub fn expected_individual_score(
+    params: &UtilityParameters,
+    reliability: f64,
+    perf_success: f64,
+    blocks_behind: u64,
+    slashable_usd: f64,
+    fee: &GRT,
+) -> f64 {
+    weighted_product_model([
+        reliability_utility(reliability),
+        performance_utility(params.performance, perf_success as u32),
+        params.economic_security.concave_utility(slashable_usd),
+        data_freshness_utility(params.data_freshness, &params.requirements, blocks_behind),
+        fee_utility(params.fee_weight, &fee, &params.budget),
+    ])
 }
 
 /// https://www.desmos.com/calculator/plpijnbvhu


### PR DESCRIPTION
This is a very annoying scenario that is apparently realistic. There are 8 indexers available. 1 is near chain head, all others are over 3 million blocks behind. Scoring outcomes are behaving as intended, as in groups of multiple indexers containing the 1 good indexer have a terrible score. However
1. We don't always pick the subset containing just the good indexer, to score in the first place. Since we don't compare every possible combination.
2. Even if we select a subset containing the good indexer and a few others (likely, after 1.), one of the others may respond first.

This is largely [lifted from the pre-multi-selection ISA](https://github.com/edgeandnode/graph-gateway/blob/a72c915f06a7c10fe84fa7875e681e5d8e745aab/indexer-selection/src/lib.rs#L273-L286)