### PR TITLE
build: pin rust toolchain version to 1.69.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.69.0"
+profile = "default"


### PR DESCRIPTION
The `main` branch depends on the latest stable toolchain, 1.69.0, at the moment of writing.

- [x] Added a `rust-toolchain.toml` file pinning the toolchain version required to compile the component (following to the `graph-node` component's repo).