### PR TITLE
chore(deps): bump toolshed version to v0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4297,8 +4297,8 @@ dependencies = [
 
 [[package]]
 name = "toolshed"
-version = "0.2.2"
-source = "git+https://github.com/edgeandnode/toolshed?rev=e9f3446#e9f344633ef0d78a3209fac295de57c6397bd009"
+version = "0.2.3"
+source = "git+https://github.com/edgeandnode/toolshed?tag=v0.2.3#caeaa72e028ef2f60f1b480de796e6d97aebf4a1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ tokio = { version = "1.24", features = [
     "sync",
     "time",
 ] }
-toolshed = { git = "https://github.com/edgeandnode/toolshed", rev = "e9f3446" }
+toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.2.3" }
 tracing = { version = "0.1", default-features = false }


### PR DESCRIPTION
I am bumping the toolshed dependency to use the latest version.