### PR TITLE
chore(deps): pin rust crate tap_core to rev c179dfe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,7 +4583,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "tap_core"
 version = "1.0.0"
-source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=6b989ac#6b989ac45b66bab3c91abff665df8aba1f923c43"
+source = "git+https://github.com/semiotic-ai/timeline-aggregation-protocol?rev=c179dfe#c179dfedee1ed8078b358de3d35f4d051f74c9c1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -29,7 +29,7 @@ serde.workspace = true
 serde_json = { version = "1.0.115", features = ["raw_value"] }
 serde_with = "3.7.0"
 siphasher.workspace = true
-tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "6b989ac" }
+tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "c179dfe" }
 thegraph-core = { workspace = true, features = ["subgraph-client"] }
 thegraph-graphql-http.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
The https://github.com/semiotic-ai/timeline-aggregation-protocol/pull/224 PR got merged. This PR pins the `tap_core` crate to this revision until a new release is available.