### PR TITLE
fix(graph-gateway): decouple graphql crate from cost-model version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,11 +803,11 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 [[package]]
 name = "cost-model"
 version = "0.1.0"
-source = "git+https://github.com/graphprotocol/agora?rev=9984f9e#9984f9ecc5401e1d637ee9e7d485d617e6cae56d"
+source = "git+https://github.com/graphprotocol/agora?rev=3367d76#3367d7650f06dae10f02bdb7663b07a66adc6978"
 dependencies = [
  "firestorm",
  "fraction",
- "graphql",
+ "graphql 0.2.0",
  "lazy_static",
  "nom",
  "num-bigint 0.2.6",
@@ -1691,7 +1691,7 @@ dependencies = [
  "faster-hex",
  "futures",
  "graph-subscriptions",
- "graphql",
+ "graphql 0.1.0",
  "graphql-http",
  "hex",
  "hyper",
@@ -1748,6 +1748,16 @@ dependencies = [
 name = "graphql"
 version = "0.1.0"
 source = "git+https://github.com/edgeandnode/toolshed?tag=graphql-v0.1.0#659205f037bda669237f3c61fa70f09cfa2fbab3"
+dependencies = [
+ "firestorm",
+ "graphql-parser",
+ "serde",
+]
+
+[[package]]
+name = "graphql"
+version = "0.2.0"
+source = "git+https://github.com/edgeandnode/toolshed?tag=graphql-v0.2.0#2df5ee975656027d4a7fbf591baf6a29dfbe0ee6"
 dependencies = [
  "firestorm",
  "graphql-parser",
@@ -4308,7 +4318,7 @@ dependencies = [
 [[package]]
 name = "toolshed"
 version = "0.2.3"
-source = "git+https://github.com/edgeandnode/toolshed?tag=v0.2.3#caeaa72e028ef2f60f1b480de796e6d97aebf4a1"
+source = "git+https://github.com/edgeandnode/toolshed?tag=v0.2.3#cdbbbf99b6f097b19d46c7aab5cf219f29e6cbb0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -13,7 +13,7 @@ axum = { version = "0.6.15", default-features = false, features = [
     "original-uri",
 ] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-cost-model = { git = "https://github.com/graphprotocol/agora", rev = "9984f9e" }
+cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3367d76" }
 ethers = { version = "2.0.10", default-features = false, features = ["abigen"] }
 eventuals = "0.6.7"
 faster-hex = "0.8.0"

--- a/graph-gateway/src/block_constraints.rs
+++ b/graph-gateway/src/block_constraints.rs
@@ -5,7 +5,7 @@ use cost_model::Context;
 use graphql::graphql_parser::query::{
     Definition, Document, OperationDefinition, Selection, Text, Value,
 };
-use graphql::{IntoStaticValue as _, QueryVariables, StaticValue};
+use graphql::{IntoStaticValue as _, StaticValue};
 use indexer_selection::UnresolvedBlock;
 use itertools::Itertools as _;
 use serde_json::{self, json};
@@ -157,7 +157,7 @@ fn deterministic_block<'c>(hash: &BlockHash) -> Value<'c, String> {
 }
 
 fn field_constraint(
-    vars: &QueryVariables,
+    vars: &cost_model::QueryVariables,
     defaults: &BTreeMap<String, StaticValue>,
     field: &Value<'_, String>,
 ) -> Option<BlockConstraint> {
@@ -172,7 +172,7 @@ fn field_constraint(
 }
 
 fn parse_constraint<'c, T: Text<'c>>(
-    vars: &QueryVariables,
+    vars: &cost_model::QueryVariables,
     defaults: &BTreeMap<String, StaticValue>,
     fields: &BTreeMap<T::Value, Value<'c, T>>,
 ) -> Option<BlockConstraint> {
@@ -192,7 +192,7 @@ fn parse_constraint<'c, T: Text<'c>>(
 
 fn parse_hash<'c, T: Text<'c>>(
     hash: &Value<'c, T>,
-    variables: &QueryVariables,
+    variables: &cost_model::QueryVariables,
     defaults: &BTreeMap<String, StaticValue>,
 ) -> Option<BlockHash> {
     match hash {
@@ -210,7 +210,7 @@ fn parse_hash<'c, T: Text<'c>>(
 
 fn parse_number<'c, T: Text<'c>>(
     number: &Value<'c, T>,
-    variables: &QueryVariables,
+    variables: &cost_model::QueryVariables,
     defaults: &BTreeMap<String, StaticValue>,
 ) -> Option<u64> {
     let n = match number {


### PR DESCRIPTION
Using the re-exported `QueryVariables` type, we can decouple the `cost-model` crate from the `graphql` crate.

This may seem like a workaround, but the effort to 100% decouple the exposed cost-model types from the rest of the Graph Gateway requires a major refactoring in the data path (a.k.a. query handling logic). At this moment, the risk and the effort is higher than the ROI.