### PR TITLE
feat(graph-gateway): indexer status client and POIs check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-compression"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1371,7 @@ dependencies = [
 name = "graph-gateway"
 version = "13.4.1"
 dependencies = [
+ "assert_matches",
  "axum",
  "chrono",
  "ethers",
@@ -1375,6 +1382,7 @@ dependencies = [
  "hex",
  "hyper",
  "indexer-selection",
+ "indoc",
  "itertools 0.11.0",
  "lazy_static",
  "maxminddb",
@@ -1742,6 +1750,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c785eefb63ebd0e33416dfcb8d6da0bf27ce752843a45632a67bf10d4d4b5c4"
 
 [[package]]
 name = "inout"

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -44,8 +44,10 @@ tracing-subscriber = { version = "0.3.16", features = [
     "json",
     "parking_lot",
 ] }
+indoc = "2.0.3"
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 hyper = "*"
 regex = "1.5"
 tokio = { version = "1.28.2", features = ["macros"] }

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -10,6 +10,7 @@ use indexer_selection::SecretKey;
 use prelude::*;
 
 use crate::chains::ethereum;
+use crate::indexers_status::poi::ProofOfIndexingInfo;
 
 #[serde_as]
 #[derive(Debug, Deserialize)]
@@ -91,6 +92,11 @@ pub struct Config {
     #[serde(default)]
     #[serde_as(as = "FromInto<Vec<SubscriptionTier>>")]
     pub subscription_tiers: SubscriptionTiers,
+    /// POI blocklist
+    #[serde(default)]
+    pub poi_blocklist: Vec<ProofOfIndexingInfo>,
+    /// POI blocklist update interval in minutes (default: 20 minutes)
+    pub poi_blocklist_update_interval: Option<u64>,
 }
 
 #[serde_as]

--- a/graph-gateway/src/indexers_blocklist.rs
+++ b/graph-gateway/src/indexers_blocklist.rs
@@ -1,0 +1,175 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use itertools::Itertools;
+use tokio::sync::Mutex;
+
+use prelude::eventuals::{self, Eventual, EventualExt, Ptr};
+use prelude::{reqwest, tokio, Address, DeploymentId, Url};
+
+use crate::indexers_status::poi::ProofOfIndexingInfo;
+use crate::indexers_status::{client, query};
+use crate::topology::{Deployment, Indexer};
+
+pub const DEFAULT_UPDATE_INTERVAL: Duration = Duration::from_secs(20 * 60); // 20 minutes
+
+/// Creates a new indexers blocklist eventual.
+///
+/// The blocklist is initialized by checking the POIs of all indexers in the network
+/// and returning the addresses of the indexers that have atleast one public POI that
+/// matches the ones configured.
+///
+/// This function also starts a recurrent task that updates the blocklist every
+/// `update_interval`.
+pub async fn indexer_blocklist(
+    client: reqwest::Client,
+    deployments: Eventual<Ptr<HashMap<DeploymentId, Arc<Deployment>>>>,
+    indexers: Eventual<Ptr<HashMap<Address, Arc<Indexer>>>>,
+    pois_info: Vec<ProofOfIndexingInfo>,
+    update_interval: Duration,
+) -> Eventual<Ptr<Vec<Address>>> {
+    let (writer, rx) = Eventual::new();
+    let writer = Arc::new(Mutex::new(writer));
+
+    // Start the recurrent task
+    eventuals::timer(update_interval)
+        .pipe_async(move |_| {
+            let client = client.clone();
+            let pois_info = pois_info.clone();
+
+            let deployments = deployments.clone();
+            let indexers = indexers.clone();
+
+            let writer = writer.clone();
+
+            async move {
+                // The GraphNetwork eventuals are guaranteed to be initialized by the time this
+                // function is called.
+                // 9fd85a49-06c3-4e74-9f61-4cc277bd1181
+                let deployments = deployments.value().await.unwrap_or_default();
+                let indexers = indexers.value().await.unwrap_or_default();
+
+                let indexers_pois_map = check_indexers_public_pois(
+                    client,
+                    deployments.as_ref(),
+                    indexers.as_ref(),
+                    pois_info,
+                )
+                .await;
+                let addresses = indexers_pois_map.keys().copied().collect::<Vec<_>>();
+
+                writer.lock().await.write(Ptr::new(addresses));
+            }
+        })
+        .forever();
+
+    rx
+}
+
+pub async fn check_indexer_pois(
+    client: reqwest::Client,
+    indexer_addr: Address,
+    indexer_url: Url,
+    pois_info: Vec<ProofOfIndexingInfo>,
+    batch_size: usize,
+) -> (Address, Vec<ProofOfIndexingInfo>) {
+    // Send the public POIs queries and merge the results into a table
+    let response_map =
+        client::send_queries_and_merge_results(client, indexer_url, &pois_info, batch_size).await;
+
+    // Check the POIs against the indexer's POIs response map and generate
+    // a list of matching POI
+    let result = pois_info
+        .iter()
+        .cloned()
+        .filter(|info| {
+            let info_meta = info.meta();
+            let info_poi = info.poi();
+
+            // Check if the POI is contained in the response map. If there is a match
+            // mark the POI (and the indexer) as "poisoned"
+            response_map
+                .get(&info_meta)
+                .map(|poi| poi == &info_poi)
+                .unwrap_or_default()
+        })
+        .collect::<Vec<_>>();
+
+    (indexer_addr, result)
+}
+
+/// For a given deployment, return the addresses of all indexers that are currently
+/// indexing it.
+pub fn deployment_indexer_addresses(
+    deployments: &HashMap<DeploymentId, Arc<Deployment>>,
+    deployment_id: &DeploymentId,
+) -> Vec<Address> {
+    deployments
+        .get(deployment_id)
+        .map(|deployment| {
+            deployment
+                .indexers
+                .iter()
+                .map(|indexer| indexer.id)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+/// Create a table with the POIs to be checked for each indexer. The table is indexed by indexer
+/// address and contains a list of POIs to be checked for that indexer.
+///
+/// Note that each indexer is indexing only a subset of the deployments in the network. Therefore,
+/// the POIs to be checked for each indexer are a subset of the POIs in the network. This function
+/// filters out the POIs that are not indexed by any indexer.
+pub fn indexer_poi_info_map(
+    deployments: &HashMap<DeploymentId, Arc<Deployment>>,
+    pois_info: &[ProofOfIndexingInfo],
+) -> HashMap<Address, Vec<ProofOfIndexingInfo>> {
+    pois_info
+        .iter()
+        .flat_map(|info| {
+            deployment_indexer_addresses(deployments, &info.deployment_id)
+                .into_iter()
+                .map(|addr| (addr, info.clone()))
+        })
+        .into_group_map()
+}
+
+/// Check if the network indexers have any of the poisoned POIs.
+///
+/// This function returns a table indicating if the indexer contains at least one of the poisioned
+/// POIs (`true`) or not (`false`).
+pub async fn check_indexers_public_pois(
+    client: reqwest::Client,
+    deployments: &HashMap<DeploymentId, Arc<Deployment>>,
+    indexers: &HashMap<Address, Arc<Indexer>>,
+    pois_info: Vec<ProofOfIndexingInfo>,
+) -> HashMap<Address, Vec<ProofOfIndexingInfo>> {
+    // Map indexers to POIs to be checked
+    let indexer_info = indexer_poi_info_map(deployments, &pois_info);
+
+    let indexer_poi_queries = indexer_info
+        .into_iter()
+        .filter_map(|(addr, pois_info)| {
+            let indexer = indexers.get(&addr)?;
+            Some((indexer.id, indexer.status_url(), pois_info))
+        })
+        .map(|(indexer_addr, indexer_url, pois_info)| {
+            let client = client.clone();
+            check_indexer_pois(
+                client,
+                indexer_addr,
+                indexer_url,
+                pois_info,
+                query::MAX_REQUESTS_PER_QUERY,
+            )
+        });
+
+    // Concurrently wait for all the indexer POI queries to finish
+    futures::future::join_all(indexer_poi_queries)
+        .await
+        .into_iter()
+        .collect()
+}

--- a/graph-gateway/src/indexers_status.rs
+++ b/graph-gateway/src/indexers_status.rs
@@ -1,0 +1,4 @@
+pub mod client;
+mod graphql;
+pub mod poi;
+pub mod query;

--- a/graph-gateway/src/indexers_status/client.rs
+++ b/graph-gateway/src/indexers_status/client.rs
@@ -1,0 +1,59 @@
+use itertools::Itertools;
+use std::collections::HashMap;
+
+use prelude::{anyhow, reqwest, DeploymentId, Url};
+
+use crate::indexers_status::poi::{BlockNumber, ProofOfIndexing, ProofOfIndexingInfo};
+use crate::indexers_status::{graphql, query};
+
+pub async fn send_public_pois_query(
+    client: reqwest::Client,
+    status_url: Url,
+    query: query::PublicProofOfIndexingQuery,
+) -> anyhow::Result<query::PublicProofOfIndexingResponse> {
+    graphql::send_graphql_query(&client, status_url, query).await
+}
+
+pub async fn send_queries_and_merge_results(
+    client: reqwest::Client,
+    url: Url,
+    pois: &[ProofOfIndexingInfo],
+    batch_size: usize,
+) -> HashMap<(DeploymentId, BlockNumber), ProofOfIndexing> {
+    debug_assert!(batch_size > 0, "Batch size must be greater than zero");
+
+    // Build the POI queries batches and create the futures
+    let queries = pois
+        .iter()
+        .map(|info| info.meta())
+        .map(
+            |(deployment, block_number)| query::PublicProofOfIndexingRequest {
+                deployment,
+                block_number,
+            },
+        )
+        .chunks(batch_size)
+        .into_iter()
+        .map(|requests| query::PublicProofOfIndexingQuery {
+            requests: requests.collect(),
+        })
+        .map(|query| send_public_pois_query(client.clone(), url.clone(), query))
+        .collect::<Vec<_>>();
+
+    // Send all queries concurrently
+    let responses = futures::future::join_all(queries).await;
+
+    let response_map: HashMap<(DeploymentId, BlockNumber), ProofOfIndexing> = responses
+        .into_iter()
+        // TODO: Handle errors (e.g., log them with trace level).
+        .filter_map(|response| response.ok())
+        .flat_map(|response| response.public_proofs_of_indexing)
+        .filter_map(|response| {
+            // If the response is missing the POI, skip it.
+            let poi = response.proof_of_indexing?;
+            Some(((response.deployment, response.block.number), poi.into()))
+        })
+        .collect::<HashMap<_, _>>();
+
+    response_map
+}

--- a/graph-gateway/src/indexers_status/graphql.rs
+++ b/graph-gateway/src/indexers_status/graphql.rs
@@ -1,0 +1,42 @@
+use serde::de::DeserializeOwned;
+use serde_json::json;
+
+use prelude::graphql::http::Response;
+use prelude::{anyhow, reqwest, Url};
+
+/// Trait for types that can be converted into a GraphQL query.
+pub trait IntoGraphqlQuery {
+    fn to_query(&self) -> String;
+}
+
+/// Send a GraphQL query to a given URL.
+///
+/// This function is a wrapper around `reqwest::Client` that:
+///  - Sets the `Content-Type` header to `application/json`.
+///  - Sets the request body to the given query.
+///  - Deserializes the response body into the given type.
+// TODO: Improve error handling. Define custom error enum.
+pub async fn send_graphql_query<T>(
+    client: &reqwest::Client,
+    url: Url,
+    query: impl IntoGraphqlQuery,
+) -> anyhow::Result<T>
+where
+    T: DeserializeOwned,
+{
+    let query = query.to_query();
+    let body = &json!({ "query": query });
+
+    let response = client.post(url.0).json(body).send().await?;
+
+    let status = response.status();
+    let body = response
+        .json::<Response<T>>()
+        .await
+        .map_err(|err| anyhow::anyhow!("Response body deserialization failed: {}", err))?;
+
+    // The GraphQL server returns a 400  if the query is invalid together with a JSON object
+    // containing the error message.
+    body.unpack()
+        .map_err(|err| anyhow::anyhow!("GraphQL query failed with status {}: {}", status, err))
+}

--- a/graph-gateway/src/indexers_status/poi.rs
+++ b/graph-gateway/src/indexers_status/poi.rs
@@ -1,0 +1,75 @@
+use prelude::{anyhow, bytes_wrapper, faster_hex, DeploymentId};
+
+use crate::indexers_status::query;
+
+pub type BlockNumber = u64;
+
+bytes_wrapper!(pub, ProofOfIndexing, 32, "HexStr");
+
+impl From<query::ProofOfIndexing> for ProofOfIndexing {
+    fn from(value: query::ProofOfIndexing) -> Self {
+        Self(value.0)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash, serde::Deserialize)]
+pub struct ProofOfIndexingInfo {
+    /// Proof of indexing (POI).
+    pub proof_of_indexing: ProofOfIndexing,
+    /// POI deployment ID (the IPFS Hash in the Graph Network Subgraph).
+    pub deployment_id: DeploymentId,
+    /// POI block number.
+    pub block_number: BlockNumber,
+}
+
+impl ProofOfIndexingInfo {
+    /// Get the POI bytes.
+    pub fn poi(&self) -> ProofOfIndexing {
+        self.proof_of_indexing
+    }
+
+    /// Get the POI metadata.
+    pub fn meta(&self) -> (DeploymentId, BlockNumber) {
+        (self.deployment_id, self.block_number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn deserialize_proof_of_indexing_info_config() {
+        //// Given
+        let poi: ProofOfIndexing =
+            "0xba8a057796a81e013789789996551bb5b2920fb9947334db956992f7098bd287"
+                .parse()
+                .expect("Invalid POI");
+        let deployment_id = "QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH"
+            .parse()
+            .expect("Invalid deployment ID/Ipfs hash");
+        let block_number = 123;
+
+        // Manually serialize into a JSON string.
+        let json = json!(
+            {
+                "proof_of_indexing": poi,
+                "deployment_id": deployment_id,
+                "block_number": block_number,
+            }
+        )
+        .to_string();
+
+        //// When
+        let info = serde_json::from_str::<ProofOfIndexingInfo>(&json);
+
+        //// Then
+        assert_matches!(info, Ok(poi_info) => {
+                assert_eq!(poi_info.poi(), poi);
+                assert_eq!(poi_info.meta(), (deployment_id, block_number));
+        });
+    }
+}

--- a/graph-gateway/src/indexers_status/query.rs
+++ b/graph-gateway/src/indexers_status/query.rs
@@ -1,0 +1,206 @@
+use indoc::indoc;
+use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
+
+use prelude::{anyhow, bytes_wrapper, faster_hex, DeploymentId};
+
+use crate::indexers_status::graphql::IntoGraphqlQuery;
+
+pub const MAX_REQUESTS_PER_QUERY: usize = 1; // TODO: Increase to 10 after indexer v0.32 is released.
+
+pub type BlockNumber = u64;
+
+bytes_wrapper!(pub, ProofOfIndexing, 32, "HexStr");
+
+#[derive(Clone, Debug)]
+pub struct PublicProofOfIndexingQuery {
+    pub requests: Vec<PublicProofOfIndexingRequest>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PublicProofOfIndexingRequest {
+    pub deployment: DeploymentId,
+    pub block_number: BlockNumber,
+}
+
+impl PublicProofOfIndexingRequest {
+    fn to_query_params(&self) -> String {
+        format!(
+            r#"{{ deployment: "{}", blockNumber: "{}" }}"#,
+            self.deployment, self.block_number
+        )
+    }
+}
+
+impl IntoGraphqlQuery for PublicProofOfIndexingQuery {
+    fn to_query(&self) -> String {
+        debug_assert!(!self.requests.is_empty(), "Must have at least one request");
+
+        let requests = self
+            .requests
+            .iter()
+            .map(|request| request.to_query_params())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        format!(
+            indoc! {
+                r#"{{
+                    publicProofsOfIndexing(requests: [{}]) {{
+                        deployment
+                        proofOfIndexing
+                        block {{ number }}
+                    }}
+                }}"#
+            },
+            requests
+        )
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublicProofOfIndexingResponse {
+    pub public_proofs_of_indexing: Vec<PublicProofOfIndexingResult>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublicProofOfIndexingResult {
+    pub deployment: DeploymentId,
+    pub block: PartialBlockPtr,
+    pub proof_of_indexing: Option<ProofOfIndexing>,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+pub struct PartialBlockPtr {
+    #[serde_as(as = "DisplayFromStr")]
+    pub number: BlockNumber,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod query {
+        use super::*;
+
+        #[test]
+        fn public_proof_of_indexing_request_to_query_params_format() {
+            //// Given
+            let request = PublicProofOfIndexingRequest {
+                deployment: "QmawxQJ5U1JvgosoFVDyAwutLWxrckqVmBTQxaMaKoj3Lw"
+                    .parse()
+                    .expect("Failed to parse deployment ID"),
+                block_number: 123,
+            };
+
+            //// When
+            let query = request.to_query_params();
+
+            //// Then
+            assert_eq!(
+                query.as_str(),
+                "{ deployment: \"QmawxQJ5U1JvgosoFVDyAwutLWxrckqVmBTQxaMaKoj3Lw\", blockNumber: \"123\" }"
+            );
+        }
+
+        #[test]
+        fn create_status_public_pois_query() {
+            //// Given
+            let query = PublicProofOfIndexingQuery {
+                requests: vec![
+                    PublicProofOfIndexingRequest {
+                        deployment: "QmawxQJ5U1JvgosoFVDyAwutLWxrckqVmBTQxaMaKoj3Lw"
+                            .parse()
+                            .expect("Failed to parse deployment ID"),
+                        block_number: 123,
+                    },
+                    PublicProofOfIndexingRequest {
+                        deployment: "QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH"
+                            .parse()
+                            .expect("Failed to parse deployment ID"),
+                        block_number: 456,
+                    },
+                ],
+            };
+
+            //// When
+            let query = query.to_query();
+
+            //// Then
+            assert_eq!(
+                query.as_str(),
+                indoc! { r#"{
+                    publicProofsOfIndexing(requests: [{ deployment: "QmawxQJ5U1JvgosoFVDyAwutLWxrckqVmBTQxaMaKoj3Lw", blockNumber: "123" }, { deployment: "QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH", blockNumber: "456" }]) {
+                        deployment
+                        proofOfIndexing
+                        block { number }
+                    }
+                }"# }
+            );
+        }
+    }
+
+    mod response {
+        use super::*;
+
+        #[test]
+        fn deserialize_public_pois_response() {
+            //// Given
+            let response = indoc! {
+                r#"{
+                    "publicProofsOfIndexing": [
+                        {
+                            "deployment": "QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH",
+                            "proofOfIndexing": "0xba8a057796a81e013789789996551bb5b2920fb9947334db956992f7098bd287",
+                            "block": {
+                                "number": "123"
+                            }
+                        },
+                        {
+                            "deployment": "QmawxQJ5U1JvgosoFVDyAwutLWxrckqVmBTQxaMaKoj3Lw",
+                            "block": {
+                                "number": "456"
+                            }
+                        }
+                    ]
+                }"# 
+            };
+
+            //// When
+            let response: PublicProofOfIndexingResponse =
+                serde_json::from_str(response).expect("Failed to deserialize response");
+
+            //// Then
+            assert_eq!(response.public_proofs_of_indexing.len(), 2);
+            assert_eq!(
+                response.public_proofs_of_indexing[0].deployment,
+                "QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH"
+                    .parse()
+                    .unwrap()
+            );
+            assert_eq!(
+                response.public_proofs_of_indexing[0].proof_of_indexing,
+                Some(
+                    "0xba8a057796a81e013789789996551bb5b2920fb9947334db956992f7098bd287"
+                        .parse()
+                        .unwrap()
+                )
+            );
+            assert_eq!(response.public_proofs_of_indexing[0].block.number, 123);
+            assert_eq!(
+                response.public_proofs_of_indexing[1].deployment,
+                "QmawxQJ5U1JvgosoFVDyAwutLWxrckqVmBTQxaMaKoj3Lw"
+                    .parse()
+                    .unwrap()
+            );
+            assert_eq!(
+                response.public_proofs_of_indexing[1].proof_of_indexing,
+                None
+            );
+            assert_eq!(response.public_proofs_of_indexing[1].block.number, 456);
+        }
+    }
+}

--- a/graph-gateway/src/lib.rs
+++ b/graph-gateway/src/lib.rs
@@ -13,6 +13,8 @@ pub mod config;
 pub mod fisherman_client;
 pub mod geoip;
 pub mod indexer_client;
+pub mod indexers_blocklist;
+pub mod indexers_status;
 pub mod indexing;
 pub mod ipfs;
 pub mod metrics;

--- a/graph-gateway/src/topology.rs
+++ b/graph-gateway/src/topology.rs
@@ -5,6 +5,7 @@ use std::{
 
 use chrono::Utc;
 use futures_util::future::join_all;
+use itertools::Itertools;
 use serde::Deserialize;
 
 use prelude::{anyhow::anyhow, eventuals::EventualExt as _, tokio::sync::RwLock, *};
@@ -16,6 +17,7 @@ use crate::{ipfs, network_subgraph};
 pub struct GraphNetwork {
     pub subgraphs: Eventual<Ptr<HashMap<SubgraphId, Subgraph>>>,
     pub deployments: Eventual<Ptr<HashMap<DeploymentId, Arc<Deployment>>>>,
+    pub indexers: Eventual<Ptr<HashMap<Address, Arc<Indexer>>>>,
 }
 
 /// In an effort to keep the ownership structure a simple tree, this only contains the info required
@@ -36,12 +38,18 @@ pub struct Deployment {
     pub version: Option<Arc<semver::Version>>,
     /// An indexer may have multiple active allocations on a deployment. We collapse them into a single logical
     /// allocation using the largest allocation ID and sum of the allocated tokens.
-    pub indexers: Vec<Indexer>,
+    pub indexers: Vec<Arc<Indexer>>,
     /// A deployment may be associated with multiple subgraphs.
     pub subgraphs: BTreeSet<SubgraphId>,
     /// Indicates that the deployment should not be served directly by this gateway. This will
     /// always be false when `allocations > 0`.
     pub transferred_to_l2: bool,
+}
+
+pub struct Allocation {
+    pub id: Address,
+    pub allocated_tokens: GRT,
+    pub indexer: Arc<Indexer>,
 }
 
 pub struct Indexer {
@@ -50,6 +58,20 @@ pub struct Indexer {
     pub staked_tokens: GRT,
     pub largest_allocation: Address,
     pub allocated_tokens: GRT,
+}
+
+impl Indexer {
+    pub fn cost_url(&self) -> Url {
+        // Indexer URLs are validated when they are added to the network, so this should never fail.
+        // 7f2f89aa-24c9-460b-ab1e-fc94697c4f4
+        self.url.join("cost").unwrap().into()
+    }
+
+    pub fn status_url(&self) -> Url {
+        // Indexer URLs are validated when they are added to the network, so this should never fail.
+        // 7f2f89aa-24c9-460b-ab1e-fc94697c4f4
+        self.url.join("status").unwrap().into()
+    }
 }
 
 pub struct Manifest {
@@ -70,9 +92,13 @@ impl GraphNetwork {
             metadata: HashMap::new(),
         })));
 
+        // Create a lookup table for subgraphs, keyed by their ID.
+        // Invalid URL indexers are filtered out. See: 7f2f89aa-24c9-460b-ab1e-fc94697c4f48
         let subgraphs = subgraphs.map(move |subgraphs| async move {
             Ptr::new(Self::subgraphs(&subgraphs, cache, l2_transfer_delay).await)
         });
+
+        // Create a lookup table for deployments, keyed by their ID (which is also their IPFS hash).
         let deployments = subgraphs.clone().map(|subgraphs| async move {
             subgraphs
                 .values()
@@ -82,14 +108,27 @@ impl GraphNetwork {
                 .into()
         });
 
+        // Create a lookup table for indexers, keyed by their ID (which is also their address).
+        let indexers = subgraphs.clone().map(|subgraphs| async move {
+            subgraphs
+                .values()
+                .flat_map(|subgraph| &subgraph.deployments)
+                .flat_map(|deployment| &deployment.indexers)
+                .map(|indexer| (indexer.id, indexer.clone()))
+                .collect::<HashMap<Address, Arc<Indexer>>>()
+                .into()
+        });
+
         // Return only after eventuals have values, to avoid serving client queries prematurely.
-        if deployments.value().await.is_err() {
+        // 9fd85a49-06c3-4e74-9f61-4cc277bd1181
+        if deployments.value().await.is_err() || indexers.value().await.is_err() {
             panic!("Failed to await Graph network topology");
         }
 
         Self {
             subgraphs,
             deployments,
+            indexers,
         }
     }
 
@@ -151,37 +190,41 @@ impl GraphNetwork {
             .map(|subgraph| subgraph.id)
             .collect();
 
-        // extract indexer info from each allocation
-        let allocations: Vec<Indexer> = version
+        // Extract indexer info from each subgraph deployment allocation
+        let indexers: Vec<Arc<Indexer>> = version
             .subgraph_deployment
             .allocations
             .iter()
             .filter_map(|allocation| {
-                Some(Indexer {
-                    id: allocation.indexer.id,
-                    url: allocation.indexer.url.as_ref()?.parse().ok()?,
-                    staked_tokens: allocation.indexer.staked_tokens.change_precision(),
-                    largest_allocation: allocation.id,
-                    allocated_tokens: allocation.allocated_tokens.change_precision(),
-                })
+                // If indexer URL parsing fails, the indexer is ignored (filtered out).
+                // 7f2f89aa-24c9-460b-ab1e-fc94697c4f4
+                let url = allocation.indexer.url.as_ref()?.parse().ok()?;
+
+                let id = allocation.indexer.id;
+                Some((
+                    id,
+                    Indexer {
+                        id,
+                        url,
+                        staked_tokens: allocation.indexer.staked_tokens.change_precision(),
+                        largest_allocation: allocation.id,
+                        allocated_tokens: allocation.allocated_tokens.change_precision(),
+                    },
+                ))
             })
-            .collect();
-        // TODO: remove need for itertools here: https://github.com/rust-lang/rust/issues/80552
-        use itertools::Itertools as _;
-        let indexers: Vec<Indexer> = allocations
-            .into_iter()
-            .map(|indexer| (*indexer.id, indexer))
-            .into_group_map()
+            .into_group_map() // TODO: remove need for itertools here: https://github.com/rust-lang/rust/issues/80552
             .into_iter()
             .filter_map(|(_, allocations)| {
-                let total_allocation: GRT = allocations.iter().map(|a| a.allocated_tokens).sum();
-                let max_allocation = allocations.iter().map(|a| a.allocated_tokens).max()?;
+                let total_allocation = allocations.iter().map(|idx| idx.allocated_tokens).sum();
+                let max_allocation = allocations.iter().map(|idx| idx.allocated_tokens).max()?;
+
                 let mut indexer = allocations
                     .into_iter()
-                    .find(|a| a.allocated_tokens == max_allocation)?;
+                    .find(|idx| idx.allocated_tokens == max_allocation)?;
                 indexer.allocated_tokens = total_allocation;
                 Some(indexer)
             })
+            .map(Arc::new)
             .collect();
 
         let transferred_to_l2 = version.subgraph_deployment.transferred_to_l2

--- a/graph-gateway/tests/it_indexers_blocklist.rs
+++ b/graph-gateway/tests/it_indexers_blocklist.rs
@@ -1,0 +1,193 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use tokio::time::timeout;
+
+use graph_gateway::indexers_blocklist::check_indexer_pois;
+use graph_gateway::indexers_status::client::{
+    send_public_pois_query, send_queries_and_merge_results,
+};
+use graph_gateway::indexers_status::poi::{ProofOfIndexing, ProofOfIndexingInfo};
+use graph_gateway::indexers_status::query::{
+    BlockNumber, PublicProofOfIndexingQuery, PublicProofOfIndexingRequest, MAX_REQUESTS_PER_QUERY,
+};
+use prelude::{reqwest, Address, DeploymentId};
+
+/// Test utility function to create a valid `ProofOfIndexingInfo` with an zeros POI.
+fn zero_poi() -> ProofOfIndexing {
+    ProofOfIndexing::from([0u8; 32])
+}
+
+/// Test utility function to create a valid `ProofOfIndexingInfo` with an arbitrary POI.
+fn test_poi(poi: &str) -> ProofOfIndexing {
+    poi.parse().expect("invalid POI")
+}
+
+/// Test utility function to create a valid `DeploymentId` with an arbitrary deployment id/ipfs hash.
+fn test_deployment_id(deployment: &str) -> DeploymentId {
+    deployment.parse().expect("invalid deployment id/ipfs hash")
+}
+
+#[tokio::test]
+async fn query_indexer_public_pois() {
+    //// Given
+    let client = reqwest::Client::new();
+    let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
+        .parse()
+        .expect("Invalid status url");
+
+    let deployment0 = test_deployment_id("QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH");
+    let deployment1 = test_deployment_id("QmawxQJ5U1JvgosoFVDyAwutLWxrckqVmBTQxaMaKoj3Lw");
+    let query = PublicProofOfIndexingQuery {
+        requests: vec![
+            PublicProofOfIndexingRequest {
+                deployment: deployment0,
+                block_number: 123,
+            },
+            PublicProofOfIndexingRequest {
+                deployment: deployment1,
+                block_number: 456,
+            },
+        ],
+    };
+
+    //// When
+    let request = send_public_pois_query(client, status_url, query);
+    let response = timeout(Duration::from_secs(60), request)
+        .await
+        .expect("timeout");
+
+    //// Then
+    assert_matches!(response, Ok(resp) => {
+        assert_eq!(resp.public_proofs_of_indexing.len(), 2);
+
+        assert_eq!(resp.public_proofs_of_indexing[0].deployment, deployment0);
+        assert_eq!(resp.public_proofs_of_indexing[0].block.number, 123);
+
+        assert_eq!(resp.public_proofs_of_indexing[1].deployment, deployment1);
+        assert_eq!(resp.public_proofs_of_indexing[1].block.number, 456);
+    });
+}
+
+/// Indexers do not support more than 10 requests at a time. It returns a 500 Internal Server
+/// Error with the following message: "query is too expensive".
+#[tokio::test]
+async fn requests_over_max_requests_per_query_should_fail() {
+    //// Given
+    const REQUESTS_PER_QUERY_LIMIT: usize = 10;
+
+    let client = reqwest::Client::new();
+    let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
+        .parse()
+        .expect("Invalid status url");
+
+    let deployment = test_deployment_id("QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH");
+    let query = PublicProofOfIndexingQuery {
+        requests: (1..=REQUESTS_PER_QUERY_LIMIT + 1)
+            .map(|i| PublicProofOfIndexingRequest {
+                deployment,
+                block_number: i as BlockNumber,
+            })
+            .collect(),
+    };
+
+    //// When
+    let request = send_public_pois_query(client, status_url, query);
+    let response = timeout(Duration::from_secs(60), request)
+        .await
+        .expect("timeout");
+
+    //// Then
+    assert!(response.is_err());
+}
+
+#[tokio::test]
+async fn send_batched_queries_and_merge_results() {
+    //// Given
+    let client = reqwest::Client::new();
+    let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
+        .parse()
+        .expect("Invalid status url");
+
+    let poi = zero_poi();
+    let deployment = test_deployment_id("QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH");
+
+    let pois_to_query = (1..=MAX_REQUESTS_PER_QUERY + 2)
+        .map(|i| ProofOfIndexingInfo {
+            proof_of_indexing: poi,
+            deployment_id: deployment,
+            block_number: i as BlockNumber,
+        })
+        .collect::<Vec<_>>();
+
+    //// When
+    let request =
+        send_queries_and_merge_results(client, status_url, &pois_to_query, MAX_REQUESTS_PER_QUERY);
+    let response = timeout(Duration::from_secs(60), request)
+        .await
+        .expect("timeout");
+
+    //// Then
+    assert_eq!(response.len(), MAX_REQUESTS_PER_QUERY + 2);
+    assert!(response.contains_key(&(deployment, 1)));
+    assert!(response.contains_key(&(deployment, 2)));
+    assert!(response.contains_key(&(deployment, 3)));
+}
+
+#[tokio::test]
+async fn check_indexer_pois_should_find_matches() {
+    //// Given
+    let client = reqwest::Client::new();
+
+    let indexer_addr = Address::default();
+    let status_url = "https://testnet-indexer-03-europe-cent.thegraph.com/status"
+        .parse()
+        .expect("Invalid status url");
+
+    let deployment = test_deployment_id("QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH");
+
+    let poi_info_block2_match = ProofOfIndexingInfo {
+        deployment_id: deployment,
+        proof_of_indexing: test_poi(
+            "0x565b9acec7d617023fdda42cef9fa73e7940653501a04d542d7b7411f09bafe2",
+        ),
+        block_number: 2,
+    };
+    let poi_info_block3_match = ProofOfIndexingInfo {
+        proof_of_indexing: test_poi(
+            "0x6cc41234cbe6d35753159a5863ba41a0a1a73e636eaa7351490437fd31677781",
+        ),
+        deployment_id: deployment,
+        block_number: 3,
+    };
+
+    // One or more POIs can be associated with the same deployment and block number. This example
+    // tests that the indexer correctly returns all the matching POIs
+    let pois_to_query = vec![
+        poi_info_block2_match.clone(),
+        ProofOfIndexingInfo {
+            proof_of_indexing: zero_poi(),
+            deployment_id: deployment,
+            block_number: 3,
+        },
+        poi_info_block3_match.clone(),
+        ProofOfIndexingInfo {
+            proof_of_indexing: zero_poi(),
+            deployment_id: deployment,
+            block_number: 1,
+        },
+    ];
+
+    //// When
+    let request = check_indexer_pois(client, indexer_addr, status_url, pois_to_query, 1);
+    let response = timeout(Duration::from_secs(60), request)
+        .await
+        .expect("timeout");
+
+    //// Then
+    let (address, pois) = response;
+    assert_eq!(address, indexer_addr);
+    assert_eq!(pois.len(), 2);
+    assert!(pois.contains(&poi_info_block2_match));
+    assert!(pois.contains(&poi_info_block3_match));
+}

--- a/prelude/src/lib.rs
+++ b/prelude/src/lib.rs
@@ -24,7 +24,10 @@ static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 use serde::Deserialize;
 use siphasher::sip::SipHasher24;
-use std::{hash::{Hash, Hasher as _}, time::SystemTime};
+use std::{
+    hash::{Hash, Hasher as _},
+    time::SystemTime,
+};
 use tracing_subscriber::{self, layer::SubscriberExt as _, util::SubscriberInitExt as _};
 
 pub fn init_tracing(json: bool) {


### PR DESCRIPTION
This PR resolves #348 and #349

- [x] Fetch public POIs from indexers (`/status` graphql endpoint).
- [x] Add the configuration parameters to provide the poisoned POIs and the blocklist update interval.
- [x] Add an eventual timer to update the indexers' blocklist.
- [x] Filter out the poisoned indexers when processing a request.