### PR TITLE
fix(indexer-selection): shift required block range by 1 minute

### DIFF
--- a/indexer-selection/src/lib.rs
+++ b/indexer-selection/src/lib.rs
@@ -262,7 +262,7 @@ impl State {
             .ok_or(IndexerError::NoStatus)?;
 
         let block_status = state.status.block.as_ref().ok_or(IndexerError::NoStatus)?;
-        if !block_status.meets_requirements(&params.requirements) {
+        if !block_status.meets_requirements(&params.requirements, params.block_rate_hz) {
             return Err(IndexerError::MissingRequiredBlock.into());
         }
 

--- a/indexer-selection/src/test.rs
+++ b/indexer-selection/src/test.rs
@@ -68,7 +68,7 @@ fn utiliy_params(
         budget,
         requirements,
         latest_block,
-        block_rate_hz: 0.1,
+        block_rate_hz: 60.0_f64.recip(),
     }
 }
 
@@ -199,8 +199,8 @@ impl Topology {
                 expected_errors.0.entry(err).or_default().insert(indexer);
             };
 
-            if matches!(required_block, Some(n) if n > status.block.as_ref().unwrap().reported_number)
-            {
+            let allowed_block = status.block.as_ref().unwrap().reported_number;
+            if matches!(required_block, Some(n) if n.saturating_sub(1) > allowed_block) {
                 set_err(IndexerError::MissingRequiredBlock);
             } else if status.block.is_none() {
                 set_err(IndexerError::NoStatus);


### PR DESCRIPTION
Users typically abused the old behavior by setting block constraints at the most recent block from some RPC provider and now the gateway cannot usually ensure that indexers have the required minimum block since indexer statuses are polled every ~30 seconds and the block was often produced within 10 seconds of the query hitting the gateway.

Even though the use-case is fragile, we still want to support it before https://github.com/graphprotocol/indexer/issues/791 is implemented.