### PR TITLE
refactor(graph-gateway): split graphql response helpers into submodule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,8 @@ name = "gateway-common"
 version = "0.0.1"
 dependencies = [
  "alloy-primitives",
+ "headers",
+ "http 0.2.11",
  "siphasher 1.0.0",
  "thegraph",
  "tracing-subscriber",
@@ -2035,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -2125,9 +2127,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -3012,7 +3014,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 3.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -3408,9 +3410,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "powerfmt"
@@ -3475,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit 0.21.0",
 ]
@@ -3651,9 +3653,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -3661,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -5255,9 +5257,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"

--- a/gateway-common/Cargo.toml
+++ b/gateway-common/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.0.1"
 
 [dependencies]
 alloy-primitives.workspace = true
+headers = "0.3.9"
+http = "0.2.11"
 siphasher.workspace = true
 thegraph.workspace = true
 tracing-subscriber.workspace = true

--- a/gateway-common/src/utils/http_ext.rs
+++ b/gateway-common/src/utils/http_ext.rs
@@ -1,0 +1,25 @@
+pub trait HttpBuilderExt {
+    fn header_typed<T: headers::Header>(self, h: T) -> Self;
+}
+
+impl HttpBuilderExt for http::response::Builder {
+    fn header_typed<T: headers::Header>(mut self, h: T) -> Self {
+        let mut v = vec![];
+        h.encode(&mut v);
+        for value in v {
+            self = self.header(T::name(), value);
+        }
+        self
+    }
+}
+
+impl HttpBuilderExt for http::request::Builder {
+    fn header_typed<T: headers::Header>(mut self, h: T) -> Self {
+        let mut v = vec![];
+        h.encode(&mut v);
+        for value in v {
+            self = self.header(T::name(), value);
+        }
+        self
+    }
+}

--- a/gateway-common/src/utils/mod.rs
+++ b/gateway-common/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod http_ext;
 pub mod testing;
 pub mod timestamp;
 pub mod tracing;

--- a/graph-gateway/src/client_query/graphql.rs
+++ b/graph-gateway/src/client_query/graphql.rs
@@ -1,0 +1,71 @@
+use axum::http::{Response, StatusCode};
+use headers::ContentType;
+use serde_json::json;
+
+use gateway_common::utils::http_ext::HttpBuilderExt;
+
+/// Serialize an error into a GraphQL error response.
+///
+/// This helper function serializes an error into a GraphQL error response JSON string.
+fn error_response_body(message: impl ToString) -> String {
+    let response_body = json!({"errors": [{"message": message.to_string()}]});
+    serde_json::to_string(&response_body).expect("failed to serialize error response")
+}
+
+/// Create a GraphQL error response.
+pub fn error_response(err: impl ToString) -> Response<String> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header_typed(ContentType::json())
+        .body(error_response_body(err))
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+    use axum::http::StatusCode;
+    use graphql_http::http::response::ResponseBody;
+    use headers::{ContentType, HeaderMapExt};
+
+    use super::error_response;
+
+    /// Deserialize a GraphQL response body.
+    fn deserialize_response_body(body: &str) -> serde_json::Result<ResponseBody<()>> {
+        serde_json::from_str(body)
+    }
+
+    /// A test error type implementing `std::error::Error` trait.
+    ///
+    /// See [`create_graphql_error_response`] for more details
+    #[derive(Debug, thiserror::Error)]
+    #[error("test error: {cause}")]
+    struct TestError {
+        cause: String,
+    }
+
+    /// Ensure that the error response body is correctly serialized.
+    #[test]
+    fn create_graphql_error_response() {
+        //* Given
+        let error = TestError {
+            cause: "test message".to_string(),
+        };
+
+        //* When
+        let response = error_response(error);
+
+        //* Then
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers().typed_get(), Some(ContentType::json()));
+
+        // Ensure that the response body is a valid GraphQL error response.
+        assert_matches!(deserialize_response_body(response.body()), Ok(resp_body) => {
+            // No data should be returned
+            assert_eq!(resp_body.data, None);
+            // There should be one error
+            assert_eq!(resp_body.errors.len(), 1);
+            assert_eq!(resp_body.errors[0].message, "test error: test message");
+        });
+    }
+}


### PR DESCRIPTION
The middlewares I am working on require these GraphQL response helpers to be in a common place to avoid cyclic dependencies.

- [x] Add a `http::Request/Response` builder extension trait to insert typed headers.
- [x] Split the GraphQL response helpers into a submodule.
- [x] Add tests covering the helper functions.