### PR TITLE
Fix TLS support for L2 forwarding

### DIFF
--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -7,7 +7,7 @@ version = "13.3.0"
 axum = { version = "0.6.15", default-features = false, features = [
     "json",
     "tokio",
-    "original-uri"
+    "original-uri",
 ] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 ethers = { version = "2.0.3", default-features = false, features = ["abigen"] }
@@ -44,8 +44,8 @@ tracing-subscriber = { version = "0.3.16", features = [
     "json",
     "parking_lot",
 ] }
-hyper = { version = "0.14.26", features = ["client", "http1", "http2"] }
 
 [dev-dependencies]
+hyper = "*"
 regex = "1.5"
 tokio = { version = "1.28.2", features = ["macros"] }

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -397,9 +397,7 @@ pub fn status<T>(result: &Result<T, client_query::Error>) -> (String, i32) {
     match result {
         Ok(_) => ("200 OK".to_string(), StatusCode::Success.into()),
         Err(err) => match err {
-            client_query::Error::Internal(_)
-            | client_query::Error::L2GatewayRequestError(_)
-            | client_query::Error::L2GatewayResponseError(_) => {
+            client_query::Error::Internal(_) | client_query::Error::L2GatewayError(_) => {
                 (err.to_string(), StatusCode::InternalError.into())
             }
             client_query::Error::InvalidAuth(_)
@@ -467,9 +465,7 @@ pub fn legacy_status<T>(result: &Result<T, client_query::Error>) -> (String, u32
         Err(err) => match err {
             client_query::Error::BlockNotFound(_) => ("Unresolved block".to_string(), 604610595),
             client_query::Error::DeploymentNotFound(_) => (err.to_string(), 628859297),
-            client_query::Error::Internal(_)
-            | client_query::Error::L2GatewayRequestError(_)
-            | client_query::Error::L2GatewayResponseError(_) => {
+            client_query::Error::Internal(_) | client_query::Error::L2GatewayError(_) => {
                 ("Internal error".to_string(), 816601499)
             }
             client_query::Error::InvalidAuth(_) => ("Invalid API key".to_string(), 888904173),


### PR DESCRIPTION
Previously, when forwarding queries to L2 we rebuilt the client request using the `hyper` `Client` & `Request` directly. Unfortunately this lacks support for TLS. So this switches to using the `reqwest` `Client` & `Request` as we do for indexer queries.