### PR TITLE
refactor(graph-gateway): update subgraph client with version query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "6.0.10"
+version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a665c228a226506796fca6de90cf1ad477157513ee15d6327bf810d5a3a98f72"
+checksum = "298a5d587d6e6fdb271bf56af2dc325a80eb291fd0fc979146584b9a05494a8c"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "6.0.10"
+version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f04964faf9ad71289d4c51b3b43a7b9c01c23c16d9c52bca48161ba8a3cbc3"
+checksum = "c7f329c7eb9b646a72f70c9c4b516c70867d356ec46cb00dcac8ad343fd006b0"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "6.0.10"
+version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a2329756a9946d83106e389a977a808ab22628cb797c1afcf174fd01c40d5"
+checksum = "6139181845757fd6a73fbb8839f3d036d7150b798db0e9bb3c6e83cdd65bd53b"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "6.0.10"
+version = "6.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305ca1e36538655babbfa8a9a1d82cb1dd01961af2feeafa06d3a0c9af793bed"
+checksum = "323a5143f5bdd2030f45e3f2e0c821c9b1d36e79cf382129c64299c50a7f3750"
 dependencies = [
  "bytes",
  "indexmap 2.1.0",
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12024c4645c97566567129c204f65d5815a8c9aecf30fcbe682b2fe034996d36"
+checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
 dependencies = [
  "serde",
 ]
@@ -843,9 +843,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28f85c3514d2a6e64160359b45a3918c3b4178bcbf4ae5d03ab2d02e521c479a"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -1018,9 +1018,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9775b22bc152ad86a0cf23f0f348b884b26add12bf741e7ffc4d4ab2ab4d205"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1368,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+checksum = "80f656be11ddf91bd709454d15d5bd896fbaf4cc3314e69349e4d1569f5b46cd"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1726,7 +1726,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trust-dns-resolver",
- "uuid 1.5.0",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -3333,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724fd11728a3804e9944b14cab63825024c40bf42f8af87c8b5d97c4bbacf426"
+checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -3393,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.24"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad981d6c340a49cdc40a1028d9c6084ec7e9fa33fcb839cab656a267071e234"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -3605,9 +3605,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -3624,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4599,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
 ]

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -38,7 +38,7 @@ rdkafka = { version = "0.36.0", features = ["gssapi", "tracing"] }
 receipts = { git = "ssh://git@github.com/edgeandnode/receipts.git", rev = "89a821c" }
 reqwest.workspace = true
 secp256k1 = { version = "0.24", default-features = false }
-semver = "1.0"
+semver = { version = "1.0", features = ["serde"] }
 serde.workspace = true
 serde_json = { version = "1.0", features = ["raw_value"] }
 serde_with = "3.1"

--- a/graph-gateway/src/indexers_status.rs
+++ b/graph-gateway/src/indexers_status.rs
@@ -1,3 +1,4 @@
 pub mod cost_models;
 pub mod indexing_statuses;
 pub mod public_poi;
+pub mod version;

--- a/graph-gateway/src/indexers_status/version.rs
+++ b/graph-gateway/src/indexers_status/version.rs
@@ -1,0 +1,50 @@
+pub use semver::Version;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct IndexerVersion {
+    pub version: Version,
+}
+
+pub mod client {
+    use toolshed::url::Url;
+
+    use super::IndexerVersion;
+
+    /// Sends a version query to the indexer and returns the version.
+    pub async fn send_version_query(
+        client: reqwest::Client,
+        version_url: Url,
+    ) -> anyhow::Result<IndexerVersion> {
+        let version = client
+            .get(version_url.0)
+            .send()
+            .await
+            .map_err(|err| anyhow::anyhow!("IndexerVersionError({err})"))?
+            .json::<IndexerVersion>()
+            .await
+            .map_err(|err| anyhow::anyhow!("IndexerVersionError({err})"))?;
+
+        Ok(version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_indexer_version_json() {
+        //// Given
+        let json = r#"{
+            "version": "0.1.0"
+        }"#;
+
+        //// When
+        let version: IndexerVersion =
+            serde_json::from_str(json).expect("Failed to deserialize IndexerVersion");
+
+        //// Then
+        assert_eq!(version.version, Version::new(0, 1, 0));
+    }
+}

--- a/graph-gateway/tests/it_indexers_status_version.rs
+++ b/graph-gateway/tests/it_indexers_status_version.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use assert_matches::assert_matches;
+use tokio::time::timeout;
+
+use graph_gateway::indexers_status::version::client;
+
+#[tokio::test]
+async fn query_indexer_public_pois() {
+    //// Given
+    let client = reqwest::Client::new();
+    let version_url = "https://testnet-indexer-03-europe-cent.thegraph.com/version"
+        .parse()
+        .expect("Invalid version url");
+
+    //// When
+    let request = client::send_version_query(client, version_url);
+    let response = timeout(Duration::from_secs(60), request)
+        .await
+        .expect("timeout");
+
+    //// Then
+    // Assert version is present and greater than 0.1.0
+    assert_matches!(response, Ok(resp) => {
+        assert!(resp.version > semver::Version::new(0, 1, 0));
+    });
+}


### PR DESCRIPTION
This pull request proposes moving the version query logic to the indexer's client module for better organization and code maintainability.

- [x] Move the version query logic to the indexer's client module.
- [x] Added some tests covering the functionality.

The idea is to turn, in the near future, the `indexers_status` module into an "indexer client module".