### PR TITLE
refactor(graph-gateway): decouple query settings from auth context

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -274,12 +274,12 @@ async fn handle_client_query_inner(
         .grt_per_usd
         .ok_or_else(|| Error::Internal(anyhow!("missing exchange rate")))?;
     let mut budget = GRT(ctx.budgeter.query_fees_target.0 * grt_per_usd.0);
-    let user_settings = ctx.auth_handler.query_settings(&auth);
-    if let Some(user_budget) = user_settings.budget {
+    let query_settings = auth.query_settings();
+    if let Some(user_budget) = query_settings.budget {
         // Security: Consumers can and will set their budget to unreasonably high values.
         // This `.min` prevents the budget from being set far beyond what it would be
-        // automatically. The reason this is important is because sometimes queries are
-        // subsidized and we would be at-risk to allow arbitrarily high values.
+        // automatically. The reason this is important is that sometimes queries are
+        // subsidized, and we would be at-risk to allow arbitrarily high values.
         let max_budget = GRT(budget.0 * UDecimal18::from(10));
         budget = GRT(user_budget.0 * grt_per_usd.0).min(max_budget);
     }

--- a/graph-gateway/src/client_query/auth.rs
+++ b/graph-gateway/src/client_query/auth.rs
@@ -5,7 +5,8 @@ use thegraph::types::{DeploymentId, SubgraphId};
 
 use crate::subgraph_studio::APIKey;
 
-pub use self::context::{AuthContext, UserSettings};
+pub use self::common::QuerySettings;
+pub use self::context::AuthContext;
 
 mod common;
 mod context;
@@ -49,6 +50,18 @@ impl AuthToken {
             AuthToken::StudioApiKey(api_key) => studio::is_domain_authorized(api_key, domain),
             AuthToken::SubscriptionsAuthToken(claims) => {
                 subscriptions::is_domain_authorized(claims, domain)
+            }
+        }
+    }
+
+    /// Get the user settings associated with the auth token.
+    ///
+    /// See [`QuerySettings`] for more information.
+    pub fn query_settings(&self) -> QuerySettings {
+        match self {
+            AuthToken::StudioApiKey(api_key) => studio::get_query_settings(api_key),
+            AuthToken::SubscriptionsAuthToken(token_claims) => {
+                subscriptions::get_query_settings(token_claims)
             }
         }
     }

--- a/graph-gateway/src/client_query/auth/common.rs
+++ b/graph-gateway/src/client_query/auth/common.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use thegraph::types::{DeploymentId, SubgraphId};
 
+use gateway_common::types::USD;
+
 use crate::topology::Deployment;
 
 /// Check if the given deployments are authorized by the given authorized deployments.
@@ -63,6 +65,12 @@ pub fn is_domain_authorized(authorized: &[&str], origin: &str) -> bool {
         || authorized
             .iter()
             .any(|pattern| match_domain(pattern, origin))
+}
+
+/// User query settings associated with an auth token.
+#[derive(Debug)]
+pub struct QuerySettings {
+    pub budget: Option<USD>,
 }
 
 #[cfg(test)]

--- a/graph-gateway/src/client_query/auth/context.rs
+++ b/graph-gateway/src/client_query/auth/context.rs
@@ -8,8 +8,6 @@ use axum::extract::FromRef;
 use eventuals::{Eventual, EventualExt, Ptr};
 use tokio::sync::RwLock;
 
-use gateway_common::types::USD;
-
 use crate::subgraph_studio::APIKey;
 use crate::subscriptions::Subscription;
 use crate::topology::Deployment;
@@ -50,11 +48,6 @@ impl FromRef<AuthContext> for subscriptions::AuthContext {
             query_counters: auth.subscription_query_counters.clone(),
         }
     }
-}
-
-#[derive(Debug)]
-pub struct UserSettings {
-    pub budget: Option<USD>,
 }
 
 impl AuthContext {
@@ -132,13 +125,5 @@ impl AuthContext {
                 subscriptions::check_token(&auth_handler, auth_token, deployments).await
             }
         }
-    }
-
-    pub fn query_settings(&self, token: &AuthToken) -> UserSettings {
-        let budget = match token {
-            AuthToken::StudioApiKey(api_key) => api_key.max_budget,
-            _ => None,
-        };
-        UserSettings { budget }
     }
 }

--- a/graph-gateway/src/client_query/auth/studio.rs
+++ b/graph-gateway/src/client_query/auth/studio.rs
@@ -9,6 +9,7 @@ use crate::subgraph_studio::{APIKey, QueryStatus};
 use crate::topology::Deployment;
 
 use super::common;
+use super::common::QuerySettings;
 
 /// Errors that may occur when parsing a Studio API key.
 #[derive(Debug, thiserror::Error)]
@@ -109,6 +110,13 @@ pub fn is_domain_authorized(api_key: &Arc<APIKey>, domain: &str) -> bool {
         .collect::<Vec<_>>();
 
     common::is_domain_authorized(allowed_domains, domain)
+}
+
+/// Get the user settings associated with the API key.
+pub fn get_query_settings(api_key: &Arc<APIKey>) -> QuerySettings {
+    QuerySettings {
+        budget: api_key.max_budget,
+    }
 }
 
 pub async fn check_token(

--- a/graph-gateway/src/client_query/auth/subscriptions.rs
+++ b/graph-gateway/src/client_query/auth/subscriptions.rs
@@ -12,6 +12,7 @@ use crate::subscriptions::Subscription;
 use crate::topology::Deployment;
 
 use super::common;
+use super::common::QuerySettings;
 
 /// App state (a.k.a [Context](crate::client_query::Context)) sub-state.
 pub struct AuthContext {
@@ -89,6 +90,11 @@ pub fn is_domain_authorized(auth_token: &AuthTokenClaims, domain: &str) -> bool 
         .collect();
 
     common::is_domain_authorized(&allowed_domains, domain)
+}
+
+/// Get the user settings associated with the auth token.
+pub fn get_query_settings(_auth: &AuthTokenClaims) -> QuerySettings {
+    QuerySettings { budget: None }
 }
 
 pub async fn check_token(


### PR DESCRIPTION
We should move some checks to the `require_auth` middleware to simplify the query auth flow. This will let us decouple the app context, our `client_query::Context`, from the auth context.

- [x] Turn the `query_settings` accessory to the `AuthToken.` There is no reason to keep the `UserSettings` associated with the auth context since we are not accessing any of the context fields