### PR TITLE
feat(graph-gateway): zeroize signing key on drop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1329,7 @@ dependencies = [
 name = "graph-gateway"
 version = "13.3.0"
 dependencies = [
+ "assert_matches",
  "axum",
  "chrono",
  "ethers",
@@ -1358,6 +1365,7 @@ dependencies = [
  "tracing-subscriber",
  "trust-dns-resolver",
  "uuid 1.3.3",
+ "zeroize",
 ]
 
 [[package]]

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -45,7 +45,9 @@ tracing-subscriber = { version = "0.3.16", features = [
     "parking_lot",
 ] }
 hyper = { version = "0.14.26", features = ["client", "http1", "http2"] }
+zeroize = { version = "1.6.0", default-features = false }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 regex = "1.5"
 tokio = { version = "1.28.2", features = ["macros"] }

--- a/graph-gateway/src/receipts.rs
+++ b/graph-gateway/src/receipts.rs
@@ -1,16 +1,19 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Arc,
+};
+
 pub use indexer_selection::receipts::QueryStatus as ReceiptStatus;
 use indexer_selection::{
     receipts::{BorrowFail, ReceiptPool},
-    Indexing, SecretKey,
+    Indexing,
 };
 use prelude::{
     tokio::sync::{Mutex, RwLock},
     *,
 };
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    sync::Arc,
-};
+
+use crate::signer_key::SignerKey;
 
 #[derive(Default)]
 pub struct ReceiptPools {
@@ -59,7 +62,7 @@ impl ReceiptPools {
 
     pub async fn update_receipt_pool(
         &self,
-        signer: &SecretKey,
+        signer: &SignerKey,
         indexing: &Indexing,
         new_allocations: &HashMap<Address, GRT>,
     ) {
@@ -77,7 +80,7 @@ impl ReceiptPools {
         // Add new_allocations not present in allocations
         for id in new_allocations.keys() {
             if !pool.contains_allocation(id) {
-                pool.add_allocation(*signer, id.0);
+                pool.add_allocation(**signer, id.0);
             }
         }
     }

--- a/graph-gateway/src/signer_key.rs
+++ b/graph-gateway/src/signer_key.rs
@@ -1,0 +1,140 @@
+use std::ops::Deref;
+use std::str::FromStr;
+
+use hdwallet::KeyChain;
+use prelude::anyhow;
+use secp256k1::{self, SecretKey};
+use zeroize::Zeroize;
+
+use crate::key_path;
+
+#[derive(Clone)]
+pub struct SignerKey(SecretKey);
+
+impl SignerKey {
+    pub fn from_slice(bytes: &[u8]) -> Result<Self, anyhow::Error> {
+        let secret_key = SecretKey::from_slice(bytes)?;
+        Ok(Self(secret_key))
+    }
+}
+
+impl Default for SignerKey {
+    fn default() -> Self {
+        Self(secp256k1::ONE_KEY)
+    }
+}
+
+impl From<SecretKey> for SignerKey {
+    fn from(key: SecretKey) -> Self {
+        Self(key)
+    }
+}
+
+impl FromStr for SignerKey {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Wallet seed zeroized on drop
+        let wallet_seed = bip39::Seed::new(
+            &bip39::Mnemonic::from_phrase(s, bip39::Language::English)?,
+            "",
+        );
+        let signer_key = hdwallet::DefaultKeyChain::new(
+            hdwallet::ExtendedPrivKey::with_seed(wallet_seed.as_bytes()).expect("Invalid mnemonic"),
+        )
+        .derive_private_key(key_path("scalar/allocations").into())
+        .expect("Failed to derive signer key")
+        .0
+        .private_key;
+
+        // Convert between versions of secp256k1 lib.
+        Ok(SignerKey::from_slice(signer_key.as_ref()).unwrap())
+    }
+}
+
+impl Deref for SignerKey {
+    type Target = SecretKey;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Zeroize for SignerKey {
+    fn zeroize(&mut self) {
+        self.0 = secp256k1::ONE_KEY;
+    }
+}
+
+impl zeroize::ZeroizeOnDrop for SignerKey {}
+
+impl Drop for SignerKey {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl std::fmt::Debug for SignerKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "SignerKey(..)")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::default::Default;
+
+    use assert_matches::assert_matches;
+
+    use super::*;
+
+    #[test]
+    fn from_slice() {
+        //// Given
+        let secret_key = secp256k1::ONE_KEY;
+
+        //// When
+        let signer_key = SignerKey::from_slice(secret_key.as_ref());
+
+        //// Then
+        assert_matches!(signer_key, Ok(key) => {
+            assert_eq!(*key, secret_key);
+        });
+    }
+
+    #[test]
+    fn from_secret_key() {
+        //// Given
+        let secret_key = secp256k1::ONE_KEY;
+
+        //// When
+        let signer_key: SignerKey = secret_key.into();
+
+        //// Then
+        assert_eq!(*signer_key, secret_key);
+    }
+
+    /// It's a bit hard to verify the inner workings like zeroing without relying on undefined behavior.
+    /// But, we can check that this at least runs.
+    #[test]
+    pub fn no_panic() {
+        //// Given
+        let secret_key = secp256k1::ONE_KEY;
+        let signing_key = SignerKey::from(secret_key);
+
+        //// When
+        drop(signing_key);
+    }
+
+    #[test]
+    fn fmt_debug() {
+        //// Given
+        let signer_key: SignerKey = SignerKey::default();
+
+        //// When
+        let signer_key_debug = format!("{:?}", signer_key);
+
+        //// Then
+        assert_eq!(signer_key_debug, "SignerKey(..)");
+    }
+}


### PR DESCRIPTION
From @That3Percent [comment](https://github.com/edgeandnode/graph-gateway/pull/11#discussion_r712480153):

> `SecretKey` generally shouldn't be passed by value so that it can be zeroized. This is tricky in Rust, but my best-effort so far is here: [solidity-bindgen/secrets](https://github.com/graphprotocol/solidity-bindgen/blob/master/solidity-bindgen/src/secrets.rs). Technically this is a security vulnerability, but it's kind of fringe.

These changes aim to add a "Zeroize on drop" behavior to the `SigningKey` struct. Additionally, I added a `Deref` trait implementation to replace all the usages of `Secretkey` with the `SigningKey` type.

This issue resolves #13 