### PR TITLE
chore(deps): use thegraph-core and thegraph-graphql-http crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,12 +293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii_utils"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
-
-[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,80 +309,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-graphql"
-version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ba89a35adbed833e0d21db467093a087c3a07b497626009eae02cb36f060567"
-dependencies = [
- "async-graphql-derive",
- "async-graphql-parser",
- "async-graphql-value",
- "async-stream",
- "async-trait",
- "base64 0.21.7",
- "bytes",
- "fast_chemail",
- "fnv",
- "futures-util",
- "handlebars",
- "http 1.0.0",
- "indexmap 2.2.5",
- "mime",
- "multer",
- "num-traits",
- "once_cell",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "static_assertions_next",
- "tempfile",
- "thiserror",
-]
-
-[[package]]
-name = "async-graphql-derive"
-version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9547f7f22688f022ea8001bdd57a1fce8996045dcb959b1730a79bafd366a9d9"
-dependencies = [
- "Inflector",
- "async-graphql-parser",
- "darling",
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "strum 0.25.0",
- "syn 2.0.52",
- "thiserror",
-]
-
-[[package]]
-name = "async-graphql-parser"
-version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8e3d4cc5074c46adfee619b5b6cf817943332f772ed5930ed78871f7dbbac6"
-dependencies = [
- "async-graphql-value",
- "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ff1287a1283ea772b4099dd556ba4577d35f069ea4a93f337a525beefcfacf"
-dependencies = [
- "bytes",
- "indexmap 2.2.5",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -470,7 +390,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 0.2.11",
+ "http",
  "http-body",
  "hyper",
  "itoa",
@@ -499,7 +419,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 0.2.11",
+ "http",
  "http-body",
  "mime",
  "rustversion",
@@ -539,6 +459,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "base64ct"
@@ -676,19 +602,7 @@ dependencies = [
 [[package]]
 name = "candidate-selection"
 version = "0.1.0"
-source = "git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=be28b44#be28b44d78381450307f650bd961de1c7111576e"
-dependencies = [
- "arrayvec 0.7.4",
- "ordered-float",
- "permutation",
- "proptest",
- "rand",
-]
-
-[[package]]
-name = "candidate-selection"
-version = "0.1.0"
-source = "git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=c0b5efa#c0b5efa6a6657c201cc71ee4108991e37bc1f581"
+source = "git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=bcd7909#bcd7909f6bc0344278d9e09e368580201b6fae22"
 dependencies = [
  "arrayvec 0.7.4",
  "ordered-float",
@@ -1528,7 +1442,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http 0.2.11",
+ "http",
  "instant",
  "jsonwebtoken",
  "once_cell",
@@ -1619,15 +1533,6 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
-]
-
-[[package]]
-name = "fast_chemail"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495a39d30d624c2caabe6312bfead73e7717692b44e0b32df168c275a2e8e9e4"
-dependencies = [
- "ascii_utils",
 ]
 
 [[package]]
@@ -1880,9 +1785,9 @@ version = "0.0.1"
 dependencies = [
  "alloy-primitives",
  "headers",
- "http 0.2.11",
+ "http",
  "siphasher 1.0.0",
- "thegraph",
+ "thegraph-core",
  "tracing-subscriber",
 ]
 
@@ -1895,12 +1800,11 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "axum",
- "candidate-selection 0.1.0 (git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=c0b5efa)",
+ "candidate-selection",
  "custom_debug",
  "ethers",
  "eventuals",
  "gateway-common",
- "graphql-http",
  "headers",
  "hex",
  "hickory-resolver",
@@ -1922,7 +1826,8 @@ dependencies = [
  "siphasher 1.0.0",
  "tap_core",
  "test-with",
- "thegraph",
+ "thegraph-core",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tonic",
@@ -1999,7 +1904,6 @@ dependencies = [
  "gateway-common",
  "gateway-framework",
  "graphql 0.3.0",
- "graphql-http",
  "headers",
  "hyper",
  "indexer-selection",
@@ -2021,7 +1925,8 @@ dependencies = [
  "serde_yaml",
  "simple-rate-limiter",
  "snmalloc-rs",
- "thegraph",
+ "thegraph-core",
+ "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -2056,19 +1961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "graphql-http"
-version = "0.2.1"
-source = "git+https://github.com/edgeandnode/toolshed?tag=graphql-http-v0.2.1#b2ba62e7eedf24b98f999797c4955527de6c3e64"
-dependencies = [
- "anyhow",
- "async-trait",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "graphql-parser"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,7 +1992,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
+ "http",
  "indexmap 2.2.5",
  "slab",
  "tokio",
@@ -2113,20 +2005,6 @@ name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
-name = "handlebars"
-version = "4.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa67bab9ff362228eb3d00bd024a4965d8231bbb7921167f0cfa66c6626b225"
-dependencies = [
- "log",
- "pest",
- "pest_derive",
- "serde",
- "serde_json",
- "thiserror",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2158,7 +2036,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 0.2.11",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2170,7 +2048,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http 0.2.11",
+ "http",
 ]
 
 [[package]]
@@ -2286,24 +2164,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http 0.2.11",
+ "http",
  "pin-project-lite",
 ]
 
@@ -2336,7 +2203,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http",
  "http-body",
  "httparse",
  "httpdate",
@@ -2356,7 +2223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http 0.2.11",
+ "http",
  "hyper",
  "rustls 0.21.10",
  "tokio",
@@ -2484,12 +2351,12 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexer-selection"
 version = "0.1.0"
-source = "git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=be28b44#be28b44d78381450307f650bd961de1c7111576e"
+source = "git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=bcd7909#bcd7909f6bc0344278d9e09e368580201b6fae22"
 dependencies = [
- "candidate-selection 0.1.0 (git+ssh://git@github.com/edgeandnode/candidate-selection.git?rev=be28b44)",
+ "candidate-selection",
  "custom_debug",
  "rand",
- "thegraph",
+ "thegraph-core",
  "url",
 ]
 
@@ -2858,24 +2725,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "multer"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15d522be0a9c3e46fd2632e272d178f56387bdb5c9fbb3a36c649062e9b5219"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http 1.0.0",
- "httparse",
- "log",
- "memchr",
- "mime",
- "spin 0.9.8",
- "version_check",
 ]
 
 [[package]]
@@ -3320,40 +3169,6 @@ dependencies = [
  "memchr",
  "thiserror",
  "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
-dependencies = [
- "once_cell",
- "pest",
- "sha2",
 ]
 
 [[package]]
@@ -3876,7 +3691,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
+ "http",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -4697,12 +4512,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "static_assertions_next"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
-
-[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4949,19 +4758,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "thegraph"
-version = "0.6.0"
-source = "git+https://github.com/edgeandnode/toolshed?tag=thegraph-v0.6.0#095bdc3b73dcbc1555285a605638a0c3bbd40d5b"
+name = "thegraph-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "101425eeaee6ab9086b2285572d63f16ce6d932b99ce8d2abf55f0d2a2f82cb0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
  "alloy-sol-types",
- "async-graphql",
- "base64 0.21.7",
+ "base64 0.22.0",
  "bs58",
  "ethers",
  "ethers-core",
- "graphql-http",
  "indoc",
  "lazy_static",
  "reqwest",
@@ -4969,9 +4777,23 @@ dependencies = [
  "serde_cbor_2",
  "serde_json",
  "serde_with",
+ "thegraph-graphql-http",
  "thiserror",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "thegraph-graphql-http"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47367b145d00fb408dab3f14621fd48377cb0cb1cced5a8ae520d6d39cca0ab9"
+dependencies = [
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -5262,7 +5084,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "h2",
- "http 0.2.11",
+ "http",
  "http-body",
  "hyper",
  "hyper-timeout",
@@ -5332,7 +5154,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.11",
+ "http",
  "http-body",
  "http-range-header",
  "pin-project-lite",
@@ -5467,7 +5289,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 0.2.11",
+ "http",
  "httparse",
  "log",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ axum = { version = "0.6.20", default-features = false, features = [
     "original-uri",
 ] }
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
-graphql-http = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-http-v0.2.1", features = [
-    "http-reqwest",
-] }
 hex = "0.4"
 primitive-types = "0.12.2"
 rand = { version = "0.8", features = ["small_rng"] }
@@ -34,7 +31,8 @@ secp256k1 = { version = "0.28", default-features = false }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 siphasher = "1.0.0"
-thegraph = { git = "https://github.com/edgeandnode/toolshed", tag = "thegraph-v0.6.0" }
+thegraph-core = "0.2.1"
+thegraph-graphql-http = "0.1.0"
 thiserror = "1.0.57"
 tokio = { version = "1.36", features = [
     "macros",

--- a/gateway-common/Cargo.toml
+++ b/gateway-common/Cargo.toml
@@ -8,5 +8,5 @@ alloy-primitives.workspace = true
 headers = "0.3.9"
 http = "0.2.11"
 siphasher.workspace = true
-thegraph.workspace = true
+thegraph-core.workspace = true
 tracing-subscriber.workspace = true

--- a/gateway-common/src/types/mod.rs
+++ b/gateway-common/src/types/mod.rs
@@ -1,5 +1,5 @@
 use alloy_primitives::Address;
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
 
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Indexing {

--- a/gateway-common/src/utils/testing.rs
+++ b/gateway-common/src/utils/testing.rs
@@ -4,7 +4,7 @@ use std::sync::Once;
 
 use alloy_primitives::Address;
 use siphasher::sip::SipHasher24;
-use thegraph::types::{BlockPointer, DeploymentId};
+use thegraph_core::types::{BlockPointer, DeploymentId};
 
 use crate::utils::tracing::init_tracing;
 

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -12,12 +12,11 @@ alloy-primitives.workspace = true
 alloy-sol-types = "0.6.4"
 anyhow.workspace = true
 axum.workspace = true
-candidate-selection = { git = "ssh://git@github.com/edgeandnode/candidate-selection.git", rev = "c0b5efa" }
+candidate-selection = { git = "ssh://git@github.com/edgeandnode/candidate-selection.git", rev = "bcd7909" }
 custom_debug = "0.6.1"
 ethers = "2.0.13"
 eventuals = "0.6.7"
 gateway-common = { path = "../gateway-common" }
-graphql-http.workspace = true
 headers = "0.3.9"
 hex.workspace = true
 hickory-resolver = "0.24.0"
@@ -38,7 +37,8 @@ serde_json = { version = "1.0.114", features = ["raw_value"] }
 serde_with = "3.6.1"
 siphasher.workspace = true
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol.git", rev = "aa973d1" }
-thegraph = { workspace = true, features = ["subgraph-client"] }
+thegraph-core = { workspace = true, features = ["subgraph-client"] }
+thegraph-graphql-http.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tonic = { version = "0.11.0", features = ["tls", "tls-roots"] }

--- a/gateway-framework/src/chains/blockmeta.rs
+++ b/gateway-framework/src/chains/blockmeta.rs
@@ -1,9 +1,10 @@
 //! StreamingFast Blockmeta client.
 
+use alloy_primitives::{BlockHash, BlockNumber};
 use std::time::Duration;
 
 use custom_debug::CustomDebug;
-use thegraph::types::{BlockHash, BlockNumber, BlockPointer};
+use thegraph_core::types::BlockPointer;
 use tokio::sync::mpsc;
 use tokio::time::interval;
 use tonic::transport::Uri;

--- a/gateway-framework/src/chains/blockmeta/rpc_client.rs
+++ b/gateway-framework/src/chains/blockmeta/rpc_client.rs
@@ -1,9 +1,9 @@
 //! StreamingFast Blockmeta gRPC client.
 
+use alloy_primitives::{BlockHash, BlockNumber};
 use std::time::Duration;
 
 use alloy_primitives::bytes::Bytes;
-use thegraph::types::{BlockHash, BlockNumber};
 use tonic::codegen::{Body, StdError};
 use tonic::transport::{Channel, Uri};
 

--- a/gateway-framework/src/chains/ethereum.rs
+++ b/gateway-framework/src/chains/ethereum.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 use std::time::Duration;
 
 use custom_debug::CustomDebug;
-use thegraph::types::BlockPointer;
+use thegraph_core::types::BlockPointer;
 use tokio::sync::mpsc;
 use tokio::time::interval;
 use tracing::Instrument;

--- a/gateway-framework/src/chains/ethereum/rpc_client.rs
+++ b/gateway-framework/src/chains/ethereum/rpc_client.rs
@@ -1,9 +1,9 @@
 //! Ethereum JSON-RPC API client.
 
+use alloy_primitives::BlockHash;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 use serde_json::Value as Json;
-use thegraph::types::BlockHash;
 use url::Url;
 
 use super::json_rpc;
@@ -13,10 +13,9 @@ pub use self::rpc_api_types::BlockByNumberParam;
 
 /// Ethereum JSON-RPC API types.
 mod rpc_api_types {
-    use alloy_primitives::BlockNumber;
+    use alloy_primitives::{BlockHash, BlockNumber};
     use serde::de::Error;
     use serde::{Deserialize, Deserializer, Serialize};
-    use thegraph::types::BlockHash;
 
     /// A block object.
     ///

--- a/gateway-framework/src/chains/mod.rs
+++ b/gateway-framework/src/chains/mod.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use alloy_primitives::{BlockHash, BlockNumber};
 use eventuals::{Eventual, EventualWriter};
-use thegraph::types::BlockPointer;
+use thegraph_core::types::BlockPointer;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::interval;
 use toolshed::epoch_cache::EpochCache;

--- a/gateway-framework/src/chains/test.rs
+++ b/gateway-framework/src/chains/test.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use thegraph::types::BlockPointer;
+use thegraph_core::types::BlockPointer;
 use tokio::sync::mpsc;
 
 use crate::chains::BlockHead;

--- a/gateway-framework/src/graphql.rs
+++ b/gateway-framework/src/graphql.rs
@@ -1,6 +1,6 @@
 use axum::http::{Response, StatusCode};
-use graphql_http::http::response::{IntoError as IntoGraphqlResponseError, ResponseBody};
 use headers::ContentType;
+use thegraph_graphql_http::http::response::{IntoError as IntoGraphqlResponseError, ResponseBody};
 
 use gateway_common::utils::http_ext::HttpBuilderExt;
 
@@ -25,8 +25,8 @@ pub fn error_response(err: impl IntoGraphqlResponseError) -> Response<String> {
 mod tests {
     use assert_matches::assert_matches;
     use axum::http::StatusCode;
-    use graphql_http::http::response::ResponseBody;
     use headers::{ContentType, HeaderMapExt};
+    use thegraph_graphql_http::http::response::ResponseBody;
 
     use super::error_response;
 

--- a/gateway-framework/src/network/network_subgraph.rs
+++ b/gateway-framework/src/network/network_subgraph.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Address;
 use eventuals::{self, Eventual, EventualExt as _, EventualWriter, Ptr};
 use serde::Deserialize;
 use serde_with::serde_as;
-use thegraph::{
+use thegraph_core::{
     client as subgraph_client,
     types::{DeploymentId, SubgraphId},
 };

--- a/gateway-framework/tests/it_chains_blockmeta_rpc.rs
+++ b/gateway-framework/tests/it_chains_blockmeta_rpc.rs
@@ -1,7 +1,7 @@
 //! Ethereum Streamingfast Blockmeta client integration tests
 
+use alloy_primitives::{BlockHash, BlockNumber};
 use assert_matches::assert_matches;
-use thegraph::types::{BlockHash, BlockNumber};
 use tonic::transport::Uri;
 
 use gateway_framework::chains::blockmeta::rpc_client::BlockmetaClient;

--- a/gateway-framework/tests/it_chains_ethereum_rpc.rs
+++ b/gateway-framework/tests/it_chains_ethereum_rpc.rs
@@ -2,8 +2,8 @@
 
 use std::str::FromStr;
 
+use alloy_primitives::{BlockHash, BlockNumber};
 use assert_matches::assert_matches;
-use thegraph::types::{BlockHash, BlockNumber};
 use url::Url;
 
 use gateway_framework::chains::ethereum::rpc_client::{BlockByNumberParam, EthRpcClient};

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -18,9 +18,8 @@ futures = "0.3"
 gateway-common = { path = "../gateway-common" }
 gateway-framework = { path = "../gateway-framework" }
 graphql.workspace = true
-graphql-http.workspace = true
 headers = "0.3.9"
-indexer-selection = { git = "ssh://git@github.com/edgeandnode/candidate-selection.git", rev = "be28b44" }
+indexer-selection = { git = "ssh://git@github.com/edgeandnode/candidate-selection.git", rev = "bcd7909" }
 indoc = "2.0.4"
 itertools = "0.12.1"
 num-traits = "0.2.18"
@@ -39,7 +38,8 @@ serde_with = "3.6"
 serde_yaml = "0.9"
 simple-rate-limiter = "1.0"
 snmalloc-rs = "0.3"
-thegraph = { workspace = true, features = ["subgraph-client", "subscriptions"] }
+thegraph-core = { workspace = true, features = ["subgraph-client", "subscriptions"] }
+thegraph-graphql-http.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toolshed.workspace = true

--- a/graph-gateway/src/block_constraints.rs
+++ b/graph-gateway/src/block_constraints.rs
@@ -9,7 +9,7 @@ use graphql::graphql_parser::query::{
 use graphql::{IntoStaticValue as _, StaticValue};
 use itertools::Itertools as _;
 use serde_json::{self, json};
-use thegraph::types::BlockPointer;
+use thegraph_core::types::BlockPointer;
 
 use gateway_framework::{block_constraints::BlockConstraint, errors::Error};
 

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -19,7 +19,6 @@ use gateway_framework::budgets::USD;
 use gateway_framework::chains::UnresolvedBlock;
 use gateway_framework::errors::UnavailableReason;
 use gateway_framework::scalar::ReceiptStatus;
-use graphql_http::http::response::{Error as GQLError, ResponseBody as GQLResponseBody};
 use headers::ContentType;
 use indexer_selection::{ArrayVec, Candidate, Normalized};
 use num_traits::cast::ToPrimitive as _;
@@ -29,7 +28,8 @@ use rand::Rng as _;
 use rand::{rngs::SmallRng, SeedableRng as _};
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
-use thegraph::types::{attestation, BlockPointer, DeploymentId};
+use thegraph_core::types::{attestation, BlockPointer, DeploymentId};
+use thegraph_graphql_http::http::response::{Error as GQLError, ResponseBody as GQLResponseBody};
 use tokio::sync::mpsc;
 use tracing::Instrument;
 use url::Url;
@@ -1065,7 +1065,7 @@ mod tests {
         /// Deserialize a GraphQL response body.
         async fn deserialize_graphql_response_body<T>(
             body: &mut BoxBody,
-        ) -> serde_json::Result<graphql_http::http::response::ResponseBody<T>>
+        ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
         where
             for<'de> T: serde::Deserialize<'de>,
         {

--- a/graph-gateway/src/client_query/attestation_header.rs
+++ b/graph-gateway/src/client_query/attestation_header.rs
@@ -2,7 +2,7 @@
 
 use axum::http::{HeaderName, HeaderValue};
 use headers::Error;
-use thegraph::types::Attestation;
+use thegraph_core::types::Attestation;
 
 static GRAPH_ATTESTATION_HEADER_NAME: HeaderName = HeaderName::from_static("graph-attestation");
 
@@ -77,7 +77,7 @@ impl headers::Header for GraphAttestation {
 mod tests {
     use assert_matches::assert_matches;
     use headers::{Header, HeaderValue};
-    use thegraph::types::Attestation;
+    use thegraph_core::types::Attestation;
 
     use super::GraphAttestation;
 

--- a/graph-gateway/src/client_query/auth.rs
+++ b/graph-gateway/src/client_query/auth.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use thegraph::types::{DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, SubgraphId};
 
 use crate::topology::Deployment;
 

--- a/graph-gateway/src/client_query/auth/common.rs
+++ b/graph-gateway/src/client_query/auth/common.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use thegraph::types::{DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, SubgraphId};
 
 use crate::topology::Deployment;
 

--- a/graph-gateway/src/client_query/auth/studio.rs
+++ b/graph-gateway/src/client_query/auth/studio.rs
@@ -1,8 +1,9 @@
+use alloy_primitives::Address;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use eventuals::{Eventual, Ptr};
-use thegraph::types::{Address, DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, SubgraphId};
 
 use crate::client_query::query_settings::QuerySettings;
 use crate::client_query::rate_limiter::RateLimitSettings;

--- a/graph-gateway/src/client_query/auth/subscriptions.rs
+++ b/graph-gateway/src/client_query/auth/subscriptions.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 
 use alloy_primitives::Address;
 use eventuals::{Eventual, Ptr};
-use thegraph::subscriptions::auth::{
+use thegraph_core::subscriptions::auth::{
     parse_auth_token as parse_bearer_token, verify_auth_token_claims, AuthTokenClaims,
 };
-use thegraph::types::{DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, SubgraphId};
 
 use crate::client_query::query_settings::QuerySettings;
 use crate::client_query::rate_limiter::RateLimitSettings;

--- a/graph-gateway/src/client_query/l2_forwarding.rs
+++ b/graph-gateway/src/client_query/l2_forwarding.rs
@@ -1,7 +1,7 @@
 use alloy_primitives::bytes::Bytes;
 use anyhow::anyhow;
 use axum::http::{header, HeaderMap, Response, Uri};
-use thegraph::types::SubgraphId;
+use thegraph_core::types::SubgraphId;
 use url::Url;
 
 use gateway_framework::errors::Error;
@@ -70,7 +70,7 @@ fn l2_request_path(original_path: &Uri, l2_subgraph_id: Option<SubgraphId>) -> S
 
 #[cfg(test)]
 mod tests {
-    use thegraph::types::{DeploymentId, SubgraphId};
+    use thegraph_core::types::{DeploymentId, SubgraphId};
 
     use super::l2_request_path;
 

--- a/graph-gateway/src/client_query/query_selector.rs
+++ b/graph-gateway/src/client_query/query_selector.rs
@@ -5,7 +5,7 @@ use axum::async_trait;
 use axum::extract::{FromRequestParts, Path};
 use axum::http::request::Parts;
 use axum::response::IntoResponse;
-use thegraph::types::{DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, SubgraphId};
 
 use gateway_framework::errors::Error;
 use gateway_framework::graphql;
@@ -93,7 +93,7 @@ mod tests {
     use axum::body::{Body, BoxBody};
     use axum::http::{Method, Request};
     use axum::Router;
-    use thegraph::types::{DeploymentId, SubgraphId};
+    use thegraph_core::types::{DeploymentId, SubgraphId};
     use tower::ServiceExt;
 
     use super::QuerySelector;
@@ -128,7 +128,7 @@ mod tests {
     /// Deserialize a GraphQL response body.
     async fn deserialize_graphql_response_body<T>(
         body: &mut BoxBody,
-    ) -> serde_json::Result<graphql_http::http::response::ResponseBody<T>>
+    ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
     where
         for<'de> T: serde::Deserialize<'de>,
     {

--- a/graph-gateway/src/client_query/rate_limiter.rs
+++ b/graph-gateway/src/client_query/rate_limiter.rs
@@ -260,7 +260,7 @@ mod tests {
     /// Deserialize a GraphQL response body.
     async fn deserialize_graphql_response_body<T>(
         body: &mut BoxBody,
-    ) -> serde_json::Result<graphql_http::http::response::ResponseBody<T>>
+    ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
     where
         for<'de> T: serde::Deserialize<'de>,
     {

--- a/graph-gateway/src/client_query/require_auth.rs
+++ b/graph-gateway/src/client_query/require_auth.rs
@@ -297,7 +297,7 @@ mod tests {
     /// Deserialize a GraphQL response body.
     async fn deserialize_graphql_response_body<T>(
         body: &mut BoxBody,
-    ) -> serde_json::Result<graphql_http::http::response::ResponseBody<T>>
+    ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
     where
         for<'de> T: serde::Deserialize<'de>,
     {

--- a/graph-gateway/src/indexer_client.rs
+++ b/graph-gateway/src/indexer_client.rs
@@ -2,7 +2,7 @@ use crate::client_query::Selection;
 use alloy_primitives::BlockNumber;
 use gateway_framework::errors::{IndexerError, UnavailableReason::*};
 use serde::Deserialize;
-use thegraph::types::attestation::Attestation;
+use thegraph_core::types::attestation::Attestation;
 
 pub struct IndexerResponse {
     pub status: u16,

--- a/graph-gateway/src/indexers/cost_models.rs
+++ b/graph-gateway/src/indexers/cost_models.rs
@@ -1,9 +1,9 @@
-use graphql_http::graphql::{Document, IntoDocument, IntoDocumentWithVariables};
-use graphql_http::http_client::ReqwestExt;
 use indoc::indoc;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
+use thegraph_graphql_http::graphql::{Document, IntoDocument, IntoDocumentWithVariables};
+use thegraph_graphql_http::http_client::ReqwestExt;
 
 #[derive(Deserialize)]
 pub struct CostModelSource {

--- a/graph-gateway/src/indexers/indexing.rs
+++ b/graph-gateway/src/indexers/indexing.rs
@@ -11,7 +11,7 @@ use futures::future::join_all;
 use gateway_common::types::Indexing;
 use semver::Version;
 use std::{collections::HashMap, sync::Arc};
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
 use tokio::sync::Mutex;
 use toolshed::epoch_cache::EpochCache;
 use url::Url;

--- a/graph-gateway/src/indexers/indexing_statuses.rs
+++ b/graph-gateway/src/indexers/indexing_statuses.rs
@@ -1,10 +1,10 @@
 use anyhow::{bail, ensure};
 use futures::future::join_all;
-use graphql_http::http_client::ReqwestExt as _;
 use indoc::formatdoc;
 use itertools::Itertools;
 use serde::Deserialize;
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
+use thegraph_graphql_http::http_client::ReqwestExt as _;
 
 pub async fn query(
     client: &reqwest::Client,

--- a/graph-gateway/src/indexers/public_poi.rs
+++ b/graph-gateway/src/indexers/public_poi.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
 use alloy_primitives::{BlockNumber, B256};
-use graphql_http::graphql::{Document, IntoDocument, IntoDocumentWithVariables};
-use graphql_http::http_client::ReqwestExt;
 use indoc::indoc;
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
+use thegraph_graphql_http::graphql::{Document, IntoDocument, IntoDocumentWithVariables};
+use thegraph_graphql_http::http_client::ReqwestExt;
 use url::Url;
 
 pub type ProofOfIndexing = B256;
@@ -154,8 +154,8 @@ mod tests {
     use super::*;
 
     mod query {
-        use graphql_http::http::request::IntoRequestParameters;
         use serde_json::json;
+        use thegraph_graphql_http::http::request::IntoRequestParameters;
 
         use super::*;
 

--- a/graph-gateway/src/indexers/version.rs
+++ b/graph-gateway/src/indexers/version.rs
@@ -1,6 +1,6 @@
-use graphql_http::http_client::ReqwestExt as _;
 use semver::Version;
 use serde::Deserialize;
+use thegraph_graphql_http::http_client::ReqwestExt as _;
 
 pub async fn query_indexer_service_version(
     client: &reqwest::Client,

--- a/graph-gateway/src/indexings_blocklist.rs
+++ b/graph-gateway/src/indexings_blocklist.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use alloy_primitives::Address;
 use eventuals::{Eventual, EventualExt, Ptr};
 use itertools::Itertools as _;
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
 use tokio::sync::Mutex;
 use url::Url;
 

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -24,7 +24,7 @@ use prometheus::{self, Encoder as _};
 use secp256k1::SecretKey;
 use serde_json::json;
 use simple_rate_limiter::RateLimiter;
-use thegraph::{
+use thegraph_core::{
     client as subgraph_client,
     types::{attestation, DeploymentId},
 };

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -5,7 +5,7 @@ use prost::Message as _;
 use rdkafka::error::KafkaResult;
 use serde::Deserialize;
 use serde_json::{json, Map};
-use thegraph::types::attestation::Attestation;
+use thegraph_core::types::attestation::Attestation;
 use toolshed::concat_bytes;
 use tracing::span;
 use tracing_subscriber::{filter::FilterFn, layer, prelude::*, registry, EnvFilter, Layer};

--- a/graph-gateway/src/subgraph_studio.rs
+++ b/graph-gateway/src/subgraph_studio.rs
@@ -4,7 +4,7 @@ use alloy_primitives::Address;
 use eventuals::{self, Eventual, EventualExt as _, EventualWriter, Ptr};
 use ordered_float::NotNan;
 use serde::Deserialize;
-use thegraph::types::{DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, SubgraphId};
 use tokio::{sync::Mutex, time::Duration};
 use url::Url;
 

--- a/graph-gateway/src/subscriptions_subgraph.rs
+++ b/graph-gateway/src/subscriptions_subgraph.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use alloy_primitives::Address;
 use eventuals::{self, Eventual, EventualExt as _, EventualWriter, Ptr};
-use thegraph::client as subgraph_client;
+use thegraph_core::client as subgraph_client;
 use tokio::sync::Mutex;
 
 use gateway_common::utils::timestamp::unix_timestamp;

--- a/graph-gateway/src/topology.rs
+++ b/graph-gateway/src/topology.rs
@@ -8,7 +8,7 @@ use futures::future::join_all;
 use gateway_framework::geoip::GeoIp;
 use itertools::Itertools;
 use serde::Deserialize;
-use thegraph::types::{DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, SubgraphId};
 use tokio::sync::{Mutex, RwLock};
 use url::Url;
 

--- a/graph-gateway/tests/it_indexers_status_indexing_statuses.rs
+++ b/graph-gateway/tests/it_indexers_status_indexing_statuses.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use assert_matches::assert_matches;
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
 use tokio::time::timeout;
 
 use graph_gateway::indexers::indexing_statuses;

--- a/graph-gateway/tests/it_indexers_status_public_pois.rs
+++ b/graph-gateway/tests/it_indexers_status_public_pois.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use alloy_primitives::BlockNumber;
 use assert_matches::assert_matches;
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
 use tokio::time::timeout;
 
 use graph_gateway::indexers::public_poi::{

--- a/graph-gateway/tests/it_indexings_blocklist.rs
+++ b/graph-gateway/tests/it_indexings_blocklist.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use alloy_primitives::Address;
-use thegraph::types::DeploymentId;
+use thegraph_core::types::DeploymentId;
 use tokio::time::timeout;
 
 use graph_gateway::indexers::public_poi::{ProofOfIndexing, ProofOfIndexingInfo};


### PR DESCRIPTION
This is a follow up PR of https://github.com/edgeandnode/candidate-selection/pull/10:

> Some of the toolshed crates have been published in the crates.io repository.
> 
> This PR replaces the `thegraph` crate with the `thegraph-core` crate.

This second PR changes:

* `thegraph` -> `thegraph-core v0.2.1`
* `graphql-http` -> `thegraph-graphql-http v0.1.0`