### PR TITLE
refactor(gateway-framework): add ethereum rpc client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
 name = "auto_impl"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +975,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "custom_debug"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e715bf0e503e909c7076c052e39dd215202e8edeb32f1c194fd630c314d256"
+dependencies = [
+ "custom_debug_derive",
+]
+
+[[package]]
+name = "custom_debug_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f731440b39c73910e253cb465ec1fac97732b3c7af215639881ec0c2a38f4f69"
+dependencies = [
+ "darling",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -1618,7 +1647,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "synstructure",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -1896,6 +1925,7 @@ dependencies = [
  "assert_matches",
  "axum",
  "candidate-selection 0.1.0 (git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=c0b5efa)",
+ "custom_debug",
  "ethers",
  "eventuals",
  "gateway-common",
@@ -1928,6 +1958,8 @@ dependencies = [
  "toolshed",
  "tracing",
  "tracing-subscriber",
+ "url",
+ "uuid 1.7.0",
 ]
 
 [[package]]
@@ -4894,6 +4926,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5629,6 +5672,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
+ "atomic",
  "getrandom",
 ]
 

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -12,8 +12,9 @@ alloy-primitives.workspace = true
 alloy-sol-types = "0.6.3"
 anyhow.workspace = true
 axum.workspace = true
-ethers = "2.0.13"
 candidate-selection = { git = "ssh://git@github.com/edgeandnode/candidate-selection.git", rev = "c0b5efa" }
+custom_debug = "0.6.1"
+ethers = "2.0.13"
 eventuals = "0.6.7"
 gateway-common = { path = "../gateway-common" }
 graphql-http.workspace = true
@@ -32,7 +33,7 @@ receipts.workspace = true
 reqwest.workspace = true
 secp256k1.workspace = true
 serde.workspace = true
-serde_json = "1.0.113"
+serde_json = { version = "1.0.113", features = ["raw_value"] }
 serde_with = "3.6.1"
 siphasher.workspace = true
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol.git", rev = "aa973d1" }
@@ -43,6 +44,8 @@ tonic = { version = "0.11.0", features = ["tls", "tls-roots"] }
 toolshed.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+url = "2.5.0"
+uuid = { version = "1.7.0", features = ["v7"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/gateway-framework/src/chains/ethereum/json_rpc.rs
+++ b/gateway-framework/src/chains/ethereum/json_rpc.rs
@@ -1,0 +1,185 @@
+//! A simple `reqwest`-based JSON-RPC client.
+
+use anyhow::anyhow;
+use serde::de::DeserializeOwned;
+use uuid::Uuid;
+
+use self::types::RawResponse;
+pub use self::types::Request;
+
+/// Utility method that generates a UUIDv7 using the current unix timestamp.
+pub fn new_request_id() -> String {
+    Uuid::now_v7().to_string()
+}
+
+/// JSON-RPC request and response types.
+mod types {
+    use serde::{Deserialize, Serialize};
+    use serde_json::value::RawValue;
+
+    /// The JSON-RPC request format.
+    #[derive(Debug, Serialize)]
+    pub struct Request<'a> {
+        /// The JSON-RPC protocol version.
+        #[serde(rename = "jsonrpc")]
+        version: &'a str,
+        /// The request ID.
+        pub(super) id: &'a str,
+        /// The method to call.
+        pub(super) method: &'a str,
+        /// The parameters for the method.
+        pub(super) params: serde_json::Value,
+    }
+
+    impl<'a> Request<'a> {
+        /// Create a new JSON-RPC request with the given ID.
+        pub fn new(id: &'a str, method: &'a str, params: serde_json::Value) -> Self {
+            Self {
+                version: "2.0",
+                id,
+                method,
+                params,
+            }
+        }
+    }
+
+    /// The raw JSON-RPC response format.
+    #[derive(Debug, Deserialize)]
+    pub struct RawResponse<'a> {
+        /// The request ID.
+        pub(super) id: &'a str,
+        /// The result of the request.
+        #[serde(default, borrow, with = "::serde_with::rust::double_option")]
+        result: Option<Option<&'a RawValue>>,
+        /// The error of the request.
+        #[serde(default, borrow, with = "::serde_with::rust::double_option")]
+        error: Option<Option<&'a RawValue>>,
+    }
+
+    impl<'a> RawResponse<'a> {
+        /// Convert the JSON-RPC response into a `Result`.
+        ///
+        /// If the response contains an error, return it. Otherwise, deserialize the result.
+        pub fn try_into_response(self) -> anyhow::Result<Response<'a>> {
+            // Report if the response has both error and result fields, or none.
+            // This is only enabled in debug builds.
+            #[cfg(debug_assertions)]
+            {
+                if self.error.is_some() && self.result.is_some() {
+                    tracing::debug!("JSON-RPC response has both error and result fields");
+                }
+
+                if self.error.is_none() && self.result.is_none() {
+                    tracing::debug!("JSON-RPC response has neither error nor result fields");
+                }
+            }
+
+            // If the response contains an error, return it
+            if let Some(Some(error)) = self.error {
+                return Ok(Response {
+                    id: self.id,
+                    result: Err(error),
+                });
+            }
+
+            // Otherwise, check the `result` field
+            match self.result {
+                // The `result` field is missing.
+                None => Err(anyhow::anyhow!("missing result")),
+                // The `result` field is present and contains `null`.
+                Some(None) => Ok(Response {
+                    id: self.id,
+                    result: Ok(None),
+                }),
+                // The `result` field is present and contains a value.
+                Some(Some(result)) => Ok(Response {
+                    id: self.id,
+                    result: Ok(Some(result)),
+                }),
+            }
+        }
+    }
+
+    /// The JSON-RPC response format.
+    #[derive(Debug)]
+    pub struct Response<'a> {
+        /// The response ID.
+        pub(super) id: &'a str,
+        /// The response result.
+        result: Result<Option<&'a RawValue>, &'a RawValue>,
+    }
+
+    impl<'a> Response<'a> {
+        /// Convert the JSON-RPC response into a `Result`.
+        ///
+        /// If the response contains an error, return it. Otherwise, deserialize the result.
+        pub fn into_result(self) -> anyhow::Result<Option<&'a RawValue>> {
+            match self.result {
+                Ok(result) => Ok(result),
+                Err(error) => Err(anyhow::anyhow!("{}", error)),
+            }
+        }
+    }
+}
+
+/// Send a raw JSON-RPC request to the Ethereum node using the given method and parameters.
+pub async fn send_request<'a, T: DeserializeOwned>(
+    http_client: &reqwest::Client,
+    url: &url::Url,
+    request: &Request<'a>,
+) -> anyhow::Result<Option<T>> {
+    tracing::debug!(
+        request_id = %request.id,
+        url = %url,
+        method = %request.method,
+        "sending request"
+    );
+
+    let response = http_client
+        .post(url.to_owned())
+        .json(request)
+        .send()
+        .await
+        .map_err(|err| anyhow!("failed to send rpc request: {}", err))?;
+
+    // Read the response body
+    let response = response
+        .bytes()
+        .await
+        .map_err(|err| anyhow!("failed to read rpc response: {}", err))?;
+
+    // Deserialize the JSON-RPC response
+    let response = serde_json::from_slice::<RawResponse>(&response)
+        .map_err(|err| anyhow::anyhow!("invalid rpc response: {}", err))?
+        .try_into_response()
+        .map_err(|err| anyhow::anyhow!("invalid rpc response: {}", err))?;
+
+    tracing::debug!(
+        url = %url,
+        request_id = %response.id,
+        "response received"
+    );
+
+    // Report if the request and response IDs match.
+    // This is only enabled in debug builds.
+    #[cfg(debug_assertions)]
+    {
+        if request.id != response.id {
+            tracing::debug!(
+                request_id = %request.id,
+                response_id = %response.id,
+                "request and response IDs do not match"
+            );
+        }
+    }
+
+    // Convert the JSON-RPC response into a `Result` and deserialize the result
+    // into the expected type
+    match response.into_result() {
+        Err(err) => Err(anyhow::anyhow!("request failed: {}", err)),
+        Ok(None) => Ok(None),
+        Ok(Some(result)) => serde_json::from_str::<T>(result.get())
+            .map(Some)
+            .map_err(|err| anyhow::anyhow!("result deserialization error: {}", err)),
+    }
+}

--- a/gateway-framework/src/chains/ethereum/rpc_client.rs
+++ b/gateway-framework/src/chains/ethereum/rpc_client.rs
@@ -1,0 +1,163 @@
+//! Ethereum JSON-RPC API client.
+
+use serde::de::DeserializeOwned;
+use serde_json::json;
+use serde_json::Value as Json;
+use thegraph::types::BlockHash;
+use url::Url;
+
+use super::json_rpc;
+
+pub use self::rpc_api_types::Block;
+pub use self::rpc_api_types::BlockByNumberParam;
+
+/// Ethereum JSON-RPC API types.
+mod rpc_api_types {
+    use alloy_primitives::BlockNumber;
+    use serde::de::Error;
+    use serde::{Deserialize, Deserializer, Serialize};
+    use thegraph::types::BlockHash;
+
+    /// A block object.
+    ///
+    /// See the [eth_getBlockByHash](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getblockbyhash)
+    /// returned object.
+    #[derive(Debug, Deserialize)]
+    pub struct Block {
+        /// The block hash. `None` when its pending block.
+        pub hash: Option<BlockHash>,
+
+        /// The block number. `None` when its pending block.
+        #[serde(deserialize_with = "deserialize_option_u64")]
+        pub number: Option<BlockNumber>,
+
+        /// Array of uncle hashes.
+        #[serde(default)]
+        pub uncles: Vec<BlockHash>,
+    }
+
+    impl Block {
+        /// Returns `true` if the block is pending.
+        pub fn is_pending(&self) -> bool {
+            self.hash.is_none() || self.number.is_none()
+        }
+    }
+
+    /// Deserialize an `u64` number from a "nullable" hex string.
+    ///
+    /// From [JSON-RPC API Conventions - Quantities](https://ethereum.org/en/developers/docs/apis/json-rpc#quantities-encoding):
+    ///
+    /// > When encoding quantities (integers, numbers): encode as hex, prefix with "0x", the most
+    /// > compact representation (slight exception: zero should be represented as "0x0").
+    fn deserialize_option_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let input: Option<&str> = Deserialize::deserialize(deserializer)?;
+        match input {
+            None => Ok(None),
+            Some(input) => {
+                // The input should start with "0x".
+                if !input.starts_with("0x") {
+                    return Err(Error::custom("invalid quantity format"));
+                }
+
+                let quantity = u64::from_str_radix(&input[2..], 16).map_err(Error::custom)?;
+                Ok(Some(quantity))
+            }
+        }
+    }
+
+    /// The parameters for the `eth_getBlockByNumber` method.
+    ///
+    /// See: [eth_getBlockByNumber](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getblockbynumber)
+    #[derive(Debug, Clone, Copy)]
+    pub enum BlockByNumberParam {
+        /// Get the earliest/genesis block.
+        Earliest,
+        /// Get the latest mined block.
+        Latest,
+        /// Get the pending block (if any).
+        Pending,
+        /// Get the block with the given number.
+        Number(BlockNumber),
+    }
+
+    impl Serialize for BlockByNumberParam {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::ser::Serializer,
+        {
+            match self {
+                Self::Earliest => "earliest".serialize(serializer),
+                Self::Latest => "latest".serialize(serializer),
+                Self::Pending => "pending".serialize(serializer),
+                Self::Number(number) => format!("{:#x}", number).serialize(serializer),
+            }
+        }
+    }
+}
+
+/// A client for interacting with an Ethereum JSON-RPC server API.
+///
+/// This client does not aim to be a full-featured Ethereum RPC client,
+/// but rather a simple client for fetching block data from an Ethereum
+/// node.
+#[derive(Clone)]
+pub struct EthRpcClient {
+    http_client: reqwest::Client,
+    url: Url,
+}
+
+impl EthRpcClient {
+    /// Create a new client for the given Ethereum JSON-RPC server.
+    pub fn new(http_client: reqwest::Client, url: Url) -> Self {
+        Self { http_client, url }
+    }
+
+    /// Get the current client version.
+    ///
+    /// See: [web3_clientVersion](https://ethereum.org/en/developers/docs/apis/json-rpc#web3_clientversion)
+    pub async fn get_client_version(&self) -> anyhow::Result<String> {
+        match self.send_request("web3_clientVersion", json!([])).await {
+            Ok(Some(version)) => Ok(version),
+            Ok(None) => Err(anyhow::anyhow!("unknown client version")),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Fetch the block with the given hash from the Ethereum node.
+    ///
+    /// - `hash`: The block hash to fetch.
+    ///
+    /// See: [eth_getBlockByHash](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getblockbyhash)
+    pub async fn get_block_by_hash(&self, hash: BlockHash) -> anyhow::Result<Option<Block>> {
+        self.send_request("eth_getBlockByHash", json!([hash.to_string(), false]))
+            .await
+    }
+
+    /// Fetch the block with the given number from the Ethereum node.
+    ///
+    /// - `by`: The block number to fetch. See [`BlockByNumberParam`] for more details.
+    ///
+    /// See: [eth_getBlockByNumber](https://ethereum.org/en/developers/docs/apis/json-rpc#eth_getblockbynumber)
+    pub async fn get_block_by_number(
+        &self,
+        by: BlockByNumberParam,
+    ) -> anyhow::Result<Option<Block>> {
+        self.send_request("eth_getBlockByNumber", json!([by, false]))
+            .await
+    }
+
+    /// Send a raw JSON-RPC request to the Ethereum node using the given method and parameters.
+    pub async fn send_request<T: DeserializeOwned>(
+        &self,
+        method: &'static str,
+        params: Json,
+    ) -> anyhow::Result<Option<T>> {
+        let request_id = json_rpc::new_request_id();
+
+        let request = json_rpc::Request::new(&request_id, method, params);
+        json_rpc::send_request(&self.http_client, &self.url, &request).await
+    }
+}

--- a/gateway-framework/src/chains/mod.rs
+++ b/gateway-framework/src/chains/mod.rs
@@ -86,7 +86,9 @@ struct Request {
 }
 
 impl BlockCache {
-    pub fn new<C: Client>(config: C::Config) -> Self {
+    pub fn new<C: Client>(config: impl Into<C::Config>) -> Self {
+        let config = config.into();
+
         let (chain_head_tx, chain_head_rx) = Eventual::new();
         let (notify_tx, notify_rx) = mpsc::unbounded_channel();
         let (request_tx, request_rx) = mpsc::unbounded_channel();

--- a/gateway-framework/src/config.rs
+++ b/gateway-framework/src/config.rs
@@ -1,18 +1,32 @@
+use std::fmt::Display;
 use std::{fmt, ops::Deref, str::FromStr};
 
 use alloy_primitives::B256;
+use custom_debug::CustomDebug;
 use secp256k1::SecretKey;
 use serde::Deserialize;
 use serde_with::{serde_as, DeserializeAs, DisplayFromStr};
-use toolshed::url::Url;
+use url::Url;
 
+// TODO: Move this to the graph-gateway::config module
 #[serde_as]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, CustomDebug, Deserialize)]
 pub struct Chain {
     /// The first name is used in logs, the others are aliases also supported in subgraph manifests.
     pub names: Vec<String>,
     #[serde_as(as = "DisplayFromStr")]
+    #[debug(with = "Display::fmt")]
     pub rpc: Url,
+}
+
+// TODO: Move this to the graph-gateway::config module
+impl From<Chain> for crate::chains::ethereum::Config {
+    fn from(value: Chain) -> Self {
+        Self {
+            names: value.names,
+            url: value.rpc,
+        }
+    }
 }
 
 #[derive(Deserialize)]

--- a/gateway-framework/tests/it_chains_ethereum_rpc.rs
+++ b/gateway-framework/tests/it_chains_ethereum_rpc.rs
@@ -1,0 +1,140 @@
+//! Ethereum JSON-RPC API client integration tests
+
+use std::str::FromStr;
+
+use assert_matches::assert_matches;
+use thegraph::types::{BlockHash, BlockNumber};
+use url::Url;
+
+use gateway_framework::chains::ethereum::rpc_client::{BlockByNumberParam, EthRpcClient};
+
+// Use the publicnode Ethereum RPC URL for testing as it is a Geth-based public and
+// non-authenticated RPC endpoint
+const TEST_RPC_URL: &str = "https://ethereum.publicnode.com";
+
+/// Helper function to get the test Ethereum RPC URL as a [`Url`].
+fn test_rpc_url() -> Url {
+    TEST_RPC_URL.parse().expect("Failed to parse URL")
+}
+
+/// It should be able to retrieve the ehtereum client version using the `web3_clientVersion` RPC
+/// method.
+#[tokio::test]
+async fn eth_client_fetch_client_version() {
+    //* Given
+    let client = EthRpcClient::new(reqwest::Client::new(), test_rpc_url());
+
+    //* When
+    let resp = client.get_client_version().await;
+
+    //* Then
+    // Assert the client version is present
+    assert_matches!(resp, Ok(version) => assert!(!version.is_empty()));
+}
+
+/// It should be able to retrieve the latest block using the `eth_getBlockByNumber` RPC method.
+#[tokio::test]
+async fn fetch_latest_block() {
+    //* Given
+    let client = EthRpcClient::new(reqwest::Client::new(), test_rpc_url());
+
+    //* When
+    let resp = client.get_block_by_number(BlockByNumberParam::Latest).await;
+
+    //* Then
+    // Assert the block number and hash are present
+    assert_matches!(resp, Ok(Some(block)) => {
+        assert_matches!(block.number, Some(num) => assert!(num > 0));
+        assert_matches!(block.hash, Some(hash) => assert!(!hash.is_empty()));
+    });
+}
+
+/// It should be able to retrieve a block associated with a certain hash using the
+/// `eth_getBlockByHash` RPC method.
+#[tokio::test]
+async fn fetch_known_block_by_hash() {
+    //* Given
+    let client = EthRpcClient::new(reqwest::Client::new(), test_rpc_url());
+
+    // The Merge: https://etherscan.io/block/15537394
+    let block_hash =
+        BlockHash::from_str("0x56a9bb0302da44b8c0b3df540781424684c3af04d0b7a38d72842b762076a664")
+            .expect("invalid hash");
+    let expected_block_number: BlockNumber = 15_537_394;
+
+    //* When
+    let resp = client.get_block_by_hash(block_hash).await;
+
+    //* Then
+    // Assert the block number and hash are present
+    assert_matches!(resp, Ok(Some(block)) => {
+        assert_matches!(block.number, Some(num) => assert_eq!(num, expected_block_number));
+        assert_matches!(block.hash, Some(hash) => assert_eq!(hash, block_hash));
+    });
+}
+
+/// It should be able to retrieve a block associated with a certain hash using the
+/// `eth_getBlockByNumber` RPC method.
+#[tokio::test]
+async fn fetch_known_block_by_number() {
+    //* Given
+    let client = EthRpcClient::new(reqwest::Client::new(), test_rpc_url());
+
+    // The Merge: https://etherscan.io/block/15537394
+    let block_number: BlockNumber = 15_537_394;
+    let expected_block_hash =
+        BlockHash::from_str("0x56a9bb0302da44b8c0b3df540781424684c3af04d0b7a38d72842b762076a664")
+            .expect("invalid hash");
+
+    //* When
+    let resp = client
+        .get_block_by_number(BlockByNumberParam::Number(block_number))
+        .await;
+
+    //* Then
+    // Assert the block number and hash are present
+    assert_matches!(resp, Ok(Some(block)) => {
+        assert_matches!(block.number, Some(num) => assert_eq!(num, block_number));
+        assert_matches!(block.hash, Some(hash) => assert_eq!(hash, expected_block_hash));
+    });
+}
+
+/// It should return `None` when trying to retrieve a block that does not exist using the
+/// `eth_getBlockByHash` RPC method.
+#[tokio::test]
+async fn fetch_inexistent_block_by_hash() {
+    //* Given
+    let client = EthRpcClient::new(reqwest::Client::new(), test_rpc_url());
+
+    // Use a hash that does not exist
+    let block_hash =
+        BlockHash::from_str("0x0000000000000000000000000000000000000000000000000000000000000000")
+            .expect("invalid hash");
+
+    //* When
+    let resp = client.get_block_by_hash(block_hash).await;
+
+    //* Then
+    // Assert the response is `None`
+    assert_matches!(resp, Ok(None));
+}
+
+/// It should return `None` when trying to retrieve a block that does not exist using the
+/// `eth_getBlockByNumber` RPC method.
+#[tokio::test]
+async fn fetch_inexistent_block_by_number() {
+    //* Given
+    let client = EthRpcClient::new(reqwest::Client::new(), test_rpc_url());
+
+    // Use a very large block number to ensure it does not exist
+    let block_number = i64::MAX as BlockNumber;
+
+    //* When
+    let resp = client
+        .get_block_by_number(BlockByNumberParam::Number(block_number))
+        .await;
+
+    //* Then
+    // Assert the response is `None`
+    assert_matches!(resp, Ok(None));
+}


### PR DESCRIPTION
This is the first iteration of the Ethereum RPC client. 

- [x] Improve the JSON-RPC error management and reporting.
- [x] Decouple Ethereum RPC client config from chain config type.
- [x] Add some integration tests covering the refactored part.
- [x] Perform additional code clean-up and document some parts.