### PR TITLE
refactor(graph-gateway): extract auth check_token logic

### DIFF
--- a/graph-gateway/src/auth.rs
+++ b/graph-gateway/src/auth.rs
@@ -4,20 +4,17 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::Address;
-use anyhow::{bail, ensure};
+use axum::extract::FromRef;
 use eventuals::{Eventual, EventualExt, Ptr};
 use graph_subscriptions::subscription_tier::SubscriptionTiers;
 use thegraph::subscriptions::auth::AuthTokenClaims;
-use thegraph::types::{DeploymentId, SubgraphId};
 use tokio::sync::RwLock;
 
 use prelude::USD;
 
-use crate::subgraph_studio::{APIKey, QueryStatus};
+use crate::subgraph_studio::APIKey;
 use crate::subscriptions::Subscription;
 use crate::topology::Deployment;
-
-use self::common::{are_deployments_authorized, are_subgraphs_authorized, is_domain_authorized};
 
 mod common;
 mod studio;
@@ -25,13 +22,37 @@ mod subscriptions;
 
 pub struct AuthHandler {
     pub api_keys: Eventual<Ptr<HashMap<String, Arc<APIKey>>>>,
-    pub special_api_keys: HashSet<String>,
-    pub special_query_key_signers: HashSet<Address>,
+    pub special_api_keys: Arc<HashSet<String>>,
+    pub special_query_key_signers: Arc<HashSet<Address>>,
     pub api_key_payment_required: bool,
     pub subscriptions: Eventual<Ptr<HashMap<Address, Subscription>>>,
     pub subscription_tiers: &'static SubscriptionTiers,
-    pub subscription_domains: HashMap<u64, Address>,
-    pub subscription_query_counters: RwLock<HashMap<Address, AtomicUsize>>,
+    pub subscription_domains: Arc<HashMap<u64, Address>>,
+    pub subscription_query_counters: Arc<RwLock<HashMap<Address, AtomicUsize>>>,
+}
+
+// TODO(LNSD): Use `client_query::Context` instead of `AuthHandler`.
+impl FromRef<AuthHandler> for studio::AuthHandler {
+    fn from_ref(auth: &AuthHandler) -> Self {
+        Self {
+            studio_keys: auth.api_keys.clone(),
+            special_api_keys: auth.special_api_keys.clone(),
+            api_key_payment_required: auth.api_key_payment_required,
+        }
+    }
+}
+
+// TODO(LNSD): Use `client_query::Context` instead of `AuthHandler`.
+impl FromRef<AuthHandler> for subscriptions::AuthHandler {
+    fn from_ref(auth: &AuthHandler) -> Self {
+        Self {
+            subscriptions: auth.subscriptions.clone(),
+            special_signers: auth.special_query_key_signers.clone(),
+            tiers: auth.subscription_tiers,
+            subscription_domains: auth.subscription_domains.clone(),
+            query_counters: auth.subscription_query_counters.clone(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -58,13 +79,13 @@ impl AuthHandler {
     ) -> &'static Self {
         let handler: &'static Self = Box::leak(Box::new(Self {
             api_keys,
-            special_api_keys,
-            special_query_key_signers,
+            special_api_keys: Arc::new(special_api_keys),
+            special_query_key_signers: Arc::new(special_query_key_signers),
             api_key_payment_required,
             subscriptions,
             subscription_tiers,
-            subscription_domains,
-            subscription_query_counters: RwLock::default(),
+            subscription_domains: Arc::new(subscription_domains),
+            subscription_query_counters: Default::default(),
         }));
 
         // Reset counters every minute.
@@ -92,12 +113,14 @@ impl AuthHandler {
         }
 
         // First, parse the bearer token as it was a Studio API key
-        if let Ok(api_key) = studio::parse_bearer_token(self, input) {
+        let auth_handler = studio::AuthHandler::from_ref(self);
+        if let Ok(api_key) = studio::parse_bearer_token(&auth_handler, input) {
             return Ok(AuthToken::StudioApiKey(api_key));
         }
 
         // Otherwise, parse the bearer token as a Subscriptions auth token
-        if let Ok(claims) = subscriptions::parse_bearer_token(self, input) {
+        let auth_handler = subscriptions::AuthHandler::from_ref(self);
+        if let Ok(claims) = subscriptions::parse_bearer_token(&auth_handler, input) {
             return Ok(AuthToken::SubscriptionsAuthToken(claims));
         }
 
@@ -110,145 +133,16 @@ impl AuthHandler {
         deployments: &[Arc<Deployment>],
         domain: &str,
     ) -> anyhow::Result<()> {
-        // Enforce the API key payment status, unless it's being subsidized.
-        if let AuthToken::StudioApiKey(api_key) = &token {
-            if self.api_key_payment_required
-                && !api_key.is_subsidized
-                && !self.special_api_keys.contains(&api_key.key)
-            {
-                match api_key.query_status {
-                    QueryStatus::Active => (),
-                    QueryStatus::Inactive => bail!("Querying not activated yet; make sure to add some GRT to your balance in the studio"),
-                    QueryStatus::ServiceShutoff => bail!("Payment required for subsequent requests for this API key"),
-                };
-            }
-        }
-
-        // Check deployment allowlist
-        let allowed_deployments: Vec<DeploymentId> = match token {
-            AuthToken::StudioApiKey(api_key) => api_key.deployments.clone(),
-            AuthToken::SubscriptionsAuthToken(claims) => claims
-                .allowed_deployments
-                .iter()
-                .flat_map(|s| s.split(','))
-                .filter_map(|s| s.parse::<DeploymentId>().ok())
-                .collect(),
-        };
-        tracing::debug!(?allowed_deployments);
-
-        if !are_deployments_authorized(&allowed_deployments, deployments) {
-            return Err(anyhow::anyhow!("Deployment not authorized by user"));
-        }
-
-        // Check subgraph allowlist
-        let allowed_subgraphs: Vec<SubgraphId> = match token {
-            AuthToken::StudioApiKey(api_key) => api_key.subgraphs.clone(),
-            AuthToken::SubscriptionsAuthToken(claims) => claims
-                .allowed_subgraphs
-                .iter()
-                .flat_map(|s| s.split(','))
-                .filter_map(|s| s.parse::<SubgraphId>().ok())
-                .collect(),
-        };
-        tracing::debug!(?allowed_subgraphs);
-
-        if !are_subgraphs_authorized(&allowed_subgraphs, deployments) {
-            return Err(anyhow::anyhow!("Subgraph not authorized by user"));
-        }
-
-        // Check domain allowlist
-        let allowed_domains: Vec<&str> = match token {
+        match token {
             AuthToken::StudioApiKey(api_key) => {
-                api_key.domains.iter().map(|s| s.as_str()).collect()
+                let auth_handler = studio::AuthHandler::from_ref(self);
+                studio::check_token(&auth_handler, api_key, deployments, domain).await
             }
-            AuthToken::SubscriptionsAuthToken(claims) => claims
-                .allowed_domains
-                .iter()
-                .flat_map(|s| s.split(','))
-                .collect(),
-        };
-        tracing::debug!(?allowed_domains);
-
-        if !is_domain_authorized(&allowed_domains, domain) {
-            return Err(anyhow::anyhow!("Domain not authorized by user"));
-        }
-
-        // Check rate limit for subscriptions. This step should be last to avoid invalid queries
-        // taking up the rate limit.
-        let auth_token = match token {
-            AuthToken::StudioApiKey(_) => return Ok(()),
-            AuthToken::SubscriptionsAuthToken(claims) => claims,
-        };
-
-        // This is safe, since we have already verified the signature and the claimed signer match.
-        // This is placed before the subscriptions domain check to allow the same special query keys to be used across
-        // testnet & mainnet.
-        if self.special_query_key_signers.contains(&auth_token.signer) {
-            return Ok(());
-        }
-
-        let user = auth_token.user();
-        let subscription = self
-            .subscriptions
-            .value_immediate()
-            .unwrap_or_default()
-            .get(&user)
-            .cloned()
-            .unwrap_or_else(|| Subscription {
-                signers: vec![user],
-                rate: 0,
-            });
-        let subscription_tier = self.subscription_tiers.tier_for_rate(subscription.rate);
-        tracing::debug!(
-            subscription_payment_rate = subscription.rate,
-            queries_per_minute = subscription_tier.queries_per_minute,
-        );
-        ensure!(
-            subscription_tier.queries_per_minute > 0,
-            "Subscription not found for user {user}"
-        );
-
-        let signer = auth_token.signer;
-        ensure!(
-            (signer == user) || subscription.signers.contains(&signer),
-            "Signer {signer} not authorized for user {user}",
-        );
-
-        let matches_subscriptions_domain = self
-            .subscription_domains
-            .get(&auth_token.chain_id.into())
-            .map(|contract| contract == &auth_token.contract)
-            .unwrap_or(false);
-        ensure!(
-            matches_subscriptions_domain,
-            "Query key chain_id or contract not allowed"
-        );
-
-        let user = auth_token.user();
-        let counters = match self.subscription_query_counters.try_read() {
-            Ok(counters) => counters,
-            // Just skip if we can't acquire the read lock. This is a relaxed operation anyway.
-            Err(_) => return Ok(()),
-        };
-        match counters.get(&user) {
-            Some(counter) => {
-                let count = counter.fetch_add(1, atomic::Ordering::Relaxed);
-                // Note that counters are for 1 minute intervals.
-                // 5720d5ea-cfc3-4862-865b-52b4508a4c14
-                let limit = subscription_tier.queries_per_minute as usize;
-                // This error message should remain constant, since the graph-subscriptions-api
-                // relies on it to track rate limited conditions.
-                // TODO: Monthly limits should use the message "Monthly query limit exceeded"
-                ensure!(count < limit, "Rate limit exceeded");
-            }
-            // No entry, acquire write lock and insert.
-            None => {
-                drop(counters);
-                let mut counters = self.subscription_query_counters.write().await;
-                counters.insert(user, AtomicUsize::from(0));
+            AuthToken::SubscriptionsAuthToken(auth_token) => {
+                let auth_handler = subscriptions::AuthHandler::from_ref(self);
+                subscriptions::check_token(&auth_handler, auth_token, deployments, domain).await
             }
         }
-        Ok(())
     }
 
     pub async fn query_settings(&self, token: &AuthToken) -> UserSettings {

--- a/graph-gateway/src/auth/studio.rs
+++ b/graph-gateway/src/auth/studio.rs
@@ -1,12 +1,13 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use axum::extract::FromRef;
+use anyhow::bail;
 use eventuals::{Eventual, Ptr};
 
-use crate::subgraph_studio::APIKey;
+use crate::subgraph_studio::{APIKey, QueryStatus};
+use crate::topology::Deployment;
 
-use super::AuthHandler;
+use super::common::{are_deployments_authorized, are_subgraphs_authorized, is_domain_authorized};
 
 /// Errors that may occur when parsing a Studio API key.
 #[derive(Debug, thiserror::Error)]
@@ -32,44 +33,104 @@ pub fn parse_studio_api_key(value: &str) -> Result<[u8; 16], ParseError> {
 }
 
 /// App state (a.k.a [Context](crate::client_query::Context)) sub-state.
-pub struct StudioAuthHandler {
-    /// A map between Studio auth bearer token string and the Studio [ApiKey](crate::subgraph_studio::APIKey).
+pub struct AuthHandler {
+    /// A map between Studio auth bearer token string and the Studio [ApiKey].
     ///
     /// API keys are fetched periodically (every 30s) from the Studio API by the gateway using the
     /// [`subgraph_studio` client](crate::subgraph_studio::Client).
-    studio_keys: Eventual<Ptr<HashMap<String, Arc<APIKey>>>>,
+    pub(super) studio_keys: Eventual<Ptr<HashMap<String, Arc<APIKey>>>>,
+
+    /// Special API keys that don't require payment.
+    ///
+    /// An API key is considered special when does not require payment and is not subsidized, i.e., these
+    /// keys won't be rejected due to non-payment.
+    pub(super) special_api_keys: Arc<HashSet<String>>,
+
+    /// Whether all API keys require payment.
+    ///
+    /// This is used to disable the payment requirement on testnets. If this is `true`, then all API keys require
+    /// payment, unless they are subsidized or special.
+    pub(super) api_key_payment_required: bool,
 }
 
-// TODO(LNSD): Use `client_query::Context` instead of `AuthHandler`.
-impl FromRef<AuthHandler> for StudioAuthHandler {
-    fn from_ref(auth: &AuthHandler) -> Self {
-        Self {
-            studio_keys: auth.api_keys.clone(),
-        }
-    }
-}
-
-impl StudioAuthHandler {
+impl AuthHandler {
     /// Get the Studio API key associated with the given bearer token string.
     pub fn get_api_key(&self, token: &str) -> Option<Arc<APIKey>> {
         self.studio_keys.value_immediate()?.get(token).cloned()
     }
+
+    /// Whether all API keys require payment.
+    ///
+    /// This is used to disable the payment requirement on testnets. If this is `true`, then all API keys require
+    /// payment, unless they are subsidized or special.
+    pub fn is_payment_required(&self) -> bool {
+        self.api_key_payment_required
+    }
+
+    /// Check if the given API key is a special key.
+    ///
+    /// An API key is considered special when does not require payment and is not subsidized, i.e., these
+    /// keys won't be rejected due to non-payment.
+    pub fn is_special_key(&self, api_key: &APIKey) -> bool {
+        self.special_api_keys.contains(&api_key.key)
+    }
 }
 
-pub fn parse_bearer_token<S>(state: &S, token: &str) -> anyhow::Result<Arc<APIKey>>
-where
-    StudioAuthHandler: FromRef<S>,
-{
+pub fn parse_bearer_token(auth: &AuthHandler, token: &str) -> anyhow::Result<Arc<APIKey>> {
     // Check if the bearer token is a valid 32 hex digits key
     if parse_studio_api_key(token).is_err() {
         return Err(anyhow::anyhow!("Invalid api key format"));
     }
 
     // Retrieve the API Key associated with the bearer token
-    let auth_handler = StudioAuthHandler::from_ref(state);
-    auth_handler
-        .get_api_key(token)
+    auth.get_api_key(token)
         .ok_or_else(|| anyhow::anyhow!("API key not found"))
+}
+
+pub async fn check_token(
+    auth: &AuthHandler,
+    api_key: &Arc<APIKey>,
+    deployments: &[Arc<Deployment>],
+    domain: &str,
+) -> anyhow::Result<()> {
+    // Enforce the API key payment status, unless it's being subsidized.
+    if auth.is_payment_required() && !api_key.is_subsidized && !auth.is_special_key(api_key) {
+        match api_key.query_status {
+            QueryStatus::Active => (),
+            QueryStatus::Inactive => bail!("Querying not activated yet; make sure to add some GRT to your balance in the studio"),
+            QueryStatus::ServiceShutoff => bail!("Payment required for subsequent requests for this API key"),
+        };
+    }
+
+    // Check deployment allowlist
+    let allowed_deployments = &api_key.deployments;
+
+    tracing::debug!(?allowed_deployments);
+    if !are_deployments_authorized(allowed_deployments, deployments) {
+        return Err(anyhow::anyhow!("Deployment not authorized by user"));
+    }
+
+    // Check subgraph allowlist
+    let allowed_subgraphs = &api_key.subgraphs;
+
+    tracing::debug!(?allowed_subgraphs);
+    if !are_subgraphs_authorized(allowed_subgraphs, deployments) {
+        return Err(anyhow::anyhow!("Subgraph not authorized by user"));
+    }
+
+    // Check domain allowlist
+    let allowed_domains = &api_key
+        .domains
+        .iter()
+        .map(AsRef::as_ref)
+        .collect::<Vec<_>>();
+
+    tracing::debug!(?allowed_domains);
+    if !is_domain_authorized(allowed_domains, domain) {
+        return Err(anyhow::anyhow!("Domain not authorized by user"));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/graph-gateway/src/auth/subscriptions.rs
+++ b/graph-gateway/src/auth/subscriptions.rs
@@ -1,22 +1,69 @@
-use axum::extract::FromRef;
-use thegraph::subscriptions::auth::{parse_auth_token, verify_auth_token_claims, AuthTokenClaims};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::AtomicUsize;
+use std::sync::{atomic, Arc};
 
-use super::AuthHandler;
+use alloy_primitives::Address;
+use eventuals::{Eventual, Ptr};
+use graph_subscriptions::subscription_tier::{SubscriptionTier, SubscriptionTiers};
+use thegraph::subscriptions::auth::{parse_auth_token, verify_auth_token_claims, AuthTokenClaims};
+use thegraph::types::{DeploymentId, SubgraphId};
+use tokio::sync::RwLock;
+
+use crate::subscriptions::Subscription;
+use crate::topology::Deployment;
+
+use super::common::{are_deployments_authorized, are_subgraphs_authorized, is_domain_authorized};
 
 /// App state (a.k.a [Context](crate::client_query::Context)) sub-state.
-pub struct SubscriptionsAuthHandler {}
+pub struct AuthHandler {
+    /// A map between the Subscription's user address and the actual
+    /// active subscription.
+    ///
+    /// Subscriptions are fetched periodically (every 30s) from the Subscriptions subgraph by
+    /// the gateway using the [`subscriptions_subgraph` client](crate::subscriptions_subgraph::Client).
+    pub(super) subscriptions: Eventual<Ptr<HashMap<Address, Subscription>>>,
 
-// TODO(LNSD): Use `client_query::Context` instead of `AuthHandler`.
-impl FromRef<AuthHandler> for SubscriptionsAuthHandler {
-    fn from_ref(_auth: &AuthHandler) -> Self {
-        Self {}
+    /// Auth token signers that don't require payment.
+    pub(super) special_signers: Arc<HashSet<Address>>,
+
+    /// The subscription tiers.
+    // TODO(LNSD): In general 'static references are not a good idea.
+    //             We should consider using an `Arc`.
+    pub(super) tiers: &'static SubscriptionTiers,
+
+    /// A map between the chain id and the subscription contract address.
+    pub(super) subscription_domains: Arc<HashMap<u64, Address>>,
+
+    /// Subscription query counters.
+    pub(super) query_counters: Arc<RwLock<HashMap<Address, AtomicUsize>>>,
+}
+
+impl AuthHandler {
+    /// Get the subscription associated with the auth token claims user.
+    pub fn get_subscription_for_user(&self, user: &Address) -> Option<Subscription> {
+        self.subscriptions.value_immediate()?.get(user).cloned()
+    }
+
+    /// Returns `true` if the given address corresponds to a special signer.
+    pub fn is_special_signer(&self, address: &Address) -> bool {
+        self.special_signers.contains(address)
+    }
+
+    /// Returns the subscription tiers for the rate.
+    pub fn tier_for_rate(&self, rate: u128) -> SubscriptionTier {
+        self.tiers.tier_for_rate(rate)
+    }
+
+    /// Whether the given chain id and contract address match the allowed subscription domains.
+    pub fn is_domain_allowed(&self, chain_id: u64, contract: &Address) -> bool {
+        self.subscription_domains
+            .get(&chain_id)
+            .map(|addr| addr == contract)
+            .unwrap_or(false)
     }
 }
 
-pub fn parse_bearer_token<S>(_state: &S, token: &str) -> anyhow::Result<AuthTokenClaims>
-where
-    SubscriptionsAuthHandler: FromRef<S>,
-{
+pub fn parse_bearer_token(_auth: &AuthHandler, token: &str) -> anyhow::Result<AuthTokenClaims> {
     let (claims, signature) =
         parse_auth_token(token).map_err(|_| anyhow::anyhow!("Invalid auth token"))?;
 
@@ -26,4 +73,129 @@ where
     }
 
     Ok(claims)
+}
+
+pub async fn check_token(
+    auth: &AuthHandler,
+    auth_token: &AuthTokenClaims,
+    deployments: &[Arc<Deployment>],
+    domain: &str,
+) -> anyhow::Result<()> {
+    // Check deployment allowlist
+    let allowed_deployments: Vec<DeploymentId> = auth_token
+        .allowed_deployments
+        .iter()
+        .flat_map(|s| s.split(','))
+        .filter_map(|s| s.parse::<DeploymentId>().ok())
+        .collect();
+    tracing::debug!(?allowed_deployments);
+
+    if !are_deployments_authorized(&allowed_deployments, deployments) {
+        return Err(anyhow::anyhow!("Deployment not authorized by user"));
+    }
+
+    // Check subgraph allowlist
+    let allowed_subgraphs: Vec<SubgraphId> = auth_token
+        .allowed_subgraphs
+        .iter()
+        .flat_map(|s| s.split(','))
+        .filter_map(|s| s.parse::<SubgraphId>().ok())
+        .collect();
+    tracing::debug!(?allowed_subgraphs);
+
+    if !are_subgraphs_authorized(&allowed_subgraphs, deployments) {
+        return Err(anyhow::anyhow!("Subgraph not authorized by user"));
+    }
+
+    // Check domain allowlist
+    let allowed_domains: Vec<&str> = auth_token
+        .allowed_domains
+        .iter()
+        .flat_map(|s| s.split(','))
+        .collect();
+    tracing::debug!(?allowed_domains);
+
+    if !is_domain_authorized(&allowed_domains, domain) {
+        return Err(anyhow::anyhow!("Domain not authorized by user"));
+    }
+
+    // This is safe, since we have already verified the signature and the claimed signer match in
+    // the `parse_bearer_token` function. This is placed before the subscriptions domain check to
+    // allow the same special query keys to be used across testnet & mainnet.
+    if auth.is_special_signer(&auth_token.signer) {
+        return Ok(());
+    }
+
+    let chain_id = auth_token.chain_id.id();
+    let contract = auth_token.contract;
+    let signer = auth_token.signer;
+    let user = auth_token.user();
+
+    // If no active subscription is found, assume the user is not subscribed. And
+    // provide a default subscription with 0 rate.
+    let subscription = auth
+        .get_subscription_for_user(&user)
+        .unwrap_or_else(|| Subscription {
+            signers: vec![user],
+            rate: 0,
+        });
+
+    let subscription_tier = auth.tier_for_rate(subscription.rate);
+    tracing::debug!(
+        subscription_payment_rate = subscription.rate,
+        queries_per_minute = subscription_tier.queries_per_minute,
+    );
+    if subscription_tier.queries_per_minute == 0 {
+        return Err(anyhow::anyhow!("Subscription not found for user {}", user));
+    }
+
+    // Check if the signer is authorized for the user.
+    //
+    // If no active subscription was found for the user, as we are returning
+    // a default subscription that includes the user in the signers set, this
+    // check will always pass.
+    if (signer != user) && !subscription.signers.contains(&signer) {
+        return Err(anyhow::anyhow!(
+            "Signer {signer} not authorized for user {user}"
+        ));
+    }
+
+    // Check if the if the auth token chain id and contract are among
+    // the allowed subscriptions domains.
+    if !auth.is_domain_allowed(chain_id, &contract) {
+        return Err(anyhow::anyhow!(
+            "Query key chain_id or contract not allowed"
+        ));
+    }
+
+    // Check rate limit for subscriptions
+    let counters = match auth.query_counters.try_read() {
+        Ok(counters) => counters,
+        // Just skip if we can't acquire the read lock. This is a relaxed operation anyway.
+        Err(_) => return Ok(()),
+    };
+
+    match counters.get(&user) {
+        Some(counter) => {
+            let count = counter.fetch_add(1, atomic::Ordering::Relaxed);
+            // Note that counters are for 1 minute intervals.
+            // 5720d5ea-cfc3-4862-865b-52b4508a4c14
+            let limit = subscription_tier.queries_per_minute as usize;
+
+            // This error message should remain constant, since the graph-subscriptions-api
+            // relies on it to track rate limited conditions.
+            // TODO: Monthly limits should use the message "Monthly query limit exceeded"
+            if count >= limit {
+                return Err(anyhow::anyhow!("Rate limit exceeded"));
+            }
+        }
+        // No entry, acquire write lock and insert.
+        None => {
+            drop(counters);
+            let mut counters = auth.query_counters.write().await;
+            counters.insert(user, AtomicUsize::from(0));
+        }
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
This is the second PR refactoring the query auth flow. 

- [x] Removed the "cyclic" import caused by implementing the `FromRef` trait inside the `auth` submodules. The `FromRef` implementation blocks are now colocated with the `AuthHandler` type.
- [x] Split the `check_token` function into two different functions, one per auth method, improving the code readability.
- [x] Updated and simplified the `auth::check_token()` function by calling the appropriate `check_token` method depending on the `AuthToken` variant.

This is a follow-up PR for #467