### PR TITLE
fix: handle subscriptions domains & special query keys

### DIFF
--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -172,10 +172,12 @@ impl FromStr for SignerKey {
 #[serde_as]
 #[derive(Debug, Deserialize)]
 pub struct Subscriptions {
-    /// Subscriptions contract owners
-    pub contract_owners: Vec<Address>,
+    /// Subscriptions contract domains
+    pub domains: Vec<SubscriptionsDomain>,
     /// Kafka topic to report subscription queries
     pub kafka_topic: Option<String>,
+    /// Query key signers that don't require payment
+    pub special_signers: Vec<Address>,
     /// Subscriptions subgraph URL
     #[serde_as(as = "DisplayFromStr")]
     pub subgraph: Url,
@@ -185,4 +187,11 @@ pub struct Subscriptions {
     #[serde(default)]
     #[serde_as(as = "FromInto<Vec<SubscriptionTier>>")]
     pub tiers: SubscriptionTiers,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+pub struct SubscriptionsDomain {
+    pub chain_id: u64,
+    pub contract: Address,
 }


### PR DESCRIPTION
This makes 2 adjustments to the auth handling of query keys:
- Subscriptions domains are added to verify that query keys are associated with expected contracts. This avoids situations where, for example, a user with only a subscription on testnet makes queries on mainnet.
- The `contract_owners` config option is replaced with `special_query_key_signers` (which better reflects it's actual use). Query keys signed by special signers do not have their subscriptions domains checked.