### PR TITLE
chore(deps): update thegraph rust crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "candidate-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=2c48a9b#2c48a9bdac34d9ab9ac4285fa34e255be024942e"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=b48f3dc#b48f3dc55d27e64a04c3f0dc80c4e8ce8712eb2f"
 dependencies = [
  "arrayvec 0.7.4",
  "ordered-float",
@@ -2360,9 +2360,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexer-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=2c48a9b#2c48a9bdac34d9ab9ac4285fa34e255be024942e"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=b48f3dc#b48f3dc55d27e64a04c3f0dc80c4e8ce8712eb2f"
 dependencies = [
- "candidate-selection 0.1.0 (git+https://github.com/edgeandnode/candidate-selection?rev=2c48a9b)",
+ "candidate-selection 0.1.0 (git+https://github.com/edgeandnode/candidate-selection?rev=b48f3dc)",
  "custom_debug",
  "rand",
  "thegraph-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ secp256k1 = { version = "0.28", default-features = false }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 siphasher = "1.0.1"
-thegraph-core = "0.2.2"
-thegraph-graphql-http = "0.1.0"
+thegraph-core = "0.2.3"
+thegraph-graphql-http = "0.1.1"
 thiserror = "1.0.58"
 tokio = { version = "1.37", features = [
     "macros",

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -19,7 +19,7 @@ gateway-common = { path = "../gateway-common" }
 gateway-framework = { path = "../gateway-framework" }
 graphql.workspace = true
 headers = "0.3.9"
-indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "2c48a9b" }
+indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "b48f3dc" }
 indoc = "2.0.5"
 itertools = "0.12.1"
 num-traits = "0.2.18"


### PR DESCRIPTION
This is an intermediate upgrade (_pre-hyper v1_) of the `the graph` crates, so we have a step to revert if the upgrade does not go smoothly.