### PR TITLE
fix: remove application of user preferences in indexer-selection

### DIFF
--- a/graph-gateway/src/auth.rs
+++ b/graph-gateway/src/auth.rs
@@ -15,7 +15,7 @@ use prelude::USD;
 use tokio::sync::RwLock;
 use toolshed::thegraph::{DeploymentId, SubgraphId};
 
-use crate::subgraph_studio::{APIKey, IndexerPreferences, QueryStatus};
+use crate::subgraph_studio::{APIKey, QueryStatus};
 use crate::subscriptions::Subscription;
 use crate::topology::Deployment;
 
@@ -30,7 +30,6 @@ pub struct AuthHandler {
 #[derive(Debug)]
 pub struct UserSettings {
     pub budget: Option<USD>,
-    pub indexer_preferences: IndexerPreferences,
 }
 
 pub enum AuthToken {
@@ -219,14 +218,7 @@ impl AuthHandler {
             AuthToken::ApiKey(api_key) => api_key.max_budget,
             _ => None,
         };
-        let indexer_preferences = match token {
-            AuthToken::ApiKey(api_key) => api_key.indexer_preferences.clone(),
-            AuthToken::Ticket(_, _) => IndexerPreferences::default(),
-        };
-        UserSettings {
-            budget,
-            indexer_preferences,
-        }
+        UserSettings { budget }
     }
 }
 

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -542,16 +542,13 @@ async fn handle_client_query_inner(
         budget_grt = budget.as_f64() as f32,
     );
 
-    let mut utility_params = UtilityParameters::new(
+    let mut utility_params = UtilityParameters {
         budget,
-        block_requirements,
-        0, // 170cbcf3-db7f-404a-be13-2022d9142677
-        block_cache.block_rate_hz,
-        user_settings.indexer_preferences.performance,
-        user_settings.indexer_preferences.data_freshness,
-        user_settings.indexer_preferences.economic_security,
-        user_settings.indexer_preferences.price_efficiency,
-    );
+        requirements: block_requirements,
+        // 170cbcf3-db7f-404a-be13-2022d9142677
+        latest_block: 0,
+        block_rate_hz: block_cache.block_rate_hz,
+    };
 
     let mut rng = SmallRng::from_entropy();
 

--- a/indexer-selection/bin/sim.rs
+++ b/indexer-selection/bin/sim.rs
@@ -42,16 +42,12 @@ async fn main() -> Result<()> {
         gen_blocks(&(0..last_block).collect::<Vec<u64>>())
     };
     let latest_block = blocks.last().unwrap().number;
-    let params = UtilityParameters::new(
+    let params = UtilityParameters {
         budget,
-        freshness_requirements,
+        requirements: freshness_requirements,
         latest_block,
-        0.1,
-        0.0,
-        0.0,
-        0.0,
-        0.0,
-    );
+        block_rate_hz: 0.1,
+    };
 
     println!("label,indexer,detail,selections,fees");
     eprintln!("| selection limit | total fees (GRT) | avg. latency (ms) | avg. blocks behind | avg. indexers selected | avg. selection time (ms) |");

--- a/indexer-selection/src/indexing.rs
+++ b/indexer-selection/src/indexing.rs
@@ -146,16 +146,9 @@ impl IndexingState {
     pub fn fee(
         &self,
         context: &mut Context<'_>,
-        weight: f64,
         budget: &GRT,
         max_indexers: u8,
     ) -> Result<GRT, SelectionError> {
-        indexer_fee(
-            &self.status.cost_model,
-            context,
-            weight,
-            budget,
-            max_indexers,
-        )
+        indexer_fee(&self.status.cost_model, context, budget, max_indexers)
     }
 }

--- a/indexer-selection/src/lib.rs
+++ b/indexer-selection/src/lib.rs
@@ -168,53 +168,7 @@ pub struct UtilityParameters {
     pub budget: GRT,
     pub requirements: BlockRequirements,
     pub latest_block: u64,
-    pub performance: ConcaveUtilityParameters,
-    pub data_freshness: ConcaveUtilityParameters,
-    pub economic_security: ConcaveUtilityParameters,
-    pub fee_weight: f64,
-}
-
-impl UtilityParameters {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        budget: GRT,
-        requirements: BlockRequirements,
-        latest_block: u64,
-        block_rate_hz: f64,
-        performance: f64,
-        data_freshness: f64,
-        economic_security: f64,
-        fee_weight: f64,
-    ) -> Self {
-        fn interp(lo: f64, hi: f64, preference: f64) -> f64 {
-            if !(0.0..=1.0).contains(&preference) {
-                return lo;
-            }
-            lo + ((hi - lo) * preference)
-        }
-        Self {
-            budget,
-            requirements,
-            latest_block,
-            // 170cbcf3-db7f-404a-be13-2022d9142677
-            performance: ConcaveUtilityParameters {
-                a: interp(1.1, 1.2, performance),
-                weight: interp(1.0, 1.5, performance),
-            },
-            // 9f6c6cb0-0e49-4bc4-848e-22a1599af45b
-            data_freshness: ConcaveUtilityParameters {
-                a: 32.0 * block_rate_hz,
-                weight: interp(1.0, 2.0, data_freshness),
-            },
-            // https://www.desmos.com/calculator/g7t53e70lf
-            economic_security: ConcaveUtilityParameters {
-                a: interp(8e-4, 4e-4, economic_security),
-                weight: interp(1.0, 1.5, economic_security),
-            },
-            // 3534cc5a-f562-48ce-ac7a-88737c80698b
-            fee_weight: interp(1.0, 2.0, fee_weight),
-        }
-    }
+    pub block_rate_hz: f64,
 }
 
 #[derive(Default)]
@@ -350,7 +304,6 @@ impl State {
         let fee = indexer_fee(
             &state.status.cost_model,
             context,
-            params.fee_weight,
             &params.budget,
             selection_limit,
         )?;

--- a/indexer-selection/src/performance.rs
+++ b/indexer-selection/src/performance.rs
@@ -6,16 +6,14 @@ use crate::{
     impl_struct_decay,
     score::ExpectedValue,
     utility::UtilityFactor,
-    ConcaveUtilityParameters,
 };
 
-// https://www.desmos.com/calculator/y2t5704v6a
-// 170cbcf3-db7f-404a-be13-2022d9142677
-pub fn performance_utility(params: ConcaveUtilityParameters, latency_ms: u32) -> UtilityFactor {
-    let sigmoid = |x: u32| 1.0 + E.powf(((x as f64).powf(params.a) - 400.0) / 300.0);
+// https://www.desmos.com/calculator/rvqjvypylj
+pub fn performance_utility(latency_ms: u32) -> UtilityFactor {
+    let sigmoid = |x: u32| 1.0 + E.powf(((x as f64).powf(1.1) - 400.0) / 300.0);
     UtilityFactor {
         utility: sigmoid(0) / sigmoid(latency_ms),
-        weight: params.weight,
+        weight: 1.0,
     }
 }
 

--- a/indexer-selection/src/test.rs
+++ b/indexer-selection/src/test.rs
@@ -74,7 +74,12 @@ fn utiliy_params(
     requirements: BlockRequirements,
     latest_block: u64,
 ) -> UtilityParameters {
-    UtilityParameters::new(budget, requirements, latest_block, 0.1, 0.0, 0.0, 0.0, 0.0)
+    UtilityParameters {
+        budget,
+        requirements,
+        latest_block,
+        block_rate_hz: 0.1,
+    }
 }
 
 impl Topology {


### PR DESCRIPTION
This remove the interpolation between utility curves for certain selection factors. This feature provided little value to users while also making it difficult to debug & adjust ISA weights based on user QoS issues.