### PR TITLE
refactor(graph-gateway): update subgraph client with graphql-http client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f658e2baef915ba0f26f1f7c42bfb8e12f532a01f449a090ded75ae7a07e9ba2"
+checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
 dependencies = [
  "flate2",
  "futures-core",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7daec1a2a2129eeba1644b220b4647ec537b0b5d4bfd6876fcc5a540056b592"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -649,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.84"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8e7c90afad890484a21653d08b6e209ae34770fb5ee298f9c699fcc1e5c856"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -998,9 +998,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
  "digest 0.10.7",
@@ -1018,9 +1018,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.6"
+version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97ca172ae9dc9f9b779a6e3a65d308f2af74e5b8c921299075bdb4a0370e914"
+checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1082,9 +1082,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
+checksum = "f258a7194e7f7c2a7837a8913aeab7fd8c383457034fa20ce4dd3dcb813e8eb8"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1162,14 +1162,13 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad13497f6e0a24292fc7b408e30d22fe9dc262da1f40d7b542c3a44e7fc0476"
+checksum = "1a5344eea9b20effb5efeaad29418215c4d27017639fd1f908260f59cbbd226e"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
  "ethers-core",
- "ethers-etherscan",
  "ethers-middleware",
  "ethers-providers",
  "ethers-signers",
@@ -1177,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e9e8acd0ed348403cc73a670c24daba3226c40b98dc1a41903766b3ab6240a"
+checksum = "8c405f24ea3a517899ba7985385c43dc4a7eb1209af3b1e0a1a32d7dcc7f8d09"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1189,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79269278125006bb0552349c03593ffa9702112ca88bc7046cc669f148fb47c"
+checksum = "0111ead599d17a7bff6985fd5756f39ca7033edc79a31b23026a8d5d64fa95cd"
 dependencies = [
  "const-hex",
  "ethers-contract-abigen",
@@ -1208,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95a43c939b2e4e2f3191c5ad4a1f279780b8a39139c9905b43a7433531e2ab"
+checksum = "51258120c6b47ea9d9bec0d90f9e8af71c977fbefbef8213c91bfed385fe45eb"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1230,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9ce44906fc871b3ee8c69a695ca7ec7f70e50cb379c9b9cb5e532269e492f6"
+checksum = "936e7a0f1197cee2b62dc89f63eff3201dbf87c283ff7e18d86d38f83b845483"
 dependencies = [
  "Inflector",
  "const-hex",
@@ -1246,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a17f0708692024db9956b31d7a20163607d2745953f5ae8125ab368ba280ad"
+checksum = "2f03e0bdc216eeb9e355b90cf610ef6c5bb8aca631f97b5ae9980ce34ea7878d"
 dependencies = [
  "arrayvec 0.7.4",
  "bytes",
@@ -1275,31 +1274,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethers-etherscan"
-version = "2.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e53451ea4a8128fbce33966da71132cf9e1040dcfd2a2084fd7733ada7b2045"
-dependencies = [
- "ethers-core",
- "reqwest",
- "semver 1.0.20",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
-
-[[package]]
 name = "ethers-middleware"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473f1ccd0c793871bbc248729fa8df7e6d2981d6226e4343e3bbaa9281074d5d"
+checksum = "681ece6eb1d10f7cf4f873059a77c04ff1de4f35c63dd7bccde8f438374fcb93"
 dependencies = [
  "async-trait",
  "auto_impl",
  "ethers-contract",
  "ethers-core",
- "ethers-etherscan",
  "ethers-providers",
  "ethers-signers",
  "futures-channel",
@@ -1318,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6838fa110e57d572336178b7c79e94ff88ef976306852d8cb87d9e5b1fc7c0b5"
+checksum = "25d6c0c9455d93d4990c06e049abf9b30daf148cf461ee939c11d88907c60816"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1354,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea44bec930f12292866166f9ddbea6aa76304850e4d8dcd66dc492b43d00ff1"
+checksum = "0cb1b714e227bbd2d8c53528adb580b203009728b17d0d0e4119353aa9bc5532"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1734,6 +1717,7 @@ dependencies = [
  "serde_yaml",
  "simple-rate-limiter",
  "tap_core",
+ "test-with",
  "thiserror",
  "tokio",
  "toolshed",
@@ -1806,9 +1790,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -1816,7 +1800,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2212,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
+checksum = "3f01b677d82ef7a676aa37e099defd83a28e15687112cafdd112d60236b6115b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -3025,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fdd22f3b9c31b53c060df4a0613a1c7f062d4115a2b984dd15b1858f7e340d"
+checksum = "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3035,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265baba7fabd416cf5078179f7d2cbeca4ce7a9041111900675ea7c4cb8a4c32"
+checksum = "065717a5dfaca4a83d2fe57db3487b311365200000551d7a364e715dbf4346bc"
 dependencies = [
  "anyhow",
  "itertools 0.11.0",
@@ -3409,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.23"
+version = "0.38.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb93593068e9babdad10e4fce47dc9b3ac25315a72a59766ffd9e9a71996a04"
+checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -3803,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core",
@@ -4107,6 +4091,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-with"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "218672fc44a147054aadbff6f977424bd98109ad5055a31e5b6dc33489790450"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4244,14 +4241,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -4270,8 +4267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.1.0",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -4283,6 +4278,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+dependencies = [
+ "indexmap 2.1.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -4893,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 dependencies = [
  "zeroize_derive",
 ]

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -61,5 +61,6 @@ uuid = { version = "1.0", default-features = false, features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-hyper = "*"
+hyper = "0.14.24"
 regex = "1.5"
+test-with = { version = "0.12.0", default-features = false }

--- a/graph-gateway/src/network_subgraph.rs
+++ b/graph-gateway/src/network_subgraph.rs
@@ -6,7 +6,6 @@ use anyhow::anyhow;
 use eventuals::{self, Eventual, EventualExt as _, EventualWriter, Ptr};
 use prelude::*;
 use serde::Deserialize;
-use serde_json::json;
 use tokio::sync::Mutex;
 use toolshed::thegraph::{DeploymentId, SubgraphId};
 
@@ -116,7 +115,7 @@ impl Client {
         let query = r#"{ graphNetwork(id: "1") { slashingPercentage } }"#;
         let response = self
             .subgraph_client
-            .query::<GraphNetworkResponse>(&json!({ "query": query }))
+            .query::<GraphNetworkResponse>(query)
             .await
             .map_err(|err| anyhow!(err))?
             .graph_network
@@ -178,7 +177,7 @@ impl Client {
 
         let subgraphs = self
             .subgraph_client
-            .paginated_query::<Subgraph>(&query)
+            .paginated_query::<Subgraph>(query)
             .await?;
 
         if subgraphs.is_empty() {

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -183,12 +183,14 @@ impl tracing_subscriber::field::Visit for CollectFields<'_> {
 
     fn record_u128(&mut self, field: &tracing::field::Field, value: u128) {
         debug_assert!(false, "u128 should not be serialized to JSON");
-        self.0.insert(field.name().to_owned(), value.into());
+        self.0
+            .insert(field.name().to_owned(), value.to_string().into());
     }
 
     fn record_i128(&mut self, field: &tracing::field::Field, value: i128) {
         debug_assert!(false, "1128 should not be serialized to JSON");
-        self.0.insert(field.name().to_owned(), value.into());
+        self.0
+            .insert(field.name().to_owned(), value.to_string().into());
     }
 }
 

--- a/graph-gateway/src/subgraph_client.rs
+++ b/graph-gateway/src/subgraph_client.rs
@@ -1,15 +1,168 @@
-use axum::http::{header, HeaderMap, HeaderValue};
-use graphql::http::Response;
-use serde::{de::DeserializeOwned, Deserialize};
-use serde_json::{json, value::RawValue, Value};
+use alloy_primitives::{BlockHash, BlockNumber};
+use graphql_http::graphql::{Document, IntoDocument, IntoDocumentWithVariables};
+use graphql_http::http::request::IntoRequestParameters;
+use graphql_http::http_client::{ReqwestExt, ResponseError, ResponseResult};
+use indoc::indoc;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::value::RawValue;
 use toolshed::thegraph::BlockPointer;
 use toolshed::url::Url;
 
+// graph-node is rejecting values of `number_gte:0` on subgraphs with a larger `startBlock`
+// TODO: delete when resolved
+const SUBGRAPH_INIT_QUERY_DOCUMENT: &str = r#"{ meta: _meta { block { number hash } } }"#;
+
+#[derive(Deserialize)]
+struct Meta {
+    block: BlockPointer,
+}
+
+/// The block at which the query should be executed.
+///
+/// This is part of the input arguments of the [`SubgraphPaginatedQuery`].
+#[derive(Clone, Debug, Default, Serialize)]
+struct BlockHeight {
+    /// Value containing a block hash
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hash: Option<BlockHash>,
+    /// Value containing a block number
+    #[serde(skip_serializing_if = "Option::is_none")]
+    number: Option<BlockNumber>,
+    /// Value containing the minimum block number.
+    ///
+    /// In the case of `number_gte`, the query will be executed on the latest block only if
+    /// the subgraph has progressed to or past the minimum block number.
+    /// Defaults to the latest block when omitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    number_gte: Option<BlockNumber>,
+}
+
+// graph-node is rejecting values of `number_gte:0` on subgraphs with a larger `startBlock`
+// TODO: delete when resolved
+#[derive(Deserialize)]
+struct SubgraphInitQueryResponse {
+    meta: Meta,
+}
+
+struct SubgraphPaginatedQuery {
+    query: Document,
+    vars: SubgraphPaginatedQueryVars,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct SubgraphPaginatedQueryVars {
+    block: BlockHeight,
+    first: u32,
+    last: String,
+}
+
+impl SubgraphPaginatedQuery {
+    fn new(query: impl IntoDocument, vars: SubgraphPaginatedQueryVars) -> Self {
+        Self {
+            query: query.into_document(),
+            vars,
+        }
+    }
+}
+
+impl IntoDocumentWithVariables for SubgraphPaginatedQuery {
+    type Variables = SubgraphPaginatedQueryVars;
+
+    fn into_document_with_variables(self) -> (Document, Self::Variables) {
+        let query = format!(
+            indoc! {
+                r#"query ($block: Block_height!, $first: Int!, $last: String!) {{
+                    meta: _meta(block: $block) {{ block {{ number hash }} }}
+                    results: {query}
+                }}"#
+            },
+            query = self.query
+        );
+
+        (query.into_document(), self.vars)
+    }
+}
+
+#[derive(Deserialize)]
+struct SubgraphPaginatedQueryResponse {
+    meta: Meta,
+    results: Vec<Box<RawValue>>,
+}
+
+#[derive(Deserialize)]
+struct SubgraphPaginatedQueryResponseOpaqueEntry {
+    id: String,
+}
+
+async fn send_query<T>(
+    client: &reqwest::Client,
+    url: Url,
+    ticket: Option<&str>,
+    query: impl IntoRequestParameters + Send,
+) -> Result<ResponseResult<T>, String>
+where
+    T: DeserializeOwned,
+{
+    let mut builder = client.post(url.0);
+
+    if let Some(ticket) = ticket {
+        builder = builder.bearer_auth(ticket)
+    }
+
+    let res = builder
+        .send_graphql(query)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    Ok(res)
+}
+
+async fn send_subgraph_query<T>(
+    client: &reqwest::Client,
+    subgraph_url: Url,
+    ticket: Option<&str>,
+    query: impl IntoRequestParameters + Send,
+) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    send_query(client, subgraph_url, ticket, query)
+        .await
+        .map_err(|err| format!("Error sending subgraph graphql query: {}", err))?
+        .map_err(|err| err.to_string())
+}
+
+async fn send_subgraph_init_query(
+    client: &reqwest::Client,
+    subgraph_url: Url,
+    ticket: Option<&str>,
+) -> Result<SubgraphInitQueryResponse, String> {
+    send_query(client, subgraph_url, ticket, SUBGRAPH_INIT_QUERY_DOCUMENT)
+        .await
+        .map_err(|err| format!("Error sending init subgraph query: {}", err))?
+        .map_err(|err| err.to_string())
+}
+
+async fn send_subgraph_paginated_query(
+    client: &reqwest::Client,
+    subgraph_url: Url,
+    ticket: Option<&str>,
+    query: SubgraphPaginatedQuery,
+) -> Result<ResponseResult<SubgraphPaginatedQueryResponse>, String> {
+    send_query(client, subgraph_url, ticket, query)
+        .await
+        .map_err(|err| format!("Error sending subgraph graphql query: {}", err))
+}
+
+/// A client for interacting with a subgraph.
 pub struct Client {
     http_client: reqwest::Client,
     subgraph_endpoint: Url,
     ticket: Option<String>,
-    latest_block: u64,
+
+    /// The latest block number that the subgraph has progressed to.
+    /// This is set to 0 initially and updated after each paginated query.
+    latest_block: BlockNumber,
 }
 
 impl Client {
@@ -26,148 +179,121 @@ impl Client {
         }
     }
 
-    pub async fn query<T: for<'de> Deserialize<'de>>(&self, query: &Value) -> Result<T, String> {
-        let response = graphql_query::<T>(
+    pub async fn query<T: for<'de> Deserialize<'de>>(
+        &self,
+        query: impl IntoRequestParameters + Send,
+    ) -> Result<T, String> {
+        let response = send_subgraph_query::<T>(
             &self.http_client,
             self.subgraph_endpoint.clone(),
-            query,
             self.ticket.as_deref(),
+            query,
         )
-        .await?
-        .data
-        .ok_or("empty response")?;
+        .await?;
 
         Ok(response)
     }
 
     pub async fn paginated_query<T: for<'de> Deserialize<'de>>(
         &mut self,
-        query: &str,
+        query: impl IntoDocument + Clone,
     ) -> Result<Vec<T>, String> {
         let batch_size: u32 = 200;
-        let mut last_id = "".to_string();
-        let mut query_block: Option<BlockPointer> = None;
-        let mut results = Vec::new();
+
         // graph-node is rejecting values of `number_gte:0` on subgraphs with a larger `startBlock`
         // TODO: delete when resolved
         if self.latest_block == 0 {
-            #[derive(Deserialize)]
-            struct InitResponse {
-                meta: Meta,
-            }
-            let init = graphql_query::<InitResponse>(
+            let init = send_subgraph_init_query(
                 &self.http_client,
                 self.subgraph_endpoint.clone(),
-                &json!({"query": "{ meta: _meta { block { number hash } } }"}),
-                self.ticket.as_deref(),
-            )
-            .await?
-            .unpack()?;
-            self.latest_block = init.meta.block.number;
-        }
-        loop {
-            let block = query_block
-                .as_ref()
-                .map(|block| json!({ "hash": block.hash }))
-                .unwrap_or(json!({ "number_gte": self.latest_block }));
-            let response = graphql_query::<PaginatedQueryResponse>(
-                &self.http_client,
-                self.subgraph_endpoint.clone(),
-                &json!({
-                    "query": format!(r#"
-                        query q($block: Block_height!, $first: Int!, $last: String!) {{
-                            meta: _meta(block: $block) {{ block {{ number hash }} }}
-                            results: {query}
-                        }}"#,
-                    ),
-                    "variables": {
-                        "block": block,
-                        "first": batch_size,
-                        "last": last_id,
-                    },
-                }),
                 self.ticket.as_deref(),
             )
             .await?;
-            let errors = response
-                .errors
-                .unwrap_or_default()
-                .into_iter()
-                .map(|err| err.message)
-                .collect::<Vec<String>>();
-            if errors
-                .iter()
-                .any(|err| err.contains("no block with that hash found"))
-            {
-                tracing::info!("Reorg detected. Restarting query to try a new block.");
-                last_id = "".to_string();
-                query_block = None;
-                continue;
-            }
-            if !errors.is_empty() {
-                return Err(errors.join(", "));
-            }
-            let data = match response.data {
-                Some(data) if !data.results.is_empty() => data,
-                _ => break,
+
+            self.latest_block = init.meta.block.number;
+        }
+
+        // The last id of the previous batch.
+        let mut last_id = "".to_string();
+        // The block at which the query should be executed.
+        let mut query_block: Option<BlockPointer> = None;
+
+        // Vector to store the results of the paginated query.
+        let mut results = Vec::new();
+
+        loop {
+            let block = query_block
+                .as_ref()
+                .map(|block| BlockHeight {
+                    hash: Some(block.hash),
+                    ..Default::default()
+                })
+                .unwrap_or({
+                    BlockHeight {
+                        number_gte: Some(self.latest_block),
+                        ..Default::default()
+                    }
+                });
+
+            let response = send_subgraph_paginated_query(
+                &self.http_client,
+                self.subgraph_endpoint.clone(),
+                self.ticket.as_deref(),
+                SubgraphPaginatedQuery::new(
+                    query.clone(),
+                    SubgraphPaginatedQueryVars {
+                        block,
+                        first: batch_size,
+                        last: last_id,
+                    },
+                ),
+            )
+            .await?;
+
+            let data = match response {
+                Ok(data) if !data.results.is_empty() => data,
+                Ok(_) => break,
+                Err(err) => match err {
+                    ResponseError::Empty => break,
+                    ResponseError::Failure { errors } => {
+                        let errors = errors
+                            .into_iter()
+                            .map(|err| err.message)
+                            .collect::<Vec<String>>();
+
+                        if errors
+                            .iter()
+                            .any(|err| err.contains("no block with that hash found"))
+                        {
+                            tracing::info!("Reorg detected. Restarting query to try a new block.");
+
+                            last_id = "".to_string();
+                            query_block = None;
+                            continue;
+                        }
+
+                        return Err(errors.join(", "));
+                    }
+                },
             };
-            last_id = serde_json::from_str::<OpaqueEntry>(data.results.last().unwrap().get())
-                .map_err(|_| "failed to extract id for last entry".to_string())?
-                .id;
+
+            last_id = serde_json::from_str::<SubgraphPaginatedQueryResponseOpaqueEntry>(
+                data.results.last().unwrap().get(),
+            )
+            .map_err(|_| "failed to extract id for last entry".to_string())?
+            .id;
             query_block = Some(data.meta.block);
+
             for entry in data.results {
                 results
                     .push(serde_json::from_str::<T>(entry.get()).map_err(|err| err.to_string())?);
             }
         }
+
         if let Some(block) = query_block {
             self.latest_block = block.number;
         }
+
         Ok(results)
     }
-}
-
-pub async fn graphql_query<T>(
-    client: &reqwest::Client,
-    url: Url,
-    body: &Value,
-    ticket: Option<&str>,
-) -> Result<Response<T>, String>
-where
-    T: DeserializeOwned,
-{
-    let headers = ticket
-        .into_iter()
-        .map(|ticket| {
-            let value = HeaderValue::from_str(&format!("Bearer {ticket}")).unwrap();
-            (header::AUTHORIZATION, value)
-        })
-        .collect::<HeaderMap>();
-    client
-        .post(url.0)
-        .headers(headers)
-        .json(body)
-        .send()
-        .await
-        .and_then(|response| response.error_for_status())
-        .map_err(|err| err.to_string())?
-        .json::<Response<T>>()
-        .await
-        .map_err(|err| err.to_string())
-}
-
-#[derive(Deserialize)]
-struct Meta {
-    block: BlockPointer,
-}
-
-#[derive(Deserialize)]
-struct PaginatedQueryResponse {
-    meta: Meta,
-    results: Vec<Box<RawValue>>,
-}
-
-#[derive(Deserialize)]
-struct OpaqueEntry {
-    id: String,
 }

--- a/graph-gateway/src/subscriptions_subgraph.rs
+++ b/graph-gateway/src/subscriptions_subgraph.rs
@@ -76,7 +76,7 @@ impl Client {
         );
         let active_subscriptions_response = self
             .subgraph_client
-            .paginated_query::<ActiveSubscription>(&query)
+            .paginated_query::<ActiveSubscription>(query)
             .await?;
         if active_subscriptions_response.is_empty() {
             return Err("Discarding empty update (active_subscriptions)".to_string());

--- a/graph-gateway/tests/it_subgraph_client.rs
+++ b/graph-gateway/tests/it_subgraph_client.rs
@@ -1,0 +1,99 @@
+use assert_matches::assert_matches;
+use serde::Deserialize;
+use toolshed::thegraph::{BlockPointer, SubgraphId};
+use toolshed::url::Url;
+
+use graph_gateway::subgraph_client::Client as SubgraphClient;
+
+/// Test helper to parse a URL.
+fn test_url(url: &str) -> Url {
+    url.parse().expect("Invalid URL")
+}
+
+/// Test helper to get the test query key from the environment.
+fn test_query_key() -> String {
+    std::env::var("THEGRAPH_TEST_QUERY_KEY").expect("Missing THEGRAPH_TEST_QUERY_KEY")
+}
+
+#[test_with::env(THEGRAPH_TEST_QUERY_KEY)]
+#[tokio::test]
+async fn send_subgraph_meta_query() {
+    //// Given
+    let ticket = test_query_key();
+
+    let http_client = reqwest::Client::new();
+    let subgraph_url = test_url("https://gateway.thegraph.com/api/deployments/id/QmRbgjyzEgfxGbodu6itfkXCQ5KA9oGxKscrcQ9QuF88oT");
+
+    let client = SubgraphClient::new(http_client, subgraph_url, Some(ticket));
+
+    // Subgraph meta query
+    const SUBGRAPH_META_QUERY_DOCUMENT: &str = r#"{ meta: _meta { block { number hash } } }"#;
+
+    #[derive(Debug, Deserialize)]
+    struct Meta {
+        block: BlockPointer,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SubgraphMetaQueryResponse {
+        meta: Meta,
+    }
+
+    //// When
+    let req_fut = client.query::<SubgraphMetaQueryResponse>(SUBGRAPH_META_QUERY_DOCUMENT);
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), req_fut)
+        .await
+        .expect("Timeout on subgraph meta query");
+
+    //// Then
+    // Assert the query succeeded and we get a non-empty block number and hash.
+    assert_matches!(res, Ok(SubgraphMetaQueryResponse { meta }) => {
+        assert!(meta.block.number > 0);
+        assert!(!meta.block.hash.is_empty());
+    });
+}
+
+#[test_with::env(THEGRAPH_TEST_QUERY_KEY)]
+#[tokio::test]
+async fn send_subgraph_paginated() {
+    //// Given
+    let ticket = test_query_key();
+    let subgraph_url = test_url("https://gateway.thegraph.com/api/deployments/id/QmRbgjyzEgfxGbodu6itfkXCQ5KA9oGxKscrcQ9QuF88oT");
+
+    let http_client = reqwest::Client::new();
+
+    let mut client = SubgraphClient::new(http_client, subgraph_url, Some(ticket));
+
+    // Query all subgraph ids.
+    const SUBGRAPHS_QUERY_DOCUMENT: &str = r#"
+        subgraphs(
+            block: $block
+            orderBy: id, orderDirection: asc
+            first: $first
+            where: {
+                id_gt: $last
+                entityVersion: 2
+            }
+        ) {
+            id
+        }
+        "#;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct Subgraph {
+        pub id: SubgraphId,
+    }
+
+    //// When
+    let req_fut = client.paginated_query::<Subgraph>(SUBGRAPHS_QUERY_DOCUMENT);
+    let res = tokio::time::timeout(std::time::Duration::from_secs(10), req_fut)
+        .await
+        .expect("Timeout on subgraph paginated query");
+
+    //// Then
+    // Assert the query succeeded and we got a non-empty list of active subscriptions.
+    assert_matches!(res, Ok(vec) => {
+        assert!(!vec.is_empty());
+    });
+}


### PR DESCRIPTION
This PR refactors the subgraph client as a previous step to refactoring the Graph Network subgraph client.

- [x] Updated the existing implementation to use the new toolshed `graph-http` client.
- [x] Reorganized the code into smaller units for better readability.
- [x] Added integration tests covering the single and paginated subgraph queries. Added an environment variable, `THEGRAPH_TEST_QUERY_KEY`, to provide the service test query credentials in the CI. If not provided, these tests are skipped.

> [!NOTE] 
> The new tests are failing intermittently due to an indexer returning a `indexing_error` error. To avoid any false positives, let's keep them off until we can solve the issue with the faulty indexer.