### PR TITLE
fix: always check attestations

### DIFF
--- a/gateway-framework/src/network/network_subgraph.rs
+++ b/gateway-framework/src/network/network_subgraph.rs
@@ -39,7 +39,6 @@ pub struct SubgraphVersion {
 pub struct SubgraphDeployment {
     #[serde(rename = "ipfsHash")]
     pub id: DeploymentId,
-    pub denied_at: u64,
     #[serde(rename = "indexerAllocations")]
     pub allocations: Vec<Allocation>,
     #[serde(default)]
@@ -149,7 +148,6 @@ impl Client {
                 versions(orderBy: version, orderDirection: asc) {{
                     subgraphDeployment {{
                         ipfsHash
-                        deniedAt
                         indexerAllocations(
                             first: 100
                             orderBy: createdAt, orderDirection: asc

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -685,10 +685,6 @@ async fn handle_indexer_query_inner(
         }
     }
 
-    if !ctx.deployment.expect_attestation {
-        return Ok(response.payload);
-    }
-
     if response.payload.attestation.is_none() {
         // TODO: This is a temporary hack to handle errors that were previously miscategorized as
         //  unattestable in graph-node.

--- a/graph-gateway/src/topology.rs
+++ b/graph-gateway/src/topology.rs
@@ -38,9 +38,8 @@ pub struct Subgraph {
 pub struct Deployment {
     pub id: DeploymentId,
     pub manifest: Arc<Manifest>,
-    pub expect_attestation: bool,
-    /// An indexer may have multiple active allocations on a deployment. We collapse them into a single logical
-    /// allocation using the largest allocation ID and sum of the allocated tokens.
+    /// An indexer may have multiple active allocations on a deployment. We collapse them into a
+    /// single logical allocation using the largest allocation ID and sum of the allocated tokens.
     pub indexers: Vec<Arc<Indexer>>,
     /// A deployment may be associated with multiple subgraphs.
     pub subgraphs: BTreeSet<SubgraphId>,
@@ -218,7 +217,6 @@ impl GraphNetwork {
         Some(Arc::new(Deployment {
             id,
             manifest,
-            expect_attestation: version.subgraph_deployment.denied_at == 0,
             subgraphs,
             indexers,
             transferred_to_l2,


### PR DESCRIPTION
Attestation checking and subgraph availability aren't really associated with one another. At this time, we don't see any reason to have gateway behavior influenced by indexing rewards.