### PR TITLE
Add monthly limit to subscription tiers

### DIFF
--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -183,6 +183,9 @@ pub struct SubscriptionTier {
     pub payment_rate: u128,
     /// Maximum query rate allowed, in queries per minute.
     pub queries_per_minute: u32,
+    /// Maximum queries per month.
+    #[serde(default)]
+    pub monthly_query_limit: Option<u64>,
 }
 
 impl From<Vec<SubscriptionTier>> for SubscriptionTiers {


### PR DESCRIPTION
This adds an optional monthly query limit to subscription tiers. This does not include enforcement of this limit. Doing so will require additional systems outside the gateway to track long-term user data.

Initially, I made the duration of the limit configurable in units of days (7 days, 30 days, etc.). The trouble with that is that a month is not measurable in days, which will never stop driving me insane. So I decided to go with just a monthly cap for now. I'm open to suggestions here.