### PR TITLE
fix(graph-gateway): avoid processing chain heads older than latest seen block

### DIFF
--- a/gateway-framework/src/chains/mod.rs
+++ b/gateway-framework/src/chains/mod.rs
@@ -172,7 +172,7 @@ impl Actor {
         // Avoid processing chain heads older than the latest seen block. Such degradation can happen when the
         // RPC provider reverts to, and reports, a block number prior to the previously known block number.
         if let Some(latest_seen_block) = self.latest_seen_block {
-            if head.block.number <= latest_seen_block {
+            if head.block.number < latest_seen_block {
                 tracing::warn!(
                     "Skipping update. Received chain head {} <= latest seen block ({})",
                     head.block.number,


### PR DESCRIPTION
This Pull Request aims to address an issue where the processing of chain heads older than the latest seen block can occur due to an RPC provider reverting to and reporting a block number before the previously known block number. This can lead to a degradation in the system's performance and perceived reliability (and unnecessary processing). 

See the postmortem report [here](https://www.notion.so/edgeandnode/2024-01-30-Gateway-RPC-issue-Ethereum-mainnet-a109a3f6a89b444290363d7d216bb7aa).

- [x] Add a check to ensure that only subsequent chain heads to the latest seen block are processed. If the reported head block number is older, a warning log is issued, and the block cache is not updated, as if the RPC provider went offline.