### PR TITLE
fix: report addresses without checksum

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -828,10 +828,7 @@ async fn handle_indexer_query_inner(
 
     let allocation = Address::from_slice(&receipt[0..20]);
 
-    tracing::info!(
-        target: reports::INDEXER_QUERY_TARGET,
-        allocation = format!("{:?}", allocation),
-    );
+    tracing::info!(target: reports::INDEXER_QUERY_TARGET, ?allocation);
 
     let response = result?;
     if response.status != StatusCode::OK.as_u16() {


### PR DESCRIPTION
The checksum serialization is causing issues for data science pipelines. Luckily the new `Address` type uses lowercase hex for debug formatting.