### PR TITLE
Resolve subgraph versions from IPFS

### DIFF
--- a/graph-gateway/src/network_subgraph.rs
+++ b/graph-gateway/src/network_subgraph.rs
@@ -24,6 +24,7 @@ pub struct Subgraph {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubgraphVersion {
+    pub metadata_hash: Option<String>,
     pub subgraph_deployment: SubgraphDeployment,
 }
 
@@ -132,6 +133,7 @@ impl Client {
             ) {
                 id
                 versions(orderBy: version, orderDirection: asc) {
+                    metadataHash
                     subgraphDeployment {
                         ipfsHash
                         indexerAllocations(where: { status: Active }) {


### PR DESCRIPTION
This adds subgraph versions labels to deployments, which will eventually be used to support more graceful subgraph upgrades. We could have used the [SubgraphVersion label](https://github.com/graphprotocol/graph-network-subgraph/blob/master/schema.graphql#L466) directly from the subgraph, but that would create a dependency on the version of the network subgraph that uses IPFS. We are avoiding that and parsing from IPFS manually so that the non-IPFS version of the network subgraph can be put on the network for gateways to use.