### PR TITLE
Update subscriptions dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,7 +1574,7 @@ dependencies = [
 [[package]]
 name = "graph-subscriptions"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/subscription-payments?rev=54db2e3#54db2e37a215a1fda44561a9c80cf145f38dfc50"
+source = "git+https://github.com/edgeandnode/subscription-payments?rev=e4f0dc9#e4f0dc92f437fa7f26df2646ce14f1b57b4c274b"
 dependencies = [
  "anyhow",
  "base64 0.21.0",

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -12,7 +12,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ethers = { version = "2.0.3", default-features = false, features = ["abigen"] }
 futures = "0.3"
 futures-util = "0.3"
-graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "54db2e3" }
+graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "e4f0dc9" }
 hdwallet = "0.3"
 hex = "0.4"
 im = "15.0"


### PR DESCRIPTION
This picks up the changes that report the JSON ticket payload for subscriptions using a hex string instead of an array of bytes.