### PR TITLE
Remove toplevel filter on subgraphDeployments query

### DIFF
--- a/graph-gateway/src/network_subgraph.rs
+++ b/graph-gateway/src/network_subgraph.rs
@@ -177,7 +177,6 @@ impl Client {
                     block: $block
                     skip: $skip
                     first: $first
-                    where: {activeSubgraphCount_gt: 0}
                 ) {
                     ipfsHash
                     versions(


### PR DESCRIPTION
This is a workaround for a suspected bug in the network subgraph. Requires further investigation.