### PR TITLE
feat(indexer-selection): penalize indexers with 0 allocation

### DIFF
--- a/indexer-selection/src/lib.rs
+++ b/indexer-selection/src/lib.rs
@@ -295,6 +295,7 @@ impl State {
         let reliability = state.reliability.expected_value();
         let perf_success = state.perf_success.expected_value();
         let slashable_usd = slashable.0.into();
+        let zero_allocation = state.status.allocation == GRT(UDecimal18::from(0));
 
         let expected_score = NotNan::new(expected_individual_score(
             params,
@@ -303,6 +304,7 @@ impl State {
             state.status.versions_behind,
             block_status.blocks_behind,
             slashable_usd,
+            zero_allocation,
             &fee,
         ))
         .unwrap_or(NotNan::zero());

--- a/indexer-selection/src/score.rs
+++ b/indexer-selection/src/score.rs
@@ -207,6 +207,7 @@ impl MetaIndexer<'_> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn expected_individual_score(
     params: &UtilityParameters,
     reliability: f64,
@@ -214,8 +215,10 @@ pub fn expected_individual_score(
     versions_behind: u8,
     blocks_behind: u64,
     slashable_usd: f64,
+    zero_allocation: bool,
     fee: &GRT,
 ) -> f64 {
+    let altruism_penalty = UtilityFactor::one(if zero_allocation { 0.8 } else { 1.0 });
     weighted_product_model([
         reliability_utility(reliability),
         performance_utility(perf_success as u32),
@@ -223,6 +226,7 @@ pub fn expected_individual_score(
         versions_behind_utility(versions_behind),
         data_freshness_utility(params.block_rate_hz, &params.requirements, blocks_behind),
         fee_utility(fee, &params.budget),
+        altruism_penalty,
     ])
 }
 


### PR DESCRIPTION
The expectation is that backstop indexers will not be selected over other indexers at equivalent QoS. Allocation size is only accounted for with sybil protection, so this makes our expected behavior much more explicit.