### PR TITLE
fix: fallback to reported indexer statuses after prediction failures

### DIFF
--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -162,6 +162,7 @@ async fn main() {
     .await;
     {
         let update_writer = update_writer.clone();
+        let indexing_statuses = indexing_statuses.clone();
         eventuals::join((network.deployments.clone(), indexing_statuses))
             .pipe_async(move |(deployments, indexing_statuses)| {
                 let update_writer = update_writer.clone();
@@ -240,6 +241,7 @@ async fn main() {
         graph_env_id: config.graph_env_id.clone(),
         auth_handler,
         network,
+        indexing_statuses,
         fisherman_client,
         block_caches,
         observations: update_writer,


### PR DESCRIPTION
The gateway's current strategy for predicting is optimized for keeping responses close to chain head. We've recently seen instances where indexers are stuck far behind chain head, potentially due to IPFS data availability issues. The gateway's predictions are not cutting it in these scenarios where `blocks_behind` values are constantly increasing. 

This PR adds an exponential backoff to the `latest_block` input to indexer selection when retries are necessary due to indexers failing to resolve the requested block hash. This also adds a more aggressive fallback based on the reported block statuses of available indexers.

This is not an ideal solution, since it adds more complexity to one of the most complex interactions in the gateway. I intend to completely rework this soon. But it will likely require support on the indexer side.
