### PR TITLE
refactor(graph-gateway): query rate limit settings as a request extension

### DIFF
--- a/graph-gateway/src/client_query/auth/studio.rs
+++ b/graph-gateway/src/client_query/auth/studio.rs
@@ -6,6 +6,7 @@ use eventuals::{Eventual, Ptr};
 use thegraph::types::{DeploymentId, SubgraphId};
 
 use crate::client_query::query_settings::QuerySettings;
+use crate::client_query::rate_limit_settings::RateLimitSettings;
 use crate::subgraph_studio::{APIKey, QueryStatus};
 use crate::topology::Deployment;
 
@@ -82,7 +83,11 @@ impl AuthContext {
 pub fn parse_auth_token(
     ctx: &AuthContext,
     token: &str,
-) -> anyhow::Result<(Arc<APIKey>, Option<QuerySettings>)> {
+) -> anyhow::Result<(
+    Arc<APIKey>,
+    Option<QuerySettings>,
+    Option<RateLimitSettings>,
+)> {
     // Check if the bearer token is a valid 32 hex digits key
     if parse_studio_api_key(token).is_err() {
         return Err(anyhow::anyhow!("invalid api key format"));
@@ -98,7 +103,7 @@ pub fn parse_auth_token(
         budget_usd: auth_token.max_budget_usd,
     };
 
-    Ok((auth_token.clone(), Some(query_settings)))
+    Ok((auth_token.clone(), Some(query_settings), None))
 }
 
 /// Check if the given deployment is authorized by the given API key.

--- a/graph-gateway/src/client_query/rate_limit_settings.rs
+++ b/graph-gateway/src/client_query/rate_limit_settings.rs
@@ -1,0 +1,13 @@
+use alloy_primitives::Address;
+
+/// Rate limit settings.
+///
+/// The settings can be provided globally (e.g., via config) or via authorization
+/// (e.g., subscription specific rate).
+#[derive(Clone, Debug, Default)]
+pub struct RateLimitSettings {
+    /// The rate limit key.
+    pub key: Address,
+    /// The query rate in queries per minute.
+    pub queries_per_minute: usize,
+}


### PR DESCRIPTION
Continuing with the plan of using the HTTP request extensions to pass different request-specific properties, this PR introduces the `RateLimitSettings` extension. The idea is to make the upcoming rate limit middleware authentication agnostic.

- [x] Extract the query rate limit settings during the Auth parsing step. For simplicity, we'll use the `user` address as the rate-limiting counters key following the current subscriptions auth schema rate-limiting implementation.
- [x] Inject the obtained rate limit settings as a request extension. Temporarily, until the rate-limiting middleware is in place, thread down the settings to the `check_token` method.