### PR TITLE
refactor(graph-gateway): change crate entry point from main.rs to lib.rs

### DIFF
--- a/graph-gateway/src/auth.rs
+++ b/graph-gateway/src/auth.rs
@@ -1,22 +1,25 @@
-use crate::{
-    price_automation::QueryBudgetFactors,
-    subgraph_studio::{APIKey, IndexerPreferences, QueryStatus},
-    subscriptions::Subscription,
-    topology::Deployment,
-};
-use graph_subscriptions::{TicketPayload, TicketVerificationDomain};
-use prelude::{
-    anyhow::{anyhow, bail, ensure, Result},
-    eventuals::EventualExt as _,
-    tokio::sync::RwLock,
-    *,
-};
 use std::{
     collections::{HashMap, HashSet},
     sync::{
         atomic::{self, AtomicUsize},
         Arc,
     },
+};
+
+use graph_subscriptions::{TicketPayload, TicketVerificationDomain};
+
+use prelude::{
+    anyhow::{anyhow, bail, ensure, Result},
+    eventuals::EventualExt as _,
+    tokio::sync::RwLock,
+    *,
+};
+
+use crate::{
+    price_automation::QueryBudgetFactors,
+    subgraph_studio::{APIKey, IndexerPreferences, QueryStatus},
+    subscriptions::Subscription,
+    topology::Deployment,
 };
 
 pub struct AuthHandler {

--- a/graph-gateway/src/block_constraints.rs
+++ b/graph-gateway/src/block_constraints.rs
@@ -1,5 +1,9 @@
-use indexer_selection::{Context, UnresolvedBlock};
+use std::collections::{BTreeMap, BTreeSet};
+
 use itertools::Itertools as _;
+use serde_json::{self, json};
+
+use indexer_selection::{Context, UnresolvedBlock};
 use prelude::graphql::graphql_parser::query::{
     Definition, Document, OperationDefinition, Selection, Text, Value,
 };
@@ -7,8 +11,6 @@ use prelude::{
     graphql::{IntoStaticValue as _, QueryVariables, StaticValue},
     *,
 };
-use serde_json::{self, json};
-use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub enum BlockConstraint {
@@ -228,8 +230,9 @@ fn parse_number<'c, T: Text<'c>>(
 mod tests {
     use std::iter::FromIterator;
 
-    use super::*;
     use prelude::test_utils::bytes_from_id;
+
+    use super::*;
 
     #[test]
     fn tests() {

--- a/graph-gateway/src/chains/ethereum.rs
+++ b/graph-gateway/src/chains/ethereum.rs
@@ -1,10 +1,13 @@
-use super::ClientMsg;
-use crate::metrics::METRICS;
-use indexer_selection::UnresolvedBlock;
-use prelude::{tokio::time::interval, *};
 use reqwest;
 use serde::{de::Error, Deserialize, Deserializer};
 use serde_json::{json, Value as JSON};
+
+use indexer_selection::UnresolvedBlock;
+use prelude::{tokio::time::interval, *};
+
+use crate::metrics::METRICS;
+
+use super::ClientMsg;
 
 #[derive(Debug)]
 pub struct Provider {

--- a/graph-gateway/src/chains/mod.rs
+++ b/graph-gateway/src/chains/mod.rs
@@ -1,10 +1,12 @@
-pub mod ethereum;
-pub mod test;
+use std::collections::{BTreeSet, HashMap};
 
-use crate::{block_constraints::*, metrics::*};
 use indexer_selection::UnresolvedBlock;
 use prelude::{epoch_cache::EpochCache, tokio::time::interval, *};
-use std::collections::{BTreeSet, HashMap};
+
+use crate::{block_constraints::*, metrics::*};
+
+pub mod ethereum;
+pub mod test;
 
 pub trait Provider {
     fn network(&self) -> &str;

--- a/graph-gateway/src/chains/test.rs
+++ b/graph-gateway/src/chains/test.rs
@@ -1,6 +1,7 @@
-use super::ClientMsg;
 use indexer_selection::UnresolvedBlock;
 use prelude::*;
+
+use super::ClientMsg;
 
 pub struct Provider {
     pub network: String,

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -992,9 +992,11 @@ pub async fn legacy_auth_adapter<B>(
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::topology::{Deployment, Manifest, Subgraph};
     use std::{collections::BTreeSet, sync::Arc};
+
+    use crate::topology::{Deployment, Manifest, Subgraph};
+
+    use super::*;
 
     #[test]
     fn resolving_subgraph_versions() {

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -1,12 +1,15 @@
-use crate::chains::ethereum;
+use std::{collections::BTreeMap, path::PathBuf};
+
 use graph_subscriptions::subscription_tier::{SubscriptionTier, SubscriptionTiers};
 use hdwallet::{self, KeyChain as _};
-use indexer_selection::SecretKey;
-use prelude::*;
 use semver::Version;
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr, FromInto};
-use std::{collections::BTreeMap, path::PathBuf};
+
+use indexer_selection::SecretKey;
+use prelude::*;
+
+use crate::chains::ethereum;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]

--- a/graph-gateway/src/exchange_rate.rs
+++ b/graph-gateway/src/exchange_rate.rs
@@ -1,15 +1,17 @@
+use std::sync::Arc;
+
 use ethers::{
     abi::Address,
     prelude::{abigen, Http},
     providers::Provider,
 };
+
 use prelude::{
     anyhow::{anyhow, ensure, Result},
     eventuals::{self, EventualExt},
     tokio::sync::Mutex,
     tracing, Duration, Eventual, EventualWriter, UDecimal, Url, USD,
 };
-use std::sync::Arc;
 
 abigen!(
     UniswapV3Pool,

--- a/graph-gateway/src/fisherman_client.rs
+++ b/graph-gateway/src/fisherman_client.rs
@@ -1,8 +1,10 @@
-use crate::indexer_client::Attestation;
-use indexer_selection::Indexing;
-use prelude::*;
 use serde::Deserialize;
 use serde_json::json;
+
+use indexer_selection::Indexing;
+use prelude::*;
+
+use crate::indexer_client::Attestation;
 
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub enum ChallengeOutcome {

--- a/graph-gateway/src/geoip.rs
+++ b/graph-gateway/src/geoip.rs
@@ -1,6 +1,8 @@
-use maxminddb::{geoip2, MaxMindDBError, Reader};
-use prelude::*;
 use std::{net::IpAddr, path::Path};
+
+use maxminddb::{geoip2, MaxMindDBError, Reader};
+
+use prelude::*;
 
 pub struct GeoIP {
     reader: Reader<Vec<u8>>,

--- a/graph-gateway/src/indexer_client.rs
+++ b/graph-gateway/src/indexer_client.rs
@@ -1,7 +1,9 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
 use indexer_selection::{Selection, UnresolvedBlock};
 use prelude::*;
-use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct IndexerResponse {

--- a/graph-gateway/src/indexing.rs
+++ b/graph-gateway/src/indexing.rs
@@ -1,17 +1,20 @@
-use crate::geoip::GeoIP;
-use crate::subgraph_client::graphql_query;
-use crate::topology::{Allocation, Deployment, Indexer};
+use std::{collections::HashMap, net::IpAddr, sync::Arc};
+
 use eventuals::EventualExt as _;
 use futures::future::join_all;
-use indexer_selection::cost_model::CostModel;
-use indexer_selection::Indexing;
-use prelude::{epoch_cache::EpochCache, graphql, url::url::Host, *};
 use semver::Version;
 use serde::Deserialize;
 use serde_json::json;
-use std::{collections::HashMap, net::IpAddr, sync::Arc};
 use tokio::sync::Mutex;
 use trust_dns_resolver::TokioAsyncResolver as DNSResolver;
+
+use indexer_selection::cost_model::CostModel;
+use indexer_selection::Indexing;
+use prelude::{epoch_cache::EpochCache, graphql, url::url::Host, *};
+
+use crate::geoip::GeoIP;
+use crate::subgraph_client::graphql_query;
+use crate::topology::{Allocation, Deployment, Indexer};
 
 pub struct IndexingStatus {
     pub chain: String,

--- a/graph-gateway/src/ipfs.rs
+++ b/graph-gateway/src/ipfs.rs
@@ -1,6 +1,8 @@
-use prelude::*;
 use std::sync::Arc;
+
 use tokio::sync::Semaphore;
+
+use prelude::*;
 
 pub struct Client {
     client: reqwest::Client,

--- a/graph-gateway/src/lib.rs
+++ b/graph-gateway/src/lib.rs
@@ -1,0 +1,45 @@
+use std::iter;
+
+use axum::Json;
+use reqwest::header::{self, HeaderMap, HeaderName, HeaderValue};
+
+use prelude::*;
+
+pub mod auth;
+pub mod block_constraints;
+pub mod chains;
+pub mod client_query;
+pub mod config;
+pub mod fisherman_client;
+pub mod geoip;
+pub mod indexer_client;
+pub mod indexing;
+pub mod ipfs;
+pub mod metrics;
+pub mod network_subgraph;
+pub mod price_automation;
+pub mod receipts;
+pub mod reports;
+pub mod subgraph_client;
+pub mod subgraph_studio;
+pub mod subscriptions;
+pub mod subscriptions_subgraph;
+pub mod topology;
+pub mod unattestable_errors;
+pub mod vouchers;
+
+pub type JsonResponse = (HeaderMap, Json<serde_json::Value>);
+
+pub fn json_response<H>(headers: H, payload: serde_json::Value) -> JsonResponse
+where
+    H: IntoIterator<Item = (HeaderName, HeaderValue)>,
+{
+    let headers = HeaderMap::from_iter(
+        iter::once((
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        ))
+        .chain(headers),
+    );
+    (headers, Json(payload))
+}

--- a/graph-gateway/src/network_subgraph.rs
+++ b/graph-gateway/src/network_subgraph.rs
@@ -1,12 +1,15 @@
-use crate::subgraph_client;
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use eventuals::{self, EventualExt as _};
-use prelude::{anyhow::anyhow, *};
 use serde::Deserialize;
 use serde_json::json;
 use serde_with::serde_as;
-use std::sync::Arc;
 use tokio::sync::Mutex;
+
+use prelude::{anyhow::anyhow, *};
+
+use crate::subgraph_client;
 
 pub struct Data {
     pub network_params: NetworkParams,

--- a/graph-gateway/src/price_automation.rs
+++ b/graph-gateway/src/price_automation.rs
@@ -15,9 +15,10 @@
 // The magic values chosen were based off of 30 days hosted service volume taken on Feb 17, 2022
 // then tweaking until it looked like a fair distribution.
 
+use std::{collections::HashMap, hash::Hash, sync::Arc};
+
 use indexer_selection::{decay::*, impl_struct_decay};
 use prelude::{clock::*, tokio::sync::Mutex, *};
-use std::{collections::HashMap, hash::Hash, sync::Arc};
 
 #[derive(Clone)]
 pub struct QueryBudgetFactors {

--- a/graph-gateway/src/receipts.rs
+++ b/graph-gateway/src/receipts.rs
@@ -1,3 +1,8 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Arc,
+};
+
 pub use indexer_selection::receipts::QueryStatus as ReceiptStatus;
 use indexer_selection::{
     receipts::{BorrowFail, ReceiptPool},
@@ -6,10 +11,6 @@ use indexer_selection::{
 use prelude::{
     tokio::sync::{Mutex, RwLock},
     *,
-};
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    sync::Arc,
 };
 
 #[derive(Default)]

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -1,14 +1,17 @@
-use crate::{
-    client_query,
-    indexer_client::{IndexerError, ResponsePayload},
-};
-use prelude::{tracing::span, *};
+use std::error::Error;
+
 use prost::Message as _;
 use rdkafka::error::KafkaResult;
 use serde::Deserialize;
 use serde_json::{json, Map};
-use std::error::Error;
 use tracing_subscriber::{filter::FilterFn, layer, prelude::*, registry, EnvFilter, Layer};
+
+use prelude::{tracing::span, *};
+
+use crate::{
+    client_query,
+    indexer_client::{IndexerError, ResponsePayload},
+};
 
 // TODO: integrate Prometheus metrics
 

--- a/graph-gateway/src/subgraph_client.rs
+++ b/graph-gateway/src/subgraph_client.rs
@@ -1,7 +1,8 @@
 use axum::http::{header, HeaderMap, HeaderValue};
-use prelude::{graphql::http::Response, *};
 use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::{json, value::RawValue, Value};
+
+use prelude::{graphql::http::Response, *};
 
 pub struct Client {
     http_client: reqwest::Client,

--- a/graph-gateway/src/subgraph_studio.rs
+++ b/graph-gateway/src/subgraph_studio.rs
@@ -1,9 +1,12 @@
-use crate::price_automation::{VolumeEstimations, VolumeEstimator};
-use eventuals::{self, EventualExt as _};
-use prelude::*;
-use serde::Deserialize;
 use std::{collections::HashMap, error::Error, sync::Arc};
+
+use eventuals::{self, EventualExt as _};
+use serde::Deserialize;
 use tokio::sync::Mutex;
+
+use prelude::*;
+
+use crate::price_automation::{VolumeEstimations, VolumeEstimator};
 
 #[derive(Clone, Debug, Default)]
 pub struct APIKey {

--- a/graph-gateway/src/subscriptions.rs
+++ b/graph-gateway/src/subscriptions.rs
@@ -1,8 +1,11 @@
-use crate::price_automation::VolumeEstimator;
-use chrono::{DateTime, NaiveDateTime, Utc};
-use prelude::{tokio::sync::Mutex, *};
-use serde::{de::Error, Deserialize, Deserializer};
 use std::sync::Arc;
+
+use chrono::{DateTime, NaiveDateTime, Utc};
+use serde::{de::Error, Deserialize, Deserializer};
+
+use prelude::{tokio::sync::Mutex, *};
+
+use crate::price_automation::VolumeEstimator;
 
 #[derive(Clone)]
 pub struct Subscription {

--- a/graph-gateway/src/subscriptions_subgraph.rs
+++ b/graph-gateway/src/subscriptions_subgraph.rs
@@ -1,11 +1,14 @@
+use std::{collections::HashMap, sync::Arc};
+
+use eventuals::{self, EventualExt as _};
+use graph_subscriptions::subscription_tier::SubscriptionTiers;
+use tokio::sync::Mutex;
+
+use prelude::*;
+
 use crate::price_automation::VolumeEstimations;
 use crate::subgraph_client;
 use crate::subscriptions::{ActiveSubscription, Subscription};
-use eventuals::{self, EventualExt as _};
-use graph_subscriptions::subscription_tier::SubscriptionTiers;
-use prelude::*;
-use std::{collections::HashMap, sync::Arc};
-use tokio::sync::Mutex;
 
 pub struct Client {
     subgraph_client: subgraph_client::Client,

--- a/graph-gateway/src/topology.rs
+++ b/graph-gateway/src/topology.rs
@@ -1,12 +1,15 @@
-use crate::{ipfs, network_subgraph};
-use chrono::Utc;
-use futures_util::future::join_all;
-use prelude::{anyhow::anyhow, eventuals::EventualExt as _, tokio::sync::RwLock, *};
-use serde::Deserialize;
 use std::{
     collections::{BTreeSet, HashMap},
     sync::Arc,
 };
+
+use chrono::Utc;
+use futures_util::future::join_all;
+use serde::Deserialize;
+
+use prelude::{anyhow::anyhow, eventuals::EventualExt as _, tokio::sync::RwLock, *};
+
+use crate::{ipfs, network_subgraph};
 
 /// Representation of the graph network being used to serve queries
 #[derive(Clone)]

--- a/graph-gateway/src/vouchers.rs
+++ b/graph-gateway/src/vouchers.rs
@@ -1,15 +1,17 @@
-use crate::{json_response, metrics::*, JsonResponse};
 use axum::{body::Bytes, extract::State, http::StatusCode};
-use indexer_selection::{
-    receipts::{self, combine_partial_vouchers, receipts_to_partial_voucher, receipts_to_voucher},
-    SecretKey,
-};
 use lazy_static::lazy_static;
-use prelude::*;
 use primitive_types::U256;
 use secp256k1::{PublicKey, Secp256k1};
 use serde::{Deserialize, Deserializer};
 use serde_json::json;
+
+use indexer_selection::{
+    receipts::{self, combine_partial_vouchers, receipts_to_partial_voucher, receipts_to_voucher},
+    SecretKey,
+};
+use prelude::*;
+
+use crate::{json_response, metrics::*, JsonResponse};
 
 lazy_static! {
     static ref SECP256K1: Secp256k1<secp256k1::All> = Secp256k1::new();


### PR DESCRIPTION
> **Note**
> Keeping this PR in Draft mode until the current version is released.

The `graph_gateway` crate is a "binary crate" (the entry point is the file `main.rs`).

This prevents us from using Cargo's `graph_gateway/tests` folder and integration tests capabilities (as it does not allow importing the `main.rs` file into the IT tests code).

A standard pattern/structure is to have `lib.rs` as the entry point of a crate and import it by a collocated `main.rs` file.

- [x] Moved all the `mod` definitions to `lib.rs` file (except one, see the comment below).
- [x] Automatically formatted all imports using Rustfmt's [`group_imports = "StdExternalCrate"`](https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=imports#StdExternalCrate%5C%3A). 
