### PR TITLE
chore: remove metric for indexer selection duration

### DIFF
--- a/gateway-framework/src/metrics.rs
+++ b/gateway-framework/src/metrics.rs
@@ -22,7 +22,6 @@ pub struct Metrics {
     pub block_cache_miss: IntCounterVec,
     pub chain_head: IntGaugeVec,
     pub blocks_per_minute: IntGaugeVec,
-    pub indexer_selection_duration: Histogram,
 }
 
 impl Metrics {
@@ -76,11 +75,6 @@ impl Metrics {
                 "gw_blocks_per_minute",
                 "chain blocks per minute",
                 &["chain"]
-            )
-            .unwrap(),
-            indexer_selection_duration: register_histogram!(
-                "gw_indexer_selection_duration",
-                "indexer selection duration"
             )
             .unwrap(),
         }

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -408,10 +408,8 @@ async fn handle_client_query_inner(
             }
         }
 
-        let selection_timer = METRICS.indexer_selection_duration.start_timer();
         let selections: ArrayVec<&Candidate, SELECTION_LIMIT> =
             indexer_selection::select(&mut rng, &candidates);
-        drop(selection_timer);
 
         let mut selections: Vec<Selection> = selections
             .iter()


### PR DESCRIPTION
Indexer selection takes less than 50 μs, so we're at a point where measuring time spent in indexer selection is best done via profiling. Prometheus metrics for this made more sense when indexer selection involved its own state management, block resolution, etc.