### PR TITLE
fix: increase the body limit of /collect-receipts route

### DIFF
--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -334,7 +334,9 @@ async fn main() {
         .route("/ready", routing::get(|| async { "Ready" }))
         .route(
             "/collect-receipts",
-            routing::post(scalar::handle_collect_receipts).with_state(legacy_signer),
+            routing::post(scalar::handle_collect_receipts)
+                .with_state(legacy_signer)
+                .layer(DefaultBodyLimit::max(3_000_000)),
         )
         .route(
             "/partial-voucher",


### PR DESCRIPTION
# Issue

An indexer trying to /collect-receipts and is failing with http 413. Their payload is 2.8MB, it kept failing even if we increased the limits of nginx/ingress accordingly. axum has a default limit of 2MB payloads.

# Solution

Increase the body limit of `/collect-receipts` to 3MB to match the limit we use in `/partial-voucher`