### PR TITLE
feat: remove subscriptions query topic

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -189,14 +189,16 @@ pub async fn handle_query(
     });
 
     span.in_scope(|| {
-        let (status_message, status_code) = reports::status(&result);
+        let status_message = match &result {
+            Ok(_) => "200 OK".to_string(),
+            Err(err) => err.to_string(),
+        };
         let (legacy_status_message, legacy_status_code) = reports::legacy_status(&result);
         tracing::info!(
             target: reports::CLIENT_QUERY_TARGET,
             start_time_ms = timestamp,
             deployment,
             %status_message,
-            status_code,
             %legacy_status_message,
             legacy_status_code,
         );
@@ -349,7 +351,6 @@ async fn handle_client_query_inner(
         AuthToken::SubscriptionsAuthToken(claims) => tracing::info!(
             target: reports::CLIENT_QUERY_TARGET,
             user_address = ?claims.user(),
-            ticket_payload = serde_json::to_string(claims).unwrap(),
         ),
     };
 

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -149,8 +149,6 @@ pub struct Scalar {
 pub struct Subscriptions {
     /// Subscriptions contract domains
     pub domains: Vec<SubscriptionsDomain>,
-    /// Kafka topic to report subscription queries
-    pub kafka_topic: Option<String>,
     /// Query key signers that don't require payment
     #[serde(default)]
     pub special_signers: Vec<Address>,

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -80,14 +80,7 @@ async fn main() {
         }
     };
 
-    reports::init(
-        kafka_client,
-        config.log_json,
-        config
-            .subscriptions
-            .as_ref()
-            .and_then(|s| s.kafka_topic.clone()),
-    );
+    reports::init(kafka_client, config.log_json);
     tracing::info!("Graph gateway starting...");
     tracing::debug!(config = %config_repr);
 


### PR DESCRIPTION
This removes reports to the subscriptions query topic, adds a `user` field for all client query reports, and a temporary `legacy_scalar` field for the transition to Scalar TAP.