### PR TITLE
fix: use TAP as the name in the receipt EIP-712 domain

### DIFF
--- a/graph-gateway/src/receipts.rs
+++ b/graph-gateway/src/receipts.rs
@@ -57,7 +57,7 @@ impl ReceiptSigner {
         Self {
             signer,
             domain: Eip712Domain {
-                name: Some("Scalar TAP".into()),
+                name: Some("TAP".into()),
                 version: Some("1".into()),
                 chain_id: Some(chain_id),
                 verifying_contract: Some(verifier),


### PR DESCRIPTION
We identified yesterday that this is what is used in the TAP contracts. We'll need to update the indexer side as well.