### PR TITLE
release 18.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,9 +443,9 @@ checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "auto_impl"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823b8bb275161044e2ac7a25879cb3e2480cb403e3943022c7c769c599b756aa"
+checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "graph-gateway"
-version = "18.1.1"
+version = "18.2.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4969,9 +4969,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "18.1.1"
+version = "18.2.0"
 
 [dependencies]
 alloy-primitives.workspace = true


### PR DESCRIPTION
# Release Notes
- chore: update min_scalar_tap_version (#608)
- fix: handle number_gte separately from exact constraints (#610)
- fix: ensure selected blocks meet gte constraint (4fa0006)
- feat(gateway-framework): blockmeta client (#609)
- feat(graph-gateway): support configuration of blockmeta service as a block cache provider (#613)
- feat: weaken block number constraint resolution (#612)
- fix: use correct oneshot implementation for perf flush
- allow startup when some chain RPCs are failing (#615)

# Config Changes
- `chains` now require an additional `rpc_type: "ethereum" | "blockmeta"` field. Existing entries for Ethereum RPC types should replace the `rpc` key with `rpc_url`.