### PR TITLE
Add subscription tiers

### DIFF
--- a/graph-gateway/src/subgraph_client.rs
+++ b/graph-gateway/src/subgraph_client.rs
@@ -28,7 +28,7 @@ impl Client {
 
     pub async fn paginated_query<T: for<'de> Deserialize<'de>>(
         &mut self,
-        query: &'static str,
+        query: &str,
     ) -> Result<Vec<T>, String> {
         let batch_size: u32 = 1000;
         let mut index: u32 = 0;


### PR DESCRIPTION
- Add config for subscription tiers.
- Filter "active subscriptions" from the subgraph, where the end of the subscription is at least 10 minutes ago.
- Associate each subscription with its query rate limit, based on the tiers.
- Merge authorized signers & user into a single set for checking tickets.