### PR TITLE
fix: limit indexing status requests by active allocations

### DIFF
--- a/graph-gateway/tests/it_indexers_status_indexing_statuses.rs
+++ b/graph-gateway/tests/it_indexers_status_indexing_statuses.rs
@@ -19,17 +19,20 @@ async fn query_indexer_indexing_statuses() {
         .parse()
         .expect("Invalid status url");
 
-    let test_deployment = test_deployment_id("QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH");
+    let test_deployments = [
+        test_deployment_id("QmeYTH2fK2wv96XvnCGH2eyKFE8kmRfo53zYVy5dKysZtH"),
+        test_deployment_id("QmSqxfDGyGenGFPkqw9sqnYar4XgzaioVWNvhw5QQ3RB1U"),
+    ];
 
     //// When
-    let request = indexing_statuses::query(client, status_url);
+    let request = indexing_statuses::query(client, status_url, &test_deployments);
     let response = timeout(Duration::from_secs(60), request)
         .await
         .expect("timeout");
 
     //// Then
     assert_matches!(response, Ok(resp) => {
-        assert!(!resp.indexing_statuses.is_empty());
-        assert!(resp.indexing_statuses.iter().any(|status| status.subgraph == test_deployment));
+        assert!(resp.indexing_statuses.len() == 2);
+        assert!(test_deployments.iter().all(|deployment| resp.indexing_statuses.iter().any(|status| &status.subgraph == deployment)));
     });
 }


### PR DESCRIPTION
Unfiltered indexing status requests can quickly become oversized when the indexer has indexed many deployments without active allocations associated with them. In the future we will also want to batch these requests if the set of deployments is too large. See #459