### PR TITLE
refactor(graph-gateway): use the thegraph crate subscriptions auth token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-chains"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df496257fe2fae392687ef30207325c50c68520108a94798b0c6cc1a6102f70"
+dependencies = [
+ "num_enum 0.7.1",
+ "serde",
+ "strum 0.25.0",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4123,18 +4134,23 @@ dependencies = [
 
 [[package]]
 name = "thegraph"
-version = "0.1.1"
-source = "git+https://github.com/edgeandnode/toolshed?tag=thegraph-v0.1.1#5694de09fad473489012866c3fbca85a5eae098b"
+version = "0.2.0"
+source = "git+https://github.com/edgeandnode/toolshed?tag=thegraph-v0.2.0#cc929e022852a107f76282afc221cfd17886ae70"
 dependencies = [
+ "alloy-chains",
  "alloy-primitives",
  "alloy-sol-types",
  "async-graphql",
+ "base64 0.21.5",
  "bs58",
+ "ethers",
  "ethers-core",
  "graphql-http",
  "indoc",
+ "lazy_static",
  "reqwest",
  "serde",
+ "serde_cbor_2",
  "serde_json",
  "serde_with 3.4.0",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ tokio = { version = "1.24", features = [
     "time",
 ] }
 toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "v0.4.0" }
-thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.1.1" }
+thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.2.0" }
 tracing = { version = "0.1", default-features = false }

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -45,7 +45,7 @@ serde_with = "3.1"
 serde_yaml = "0.9"
 simple-rate-limiter = "1.0"
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", tag = "tap_core-v0.7.0" }
-thegraph = { workspace = true, features = ["subgraph-client"] }
+thegraph = { workspace = true, features = ["subgraph-client", "subscriptions"] }
 thiserror = "1.0.40"
 tokio.workspace = true
 toolshed.workspace = true

--- a/indexer-selection/src/simulation.rs
+++ b/indexer-selection/src/simulation.rs
@@ -3,11 +3,11 @@ use std::time::{Duration, Instant};
 
 use alloy_primitives::Address;
 use anyhow::Result;
-use prelude::test_utils::{bytes_from_id, init_test_tracing};
-use prelude::{UDecimal18, GRT};
 use rand::{prelude::SmallRng, Rng as _, SeedableRng as _};
 use rand_distr::Normal;
-use thegraph::types::DeploymentId;
+
+use prelude::test_utils::{bytes_from_id, init_test_tracing};
+use prelude::{UDecimal18, GRT};
 
 use crate::{
     BlockStatus, Candidate, IndexerErrorObservation, Indexing, IndexingStatus, Selection, State,
@@ -43,7 +43,7 @@ pub async fn simulate(
 ) -> Result<Results> {
     init_test_tracing();
 
-    let deployment = DeploymentId(bytes_from_id(1).into());
+    let deployment = bytes_from_id(1).into();
     let mut results = Results {
         client_queries: 10_000,
         ..Default::default()

--- a/indexer-selection/src/test.rs
+++ b/indexer-selection/src/test.rs
@@ -79,7 +79,7 @@ impl Topology {
         update_writer: &mut QueueWriter<Update>,
     ) -> Self {
         let deployments = (0..rng.gen_range(config.deployments.clone()))
-            .map(|id| DeploymentId(bytes_from_id(id).into()))
+            .map(|id| bytes_from_id(id).into())
             .collect();
         let blocks = (0..rng.gen_range(config.blocks.clone()))
             .map(|id| BlockPointer {
@@ -288,7 +288,7 @@ fn favor_higher_version() {
         .map(|i| Candidate {
             indexing: Indexing {
                 indexer: bytes_from_id(0).into(),
-                deployment: DeploymentId(bytes_from_id(i).into()),
+                deployment: bytes_from_id(i).into(),
             },
             fee: GRT(UDecimal18::from(1)),
         })


### PR DESCRIPTION
The work done in the `thegraph` crate with the Subscriptions Auth token (e.g., use Alloy types instead of ethers-rs) is paying off.

- [x] Update the rust crate `thegraph` to 0.2.0.
- [x] Replace the _graph-subscriptions-rs_ `TicketPayload` with the `thegraph` equivalent that uses Alloy types.
- [x] Various minor changes to align variable and type names with the new terminology.
