### PR TITLE
fix: avoid retaining uncled blocks in cache

### DIFF
--- a/prelude/src/epoch_cache.rs
+++ b/prelude/src/epoch_cache.rs
@@ -82,6 +82,13 @@ impl<K: Eq + Hash, V, const C: u8> EpochCache<K, V, C> {
             f(v);
         }
     }
+
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&K, &mut V) -> bool,
+    {
+        self.0.retain(|k, (v, _)| f(k, v));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I have no evidence that this has caused issues. But it seems like a potentially nasty bug on chains that produce blocks more frequently than we poll for chain heads, since we may miss uncles. Seems like a good precaution anyway. The performance impact should be minimal because we deduplicate RPC requests on cache miss.