### PR TITLE
fix: retain indexing statuses

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -45,7 +45,7 @@ use crate::block_constraints::{block_constraints, make_query_deterministic, Bloc
 use crate::budgets::{self, Budgeter};
 use crate::chains::BlockCache;
 use crate::indexer_client::{check_block_error, IndexerClient, IndexerError, ResponsePayload};
-use crate::indexing::IndexingStatus;
+use crate::indexers::indexing;
 use crate::metrics::{with_metric, METRICS};
 use crate::reports::{self, serialize_attestation, KafkaClient};
 use crate::topology::{Deployment, GraphNetwork, Subgraph};
@@ -99,7 +99,7 @@ pub struct Context {
     pub l2_gateway: Option<Url>,
     pub block_caches: &'static HashMap<String, BlockCache>,
     pub network: GraphNetwork,
-    pub indexing_statuses: Eventual<Ptr<HashMap<Indexing, IndexingStatus>>>,
+    pub indexing_statuses: Eventual<Ptr<HashMap<Indexing, indexing::Status>>>,
     pub attestation_domain: &'static Eip712Domain,
     pub indexings_blocklist: Eventual<Ptr<HashSet<Indexing>>>,
     pub isa_state: DoubleBufferReader<indexer_selection::State>,

--- a/graph-gateway/src/indexers.rs
+++ b/graph-gateway/src/indexers.rs
@@ -1,4 +1,5 @@
 pub mod cost_models;
+pub mod indexing;
 pub mod indexing_statuses;
 pub mod public_poi;
 pub mod version;

--- a/graph-gateway/src/lib.rs
+++ b/graph-gateway/src/lib.rs
@@ -12,7 +12,6 @@ pub mod config;
 pub mod geoip;
 pub mod indexer_client;
 pub mod indexers;
-pub mod indexing;
 pub mod indexings_blocklist;
 pub mod ipfs;
 pub mod metrics;


### PR DESCRIPTION
This change moves the `indexing` module into `indexers`, and uses previous indexing statuses when status updates fail for some indexer. This mitigates the potential impact of indexers failing to get selected due to quick network errors.