### PR TITLE
chore(deps): replace trust-dns-resolver with hickory-resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,7 @@ dependencies = [
  "graph-subscriptions",
  "graphql 0.3.0",
  "graphql-http",
+ "hickory-resolver",
  "hyper",
  "indexer-selection",
  "indoc",
@@ -1973,7 +1974,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "trust-dns-resolver",
  "uuid 1.6.1",
 ]
 
@@ -2132,6 +2132,51 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hmac"
@@ -5119,52 +5164,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
- "trust-dns-proto",
 ]
 
 [[package]]

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -43,7 +43,7 @@ tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["cors"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-trust-dns-resolver = "0.23.0"
+hickory-resolver = "0.24.0"
 uuid = { version = "1.6", default-features = false, features = ["v4"] }
 axum.workspace = true
 

--- a/graph-gateway/src/indexers/indexing.rs
+++ b/graph-gateway/src/indexers/indexing.rs
@@ -4,6 +4,7 @@ use alloy_primitives::Address;
 use cost_model::CostModel;
 use eventuals::{Eventual, EventualExt as _, EventualWriter, Ptr};
 use futures::future::join_all;
+use hickory_resolver::TokioAsyncResolver as DNSResolver;
 use semver::Version;
 use thegraph::types::{BlockPointer, DeploymentId};
 use tokio::sync::Mutex;
@@ -11,7 +12,6 @@ use toolshed::{
     epoch_cache::EpochCache,
     url::{url::Host, Url},
 };
-use trust_dns_resolver::TokioAsyncResolver as DNSResolver;
 
 use gateway_common::types::Indexing;
 use gateway_framework::geoip::GeoIP;


### PR DESCRIPTION
The `trust-dns` project has been renamed to `hickory-dns`:

> **NOTICE** This project was rebranded fromt Trust-DNS to Hickory DNS and has been moved to the https://github.com/hickory-dns/hickory-dns organization and repo, this crate/binary has been moved to [hickory-dns](https://crates.io/crates/hickory-dns), from 0.24 and onward, for prior versions see [trust-dns](https://crates.io/crates/trust-dns).

This PR replaces the crate and upgrades to the latest version (v0.24.0).