### PR TITLE
refactor(graph-gateway): query settings as a request extension

### DIFF
--- a/graph-gateway/src/client_query/auth.rs
+++ b/graph-gateway/src/client_query/auth.rs
@@ -5,7 +5,6 @@ use thegraph::types::{DeploymentId, SubgraphId};
 
 use crate::subgraph_studio::APIKey;
 
-pub use self::common::QuerySettings;
 pub use self::context::AuthContext;
 
 mod common;
@@ -19,6 +18,18 @@ pub enum AuthToken {
     StudioApiKey(Arc<APIKey>),
     /// Auth token associated with a subscription.
     SubscriptionsAuthToken(AuthTokenClaims),
+}
+
+impl From<Arc<APIKey>> for AuthToken {
+    fn from(value: Arc<APIKey>) -> Self {
+        AuthToken::StudioApiKey(value)
+    }
+}
+
+impl From<AuthTokenClaims> for AuthToken {
+    fn from(value: AuthTokenClaims) -> Self {
+        AuthToken::SubscriptionsAuthToken(value)
+    }
 }
 
 impl AuthToken {
@@ -50,18 +61,6 @@ impl AuthToken {
             AuthToken::StudioApiKey(api_key) => studio::is_domain_authorized(api_key, domain),
             AuthToken::SubscriptionsAuthToken(claims) => {
                 subscriptions::is_domain_authorized(claims, domain)
-            }
-        }
-    }
-
-    /// Get the user settings associated with the auth token.
-    ///
-    /// See [`QuerySettings`] for more information.
-    pub fn query_settings(&self) -> QuerySettings {
-        match self {
-            AuthToken::StudioApiKey(api_key) => studio::get_query_settings(api_key),
-            AuthToken::SubscriptionsAuthToken(token_claims) => {
-                subscriptions::get_query_settings(token_claims)
             }
         }
     }

--- a/graph-gateway/src/client_query/auth/common.rs
+++ b/graph-gateway/src/client_query/auth/common.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use indexer_selection::NotNan;
 use thegraph::types::{DeploymentId, SubgraphId};
 
 use crate::topology::Deployment;
@@ -64,12 +63,6 @@ pub fn is_domain_authorized(authorized: &[&str], origin: &str) -> bool {
         || authorized
             .iter()
             .any(|pattern| match_domain(pattern, origin))
-}
-
-/// User query settings associated with an auth token.
-#[derive(Debug)]
-pub struct QuerySettings {
-    pub budget_usd: Option<NotNan<f64>>,
 }
 
 #[cfg(test)]

--- a/graph-gateway/src/client_query/query_settings.rs
+++ b/graph-gateway/src/client_query/query_settings.rs
@@ -1,0 +1,7 @@
+use indexer_selection::NotNan;
+
+/// User query settings typically associated with an auth token.
+#[derive(Clone, Debug, Default)]
+pub struct QuerySettings {
+    pub budget_usd: Option<NotNan<f64>>,
+}


### PR DESCRIPTION
Use HTTP request extensions to pass request-bound settings, in this case, the auth query settings.

- [x] Decouple `QuerySettings` from the `auth` module. Moved to its parent module,  `client_query`.
- [x] Extract the query settings at the `parse_auth_token()` step.
- [x] Pass the query settings to the handler via request extensions if the auth schema specifies them.
- [x] Check if the subscription exists during `subscriptions::parse_auth_token()` step. If no subscriptions associated with the bearer token exist, bailout at the `require_auth` middleware.