### PR TITLE
Relax subscription rate limits to per-minute, with 10m windows

### DIFF
--- a/graph-gateway/src/auth.rs
+++ b/graph-gateway/src/auth.rs
@@ -61,9 +61,9 @@ impl AuthHandler {
             subscription_query_counters: RwLock::default(),
         }));
 
-        // Reset counters every 10 seconds.
+        // Reset counters every 10 minutes.
         // 5720d5ea-cfc3-4862-865b-52b4508a4c14
-        eventuals::timer(Duration::from_secs(10))
+        eventuals::timer(Duration::from_secs(600))
             .pipe_async(|_| async {
                 let mut counters = handler.subscription_query_counters.write().await;
                 counters.retain(|_, v| {
@@ -204,9 +204,9 @@ impl AuthHandler {
         match counters.get(&user) {
             Some(counter) => {
                 let count = counter.fetch_add(1, atomic::Ordering::Relaxed);
-                // Note that counters are for 10s intervals
+                // Note that counters are for 10 minute intervals
                 // 5720d5ea-cfc3-4862-865b-52b4508a4c14
-                let limit = subscription.query_rate_limit as usize * 10;
+                let limit = subscription.queries_per_minute as usize * 10;
                 ensure!(count < limit, "Rate limit exceeded");
             }
             // No entry, acquire write lock and insert.

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -171,8 +171,8 @@ pub struct SubscriptionTier {
     /// Payment rate from the subcription contract.
     #[serde_as(as = "DisplayFromStr")]
     pub payment_rate: u128,
-    /// Maximum query rate allowed, in queries per second.
-    pub query_rate_limit: u32,
+    /// Maximum query rate allowed, in queries per minute.
+    pub queries_per_minute: u32,
 }
 
 impl From<Vec<SubscriptionTier>> for SubscriptionTiers {

--- a/graph-gateway/src/subscriptions.rs
+++ b/graph-gateway/src/subscriptions.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct Subscription {
     pub signers: Vec<Address>,
-    pub query_rate_limit: u32,
+    pub queries_per_minute: u32,
     pub usage: Arc<Mutex<VolumeEstimator>>,
 }
 

--- a/graph-gateway/src/subscriptions_subgraph.rs
+++ b/graph-gateway/src/subscriptions_subgraph.rs
@@ -25,7 +25,7 @@ impl Client {
             (
                 owner,
                 Subscription {
-                    query_rate_limit: u32::MAX,
+                    queries_per_minute: u32::MAX,
                     // TODO: query for authorized signers for owner.
                     signers: vec![],
                     usage: Arc::default(),
@@ -109,7 +109,7 @@ impl Client {
                 let tier = self.tiers.tier_for_rate(active_sub.rate);
                 let sub = Subscription {
                     signers: signers.collect(),
-                    query_rate_limit: tier.query_rate_limit,
+                    queries_per_minute: tier.queries_per_minute,
                     usage: self.subscriptions_usage.get(&user.id),
                 };
                 (user.id, sub)


### PR DESCRIPTION
This has the benefit of making prices more granular on the lower end. Also, we're facilitating bursts of traffic in 10 minute windows rather than 10 seconds.