### PR TITLE
refactor: remove selection retry loop

### DIFF
--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -29,10 +29,6 @@ pub struct Config {
     pub geoip_blocked_countries: Vec<String>,
     /// Graph network environment identifier, inserted into Kafka messages
     pub graph_env_id: String,
-    /// Rounds of indexer selection and queries to attempt. Note that indexer queries have a 20s
-    /// timeout, so setting this to 5 for example would result in a 100s worst case response time
-    /// for a client query.
-    pub indexer_selection_retry_limit: usize,
     /// IPFS endpoint with access to the subgraph files
     #[serde_as(as = "DisplayFromStr")]
     pub ipfs: Url,

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -274,7 +274,6 @@ async fn main() {
     update_writer.flush().await.unwrap();
 
     let client_query_ctx = client_query::Context {
-        indexer_selection_retry_limit: config.indexer_selection_retry_limit,
         l2_gateway: config.l2_gateway,
         indexer_client: IndexerClient {
             client: http_client.clone(),


### PR DESCRIPTION
This loop is no longer required, now that budgeting has been lifted out of indexer selection and indexer status tracking is more reliable.