### PR TITLE
feat(graph-gateway): added indexers lookup table to graph network

### DIFF
--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -42,7 +42,7 @@ use graph_gateway::{
     reports,
     reports::KafkaClient,
     subgraph_client, subgraph_studio, subscriptions_subgraph,
-    topology::{Deployment, GraphNetwork, Indexer},
+    topology::{Deployment, GraphNetwork},
     vouchers, JsonResponse,
 };
 use indexer_selection::{
@@ -428,13 +428,7 @@ async fn write_indexer_inputs(
             .into_iter()
             .flat_map(|deployment| &deployment.indexers)
             .filter(|indexer| indexer.id == indexing.indexer)
-            .map(
-                |Indexer {
-                     largest_allocation,
-                     allocated_tokens,
-                     ..
-                 }| (*largest_allocation, *allocated_tokens),
-            )
+            .map(|indexer| (indexer.largest_allocation, indexer.allocated_tokens))
             .collect();
 
         receipt_pools


### PR DESCRIPTION
I decided to chunk into smaller PRs #364 since the conflicts with the `main` branch are making me rework certain parts.

This PR adds the following increments:

- [x] Added an Address<->Indexer lookup table to the `GraphNetwork` struct.
- [x] As all `Indexer`'s URLs are guaranteed to be valid  (see: 7f2f89aa-24c9-460b-ab1e-fc94697c4f4), use the indexer associated `statu_url` and `cost_url` methods.