### PR TITLE
fix: default free subscription tier

### DIFF
--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -159,6 +159,7 @@ pub struct Subscriptions {
     /// Kafka topic to report subscription queries
     pub kafka_topic: Option<String>,
     /// Query key signers that don't require payment
+    #[serde(default)]
     pub special_signers: Vec<Address>,
     /// Subscriptions subgraph URL
     #[serde_as(as = "DisplayFromStr")]

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -239,7 +239,6 @@ async fn main() {
             subgraph_client::Client::builder(http_client.clone(), subscriptions.subgraph.clone())
                 .with_auth_token(subscriptions.ticket.clone())
                 .build(),
-            subscription_tiers,
         ),
     };
     let auth_handler = AuthHandler::create(
@@ -252,6 +251,7 @@ async fn main() {
             .collect(),
         config.api_key_payment_required,
         subscriptions,
+        subscription_tiers,
         config
             .subscriptions
             .iter()

--- a/graph-gateway/src/subgraph_studio.rs
+++ b/graph-gateway/src/subgraph_studio.rs
@@ -10,10 +10,8 @@ use toolshed::url::Url;
 
 #[derive(Clone, Debug, Default)]
 pub struct APIKey {
-    pub id: i64,
     pub key: String,
     pub is_subsidized: bool,
-    pub user_id: i64,
     pub user_address: Address,
     pub query_status: QueryStatus,
     pub max_budget: Option<USD>,
@@ -80,10 +78,8 @@ impl Client {
             .into_iter()
             .filter_map(|api_key| {
                 let api_key = APIKey {
-                    id: api_key.id,
                     key: api_key.key,
                     is_subsidized: api_key.is_subsidized,
-                    user_id: api_key.user_id,
                     user_address: api_key.user_address.parse().ok()?,
                     query_status: api_key.query_status,
                     max_budget: api_key
@@ -121,10 +117,8 @@ struct GetGatewayApiKeysResponsePayload {
 
 #[derive(Deserialize)]
 struct GatewayApiKey {
-    id: i64,
     key: String,
     is_subsidized: bool,
-    user_id: i64,
     user_address: String,
     query_status: QueryStatus,
     max_budget: Option<f64>,

--- a/graph-gateway/src/subscriptions.rs
+++ b/graph-gateway/src/subscriptions.rs
@@ -4,10 +4,10 @@ use alloy_primitives::Address;
 use chrono::{DateTime, NaiveDateTime, TimeZone as _, Utc};
 use serde::{de::Error, Deserialize, Deserializer};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Subscription {
     pub signers: Vec<Address>,
-    pub queries_per_minute: u32,
+    pub rate: u128,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
This defaults a user's subscription to one with zero payment rate. A zero rate subscription should not have to go through the contract, since the contract provides no valuable refund guarantees in this case. A free tier still needs to be configured to have a nonzero `queries_per_minute`.