### PR TITLE
reporting: Add graph_env field to Kafka messages

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -78,6 +78,7 @@ pub struct Context {
     pub indexer_client: IndexerClient,
     pub kafka_client: Arc<KafkaClient>,
     pub fisherman_client: Option<Arc<FishermanClient>>,
+    pub graph_env_id: String,
     pub api_keys: Eventual<Ptr<HashMap<String, Arc<APIKey>>>>,
     pub api_key_payment_required: bool,
     pub special_api_keys: Arc<HashSet<String>>,
@@ -121,6 +122,7 @@ pub async fn handle_query(
             .and_then(|value| value.to_str().ok())
             .unwrap_or("")
             .to_string(),
+        graph_env: ctx.graph_env_id.clone(),
         api_key: request
             .match_info()
             .get("api_key")
@@ -472,6 +474,7 @@ async fn handle_client_query_inner(
         };
         indexer_query_context.report.query_id = report.query_id.clone();
         indexer_query_context.report.ray_id = report.ray_id.clone();
+        indexer_query_context.report.graph_env = report.graph_env.clone();
         indexer_query_context.report.api_key = report.api_key.clone();
         indexer_query_context.report.deployment = report.deployment.clone();
         indexer_query_context.report.network = report.network.clone();

--- a/graph-gateway/src/kafka_client.rs
+++ b/graph-gateway/src/kafka_client.rs
@@ -35,6 +35,7 @@ impl KafkaClient {
 pub struct ClientQueryResult {
     pub query_id: String,
     pub ray_id: String,
+    pub graph_env: String,
     pub timestamp: u64,
     pub api_key: String,
     pub deployment: String,
@@ -56,6 +57,7 @@ impl Msg for ClientQueryResult {
 pub struct IndexerAttempt {
     pub query_id: String,
     pub ray_id: String,
+    pub graph_env: String,
     pub api_key: String,
     pub deployment: String,
     pub network: String,

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -188,6 +188,7 @@ async fn main() {
         indexer_client: IndexerClient {
             client: http_client.clone(),
         },
+        graph_env_id: opt.graph_env_id.clone(),
         subgraph_info,
         subgraph_deployments: network_subgraph_data.subgraph_deployments,
         deployment_indexers: network_subgraph_data.deployment_indexers,

--- a/graph-gateway/src/opt.rs
+++ b/graph-gateway/src/opt.rs
@@ -33,6 +33,13 @@ pub struct Opt {
     #[clap(
         long,
         env,
+        help = "Graph network environment identifier, inserted into Kafka messages",
+        default_value = ""
+    )]
+    pub graph_env_id: String,
+    #[clap(
+        long,
+        env,
         help = "API keys that won't be blocked for non-payment",
         default_value = "",
         use_delimiter = true


### PR DESCRIPTION
This allows data science to differentiate Kafka messages by Graph network (mainnet, testnet-arbitrum, etc.)

Closes #274