### PR TITLE
refactor(graph-gateway): move legacy_auth_adapter under client_query module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,6 +1947,7 @@ dependencies = [
  "graph-subscriptions",
  "graphql 0.3.0",
  "graphql-http",
+ "headers",
  "hickory-resolver",
  "hyper",
  "indexer-selection",
@@ -2105,6 +2106,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.6",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber.workspace = true
 hickory-resolver = "0.24.0"
 uuid = { version = "1.6", default-features = false, features = ["v4"] }
 axum.workspace = true
+headers = "0.3.9"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/graph-gateway/src/client_query/legacy_auth_adapter.rs
+++ b/graph-gateway/src/client_query/legacy_auth_adapter.rs
@@ -1,0 +1,170 @@
+use std::collections::BTreeMap;
+
+use axum::body::BoxBody;
+use axum::extract::Path;
+use axum::http::{header, Request, Response};
+use axum::middleware::Next;
+use axum::RequestPartsExt;
+use headers::{Authorization, HeaderMapExt};
+
+/// This adapter middleware extracts the authorization token from the `api_key` path parameter,
+/// and adds it to the request in the `Authorization` header.
+///
+/// If the request already has an `Authorization` header, it is left unchanged.
+/// If the request does not have an `api_key` path parameter, it is left unchanged.
+///
+/// This is a temporary adapter middleware to allow legacy clients to use the new auth scheme.
+pub async fn legacy_auth_adapter<ReqBody>(
+    mut request: Request<ReqBody>,
+    next: Next<ReqBody>,
+) -> Response<BoxBody> {
+    // If the request already has an `Authorization` header, don't do anything
+    if !request.headers().contains_key(header::AUTHORIZATION) {
+        let (mut parts, body) = request.into_parts();
+
+        // Extract the `api_key` from the path and add it to the Authorization header
+        if let Ok(Path(path)) = parts.extract::<Path<BTreeMap<String, String>>>().await {
+            if let Some(api_key) = path.get("api_key") {
+                parts
+                    .headers
+                    .typed_insert(Authorization::bearer(api_key).expect("valid api_key"));
+            }
+        }
+
+        // reconstruct the request
+        request = Request::from_parts(parts, body);
+    }
+
+    next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::{HeaderMap, Method, Request, StatusCode};
+    use axum::routing::{get, post};
+    use axum::{middleware, Router};
+    use tower::ServiceExt;
+
+    use super::legacy_auth_adapter;
+
+    fn test_router() -> Router {
+        async fn handler(headers: HeaderMap) -> String {
+            headers
+                .get(AUTHORIZATION)
+                .and_then(|header| header.to_str().ok())
+                .unwrap_or_default()
+                .to_owned()
+        }
+
+        let api = Router::new()
+            .route("/subgraphs/id/:subgraph_id", post(handler))
+            .route("/:api_key/subgraphs/id/:subgraph_id", post(handler))
+            .route("/deployments/id/:deployment_id", post(handler))
+            .route("/:api_key/deployments/id/:deployment_id", post(handler))
+            .layer(middleware::from_fn(legacy_auth_adapter));
+        Router::new()
+            .route("/", get(|| async { "OK" }))
+            .nest("/api", api)
+    }
+
+    fn test_body() -> Body {
+        Body::from("test")
+    }
+
+    #[tokio::test]
+    async fn test_preexistent_auth_header() {
+        // Given
+        let app = test_router();
+
+        let api_key = "deadbeefdeadbeefdeadbeefdeadbeef"; // 32 hex digits
+        let auth_header = format!("Bearer {api_key}");
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/api/subgraphs/id/456")
+            .header(AUTHORIZATION, auth_header.clone())
+            .body(test_body())
+            .unwrap();
+
+        // When
+        let res = app.oneshot(request).await.unwrap();
+
+        // Then
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = hyper::body::to_bytes(res).await.unwrap();
+        assert_eq!(&body[..], auth_header.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_legacy_auth() {
+        // Given
+        let app = test_router();
+
+        let api_key = "deadbeefdeadbeefdeadbeefdeadbeef"; // 32 hex digits
+        let auth_header = format!("Bearer {api_key}");
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/api/{api_key}/subgraphs/id/456"))
+            .body(test_body())
+            .unwrap();
+
+        // When
+        let res = app.oneshot(request).await.unwrap();
+
+        // Then
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = hyper::body::to_bytes(res).await.unwrap();
+        assert_eq!(&body[..], auth_header.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_legacy_auth_with_preexistent_auth_header() {
+        // Given
+        let app = test_router();
+
+        let api_key = "deadbeefdeadbeefdeadbeefdeadbeef"; // 32 hex digits
+        let auth_header = "Bearer 123";
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/api/{api_key}/subgraphs/id/456"))
+            .header(AUTHORIZATION, auth_header)
+            .body(test_body())
+            .unwrap();
+
+        // When
+        let res = app.oneshot(request).await.unwrap();
+
+        // Then
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = hyper::body::to_bytes(res).await.unwrap();
+        assert_eq!(&body[..], auth_header.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn test_no_auth() {
+        // Given
+        let app = test_router();
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/api/subgraphs/id/456")
+            .body(test_body())
+            .unwrap();
+
+        // When
+        let res = app.oneshot(request).await.unwrap();
+
+        // Then
+        assert_eq!(res.status(), StatusCode::OK);
+
+        let body = hyper::body::to_bytes(res).await.unwrap();
+        assert_eq!(&body[..], b"");
+    }
+}


### PR DESCRIPTION
This is a code reorganization PR:

- [x] Moved the legacy_auth_adapter middleware (and its tests) under the `client_query` module.
- [x] Use typed headers from `headers` crate.
