### PR TITLE
Add support for L2 subgraph migration

### DIFF
--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -28,7 +28,7 @@ secp256k1 = { version = "0.24", default-features = false }
 semver = "1.0"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value"] }
-serde_with = "2.2"
+serde_with = { version = "2.2", features = ["chrono_0_4"] }
 serde_yaml = "0.9"
 simple-rate-limiter = "1.0"
 tiny-bip39 = "1.0"

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -61,6 +61,8 @@ fn query_id() -> String {
 pub enum Error {
     #[error("Block not found: {0}")]
     BlockNotFound(UnresolvedBlock),
+    #[error("Subgraph deployment not found (subgraph migrated to L2): {0}")]
+    DeploymentMigrated(DeploymentId),
     #[error("Subgraph deployment not found: {0}")]
     DeploymentNotFound(DeploymentId),
     #[error("Internal error: {0:#}")]
@@ -214,6 +216,9 @@ async fn resolve_subgraph_deployment(
     } else {
         return Err(Error::InvalidDeploymentId("".to_string()));
     };
+    if deployments.migrated_away(&deployment).await {
+        return Err(Error::DeploymentMigrated(deployment));
+    }
     subgraph_info
         .value_immediate()
         .and_then(|map| map.get(&deployment)?.value_immediate())

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -34,6 +34,8 @@ pub struct Config {
     pub kafka: KafkaConfig,
     /// Format log output as JSON
     pub log_json: bool,
+    /// Hours after subgraph migration to L2 where service is continued.
+    pub l2_migration_delay_hours: Option<u32>,
     #[serde_as(as = "DisplayFromStr")]
     pub min_indexer_version: Version,
     #[serde_as(as = "DisplayFromStr")]

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -137,7 +137,11 @@ async fn main() {
 
     let network_subgraph_client =
         subgraph_client::Client::new(http_client.clone(), config.network_subgraph.clone());
-    let network_subgraph_data = network_subgraph::Client::create(network_subgraph_client);
+    let l2_migration_delay = config
+        .l2_migration_delay_hours
+        .map(|hours| chrono::Duration::hours(hours as i64));
+    let network_subgraph_data =
+        network_subgraph::Client::create(network_subgraph_client, l2_migration_delay);
     update_from_eventual(
         network_subgraph_data.slashing_percentage,
         update_writer.clone(),

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -392,6 +392,7 @@ pub fn status<T>(result: &Result<T, client_query::Error>) -> (String, i32) {
                 (err.to_string(), StatusCode::UserError.into())
             }
             client_query::Error::BlockNotFound(_)
+            | client_query::Error::DeploymentMigrated(_)
             | client_query::Error::DeploymentNotFound(_)
             | client_query::Error::NoIndexers
             | client_query::Error::NoSuitableIndexer(_)
@@ -451,7 +452,8 @@ pub fn legacy_status<T>(result: &Result<T, client_query::Error>) -> (String, u32
         Ok(_) => ("200 OK".to_string(), 0),
         Err(err) => match err {
             client_query::Error::BlockNotFound(_) => ("Unresolved block".to_string(), 604610595),
-            client_query::Error::DeploymentNotFound(_) => (err.to_string(), 628859297),
+            client_query::Error::DeploymentMigrated(_)
+            | client_query::Error::DeploymentNotFound(_) => (err.to_string(), 628859297),
             client_query::Error::Internal(_) => ("Internal error".to_string(), 816601499),
             client_query::Error::InvalidAuth(_) => ("Invalid API key".to_string(), 888904173),
             client_query::Error::InvalidDeploymentId(_) => (err.to_string(), 19391651),

--- a/graph-gateway/src/subgraph_deployments.rs
+++ b/graph-gateway/src/subgraph_deployments.rs
@@ -1,5 +1,5 @@
 use prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone)]
 pub struct SubgraphDeployments {
@@ -16,6 +16,8 @@ pub struct Inputs {
     // And then these multiple users could publish the Subgraph.
     // This creates a scenario where a single DeploymentId could be linked with multiple SubgraphIDs.
     pub deployment_to_subgraphs: HashMap<DeploymentId, Vec<SubgraphId>>,
+    // Set of deployments migrated away from the network environment served by this gateway.
+    pub migrated_away: HashSet<DeploymentId>,
 }
 
 impl SubgraphDeployments {
@@ -37,5 +39,13 @@ impl SubgraphDeployments {
             .deployment_to_subgraphs
             .get(deployment)
             .cloned()
+    }
+
+    pub async fn migrated_away(&self, deployment: &DeploymentId) -> bool {
+        self.inputs
+            .value()
+            .await
+            .map(|inputs| inputs.migrated_away.contains(deployment))
+            .unwrap_or(false)
     }
 }


### PR DESCRIPTION
This adds a grace period where we continue serving subgraphs for some period of time after they migrate to L2.