### PR TITLE
chore(deps): update rust crate tap_core to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4561,8 +4561,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tap_core"
-version = "0.7.0"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=aa973d1#aa973d18ad88890524932ff646ff4a2963dd8b4a"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ee4bdef618598aad5fc955500ab152cca403698f09efb686f277046b7cca915"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -29,7 +29,7 @@ serde.workspace = true
 serde_json = { version = "1.0.115", features = ["raw_value"] }
 serde_with = "3.7.0"
 siphasher.workspace = true
-tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "aa973d1" }
+tap_core = "1.0.0"
 thegraph-core = { workspace = true, features = ["subgraph-client"] }
 thegraph-graphql-http.workspace = true
 thiserror.workspace = true

--- a/gateway-framework/src/scalar/receipts.rs
+++ b/gateway-framework/src/scalar/receipts.rs
@@ -12,7 +12,7 @@ use gateway_common::types::Indexing;
 use rand::RngCore;
 pub use receipts::{QueryStatus as ReceiptStatus, ReceiptPool};
 use secp256k1::SecretKey;
-use tap_core::{eip_712_signed_message::EIP712SignedMessage, tap_receipt::Receipt};
+use tap_core::{receipt::Receipt, signed_message::EIP712SignedMessage};
 use tokio::sync::{Mutex, RwLock};
 
 pub struct ReceiptSigner {
@@ -111,7 +111,6 @@ impl ReceiptSigner {
         let wallet =
             Wallet::from_bytes(self.signer.as_ref()).expect("failed to prepare receipt wallet");
         let signed = EIP712SignedMessage::new(&self.domain, receipt, &wallet)
-            .await
             .expect("failed to sign receipt");
         Some(ScalarReceipt::TAP(signed))
     }


### PR DESCRIPTION
The latest version of the TAP core crate (version 1.0.0) has been released, and this pull request updates the dependency to use this newest version.

> [!NOTE]
> This is a dependency for the alloy-rs crates upgrade to the latest version.