### PR TITLE
fix: ignore indexing status block hashes

### DIFF
--- a/graph-gateway/src/indexers/indexing.rs
+++ b/graph-gateway/src/indexers/indexing.rs
@@ -1,13 +1,13 @@
 use std::{collections::HashMap, net::IpAddr, sync::Arc};
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, BlockNumber};
 use anyhow::{anyhow, ensure};
 use cost_model::CostModel;
 use eventuals::{Eventual, EventualExt as _, EventualWriter, Ptr};
 use futures::future::join_all;
 use hickory_resolver::TokioAsyncResolver as DNSResolver;
 use semver::Version;
-use thegraph::types::{BlockPointer, DeploymentId};
+use thegraph::types::DeploymentId;
 use tokio::sync::Mutex;
 use toolshed::{
     epoch_cache::EpochCache,
@@ -24,8 +24,8 @@ use crate::topology::Deployment;
 
 #[derive(Clone)]
 pub struct Status {
-    pub block: BlockPointer,
-    pub min_block: Option<u64>,
+    pub block: BlockNumber,
+    pub min_block: Option<BlockNumber>,
     pub cost_model: Option<Ptr<CostModel>>,
     pub legacy_scalar: bool,
 }
@@ -252,10 +252,7 @@ async fn query_status(
             let cost_model = cost_models.remove(&indexing.deployment);
             let block_status = chain.latest_block.as_ref()?;
             let status = Status {
-                block: BlockPointer {
-                    number: block_status.number.parse().ok()?,
-                    hash: block_status.hash,
-                },
+                block: block_status.number.parse().ok()?,
                 min_block: chain
                     .earliest_block
                     .as_ref()

--- a/graph-gateway/src/indexers/indexing_statuses.rs
+++ b/graph-gateway/src/indexers/indexing_statuses.rs
@@ -1,12 +1,9 @@
-use std::borrow::Cow;
-
-use alloy_primitives::BlockHash;
 use anyhow::{bail, ensure};
 use futures::future::join_all;
 use graphql_http::http_client::ReqwestExt as _;
 use indoc::formatdoc;
 use itertools::Itertools;
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use thegraph::types::DeploymentId;
 
 pub async fn query(
@@ -24,11 +21,9 @@ pub async fn query(
                         network
                         latestBlock {{
                             number
-                            hash
                         }}
                         earliestBlock {{
                             number
-                            hash
                         }}
                     }}
                 }}
@@ -80,19 +75,6 @@ pub struct ChainStatus {
 #[derive(Debug, Deserialize)]
 pub struct BlockStatus {
     pub number: String,
-    #[serde(deserialize_with = "deserialize_bad_hex")]
-    pub hash: BlockHash,
-}
-
-fn deserialize_bad_hex<'de, D>(deserializer: D) -> Result<BlockHash, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s = Cow::<str>::deserialize(deserializer)?;
-    if s == "0x0" {
-        return Ok(BlockHash::ZERO);
-    }
-    s.parse().map_err(serde::de::Error::custom)
 }
 
 #[cfg(test)]

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -472,7 +472,7 @@ async fn write_indexer_inputs(
             stake: indexer.staked_tokens,
             allocation: indexer.allocated_tokens,
             block: Some(BlockStatus {
-                reported_number: status.block.number,
+                reported_number: status.block,
                 behind_reported_block: false,
                 min_block: status.min_block,
             }),


### PR DESCRIPTION
These payloads can be quite large, even with batching. So we should save space where it is reasonable. Block hashes are unused, and shouldn't be given that they are often `0x0` anyway.