### PR TITLE
refactor(graph-gateway): check auth requirements in the auth middleware

### DIFF
--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -261,15 +261,15 @@ async fn main() {
         ),
     };
     let auth_handler = AuthContext::create(
+        config.api_key_payment_required,
         api_keys,
         HashSet::from_iter(config.special_api_keys),
+        subscriptions,
         config
             .subscriptions
             .iter()
             .flat_map(|s| s.special_signers.clone())
             .collect(),
-        config.api_key_payment_required,
-        subscriptions,
         config
             .subscriptions
             .as_ref()


### PR DESCRIPTION
Move the Query selector dependent checks up in the handler and the auth-specific check within the required auth middleware.

- [x] Move auth schema specific non-query-selector-dependent checks to the require auth middleware.
- [x] Use the `require_payment` configuration flag to avoid performing auth-specific checks for all current auth schemas. Previously, it was only enforced for the subscriptions auth schema. This is typically used in the "testnet" deployments.
- [x] Encapsulate the auth token information to expose a homogeneous API. It will allow us to extract a trait to make the "require auth" middleware implementation agnostic.

This is a follow-up PR for #582