### PR TITLE
feat: weaken block number constraint resolution

### DIFF
--- a/graph-gateway/src/block_constraints.rs
+++ b/graph-gateway/src/block_constraints.rs
@@ -109,16 +109,9 @@ pub fn make_query_deterministic(
                             *arg = deterministic_block(&latest.hash);
                         }
                         BlockConstraint::Number(number) => {
-                            let block =
-                                resolved
-                                    .iter()
-                                    .find(|b| b.number == number)
-                                    .ok_or_else(|| {
-                                        Error::Internal(anyhow!(
-                                            "failed to resolve block: {number}"
-                                        ))
-                                    })?;
-                            *arg = deterministic_block(&block.hash);
+                            if let Some(block) = resolved.iter().find(|b| b.number == number) {
+                                *arg = deterministic_block(&block.hash);
+                            }
                         }
                     };
                 }


### PR DESCRIPTION
This implements the high-priority part of #611. All block hash constraints are still resolved for now.