### PR TITLE
chore: remove special healthcheck route (#319)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
+## IDEs and editors
+/.idea
+/.vscode
+
+## Rust
 /target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+## IDEs and editors
+/.idea
+/.vscode
+
+## Rust
 **/*.rs.bk
 /target/
 test-outputs/

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -313,7 +313,6 @@ async fn main() {
 
     let router = Router::new()
         .route("/", routing::get(|| async { "Ready to roll!" }))
-        .route("/ready", routing::get(|| async { "Ready" }))
         .route(
             "/collect-receipts",
             routing::post(vouchers::handle_collect_receipts).with_state(signer_key),


### PR DESCRIPTION
This PR removes the no longer needed as inputs are synced before the server is started. The server is ready once it starts accepting HTTP traffic.

This PR resolves #319

- [x] Removed the legacy `/ready` _healthcheck_ route.
- [x] Point to `/` k8s readiness probe configuration: https://github.com/edgeandnode/graph-infra/pull/536