### PR TITLE
chore(ci): add cargo build caching to ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
-on: [push]
+name: ci
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
 
-name: Continuous Integration
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -10,25 +17,22 @@ env:
   GH_TOKEN: ${{ secrets.GH_PRIVATE_TOKEN }}
 
 jobs:
-  check:
+  check_and_test:
+    name: "check and test"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v2
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: check-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
           toolchain: stable
           components: rustfmt, clippy
 
-      - name: Prepare
+      - name: Cache Cargo build files
+        uses: Leafwing-Studios/cargo-cache@v1
+
+      - name: Prepare build env
         run: |
           git config --global credential.helper store
           git config --global --replace-all url.https://github.com/.insteadOf ssh://git@github.com/
@@ -38,6 +42,11 @@ jobs:
           sudo apt-get install -y lld librdkafka-dev libsasl2-dev
 
       - run: cargo check
-      - run: cargo test -- --nocapture
       - run: cargo fmt --all -- --check
       - run: cargo clippy -- -D warnings
+
+      - name: Unit tests
+        run: cargo test --lib -- --nocapture
+
+      - name: Integration tests
+        run: cargo test --test '*'


### PR DESCRIPTION
Running the CI pipeline can take more than 10 minutes. And in the case the integration test fail (due to external reasons), one would have to rerun the CI job, consuming another 10 minutes.

 - [x] This PR adds a "cargo build cache" step that caches the build artifacts to optimize significantly for the CI execution time. Reducing the execution time from minutes to a few seconds. 
 - [x] The unit and integration test steps have also been split to make spotting the failing test case easier.
 - [x] Limited the CI jobs concurrency to only one per PR. When a new push happens, the previous build is canceled.
 - [x] CI builds will only happen when "a PR is opened, or a push happens on a PR" and when a PR is merged into the `main` branch.

-------

As _Seeing is believing 👀_:

> First run (no cache):
> 
> ![image](https://github.com/edgeandnode/graph-gateway/assets/3949095/58da593b-548d-4f2f-b79a-43a5782cf45d)
> 
> Reusing an existing cache:
> 
> ![image](https://github.com/edgeandnode/graph-gateway/assets/3949095/9a9da757-bb87-4734-b6d3-491abcb6c5d9)
> 