### PR TITLE
feat(auth): replace subscription tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1871,7 +1871,7 @@ dependencies = [
  "semver 1.0.21",
  "serde",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with",
  "siphasher 1.0.0",
  "tap_core",
  "thegraph",
@@ -1962,7 +1962,7 @@ dependencies = [
  "semver 1.0.21",
  "serde",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with",
  "serde_yaml",
  "simple-rate-limiter",
  "snmalloc-rs",
@@ -1980,7 +1980,7 @@ dependencies = [
 [[package]]
 name = "graph-subscriptions"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/subscription-payments?rev=334d18b#334d18bbbd3607559285042570048bf1ff211f56"
+source = "git+https://github.com/edgeandnode/subscription-payments?rev=c69f6c1#c69f6c1bdc8002cef588d75e8e53fb2e4cf09f52"
 dependencies = [
  "anyhow",
  "base64 0.21.6",
@@ -1989,7 +1989,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_cbor_2",
- "serde_with 2.3.3",
+ "serde_with",
 ]
 
 [[package]]
@@ -4301,22 +4301,6 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "serde",
- "serde_json",
- "serde_with_macros 2.3.3",
- "time",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
@@ -4328,20 +4312,8 @@ dependencies = [
  "indexmap 2.1.0",
  "serde",
  "serde_json",
- "serde_with_macros 3.4.0",
+ "serde_with_macros",
  "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -4801,7 +4773,7 @@ dependencies = [
  "serde",
  "serde_cbor_2",
  "serde_json",
- "serde_with 3.4.0",
+ "serde_with",
  "sha3",
  "thiserror",
  "toolshed",

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -15,7 +15,7 @@ faster-hex = "0.9.0"
 futures = "0.3"
 gateway-common = { path = "../gateway-common" }
 gateway-framework = { path = "../gateway-framework" }
-graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "334d18b" }
+graph-subscriptions = { git = "https://github.com/edgeandnode/subscription-payments", rev = "c69f6c1" }
 graphql.workspace = true
 graphql-http.workspace = true
 indexer-selection = { path = "../indexer-selection" }

--- a/graph-gateway/src/auth.rs
+++ b/graph-gateway/src/auth.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use alloy_primitives::Address;
 use axum::extract::FromRef;
 use eventuals::{Eventual, EventualExt, Ptr};
-use graph_subscriptions::subscription_tier::SubscriptionTiers;
 use thegraph::subscriptions::auth::AuthTokenClaims;
 use tokio::sync::RwLock;
 
@@ -26,7 +25,7 @@ pub struct AuthHandler {
     pub special_query_key_signers: Arc<HashSet<Address>>,
     pub api_key_payment_required: bool,
     pub subscriptions: Eventual<Ptr<HashMap<Address, Subscription>>>,
-    pub subscription_tiers: &'static SubscriptionTiers,
+    pub subscription_rate_per_query: u128,
     pub subscription_domains: Arc<HashMap<u64, Address>>,
     pub subscription_query_counters: Arc<RwLock<HashMap<Address, AtomicUsize>>>,
 }
@@ -48,7 +47,7 @@ impl FromRef<AuthHandler> for subscriptions::AuthHandler {
         Self {
             subscriptions: auth.subscriptions.clone(),
             special_signers: auth.special_query_key_signers.clone(),
-            tiers: auth.subscription_tiers,
+            rate_per_query: auth.subscription_rate_per_query,
             subscription_domains: auth.subscription_domains.clone(),
             query_counters: auth.subscription_query_counters.clone(),
         }
@@ -74,7 +73,7 @@ impl AuthHandler {
         special_query_key_signers: HashSet<Address>,
         api_key_payment_required: bool,
         subscriptions: Eventual<Ptr<HashMap<Address, Subscription>>>,
-        subscription_tiers: &'static SubscriptionTiers,
+        subscription_rate_per_query: u128,
         subscription_domains: HashMap<u64, Address>,
     ) -> &'static Self {
         let handler: &'static Self = Box::leak(Box::new(Self {
@@ -83,7 +82,7 @@ impl AuthHandler {
             special_query_key_signers: Arc::new(special_query_key_signers),
             api_key_payment_required,
             subscriptions,
-            subscription_tiers,
+            subscription_rate_per_query,
             subscription_domains: Arc::new(subscription_domains),
             subscription_query_counters: Default::default(),
         }));

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -1,11 +1,10 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
 use alloy_primitives::{Address, U256};
-use graph_subscriptions::subscription_tier::{SubscriptionTier, SubscriptionTiers};
 use secp256k1::SecretKey;
 use semver::Version;
 use serde::Deserialize;
-use serde_with::{serde_as, DisplayFromStr, FromInto};
+use serde_with::{serde_as, DisplayFromStr};
 use thegraph::types::UDecimal18;
 use toolshed::url::Url;
 
@@ -157,10 +156,10 @@ pub struct Subscriptions {
     pub subgraph: Url,
     /// Subscriptions ticket for internal queries
     pub ticket: Option<String>,
-    /// Subscription tiers
-    #[serde(default)]
-    #[serde_as(as = "FromInto<Vec<SubscriptionTier>>")]
-    pub tiers: SubscriptionTiers,
+    /// Subscription rate required per query per minute.
+    /// e.g. If 0.01 USDC (6 decimals) is required per query per minute, then this should be set to
+    /// 10000.
+    pub rate_per_query: u128,
 }
 
 #[serde_as]


### PR DESCRIPTION
Subscription tiers were only required because of monthly quotas. This simplifies subscriptions support to be just a direct conversion from subscription rate to rate limit for the subscribed user.