### PR TITLE
refactor: move more into the framework's network module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,18 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "candidate-selection"
-version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=bcd7909#bcd7909f6bc0344278d9e09e368580201b6fae22"
-dependencies = [
- "arrayvec 0.7.4",
- "ordered-float",
- "permutation",
- "proptest",
- "rand",
-]
-
-[[package]]
 name = "cargo-platform"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,14 +1835,16 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "axum",
- "candidate-selection 0.1.0 (git+https://github.com/edgeandnode/candidate-selection?rev=bcd7909)",
+ "candidate-selection",
  "chrono",
+ "cost-model",
  "ethers",
  "eventuals",
  "gateway-common",
  "headers",
  "hex",
  "hickory-resolver",
+ "indexer-selection",
  "ipnetwork",
  "itertools 0.12.1",
  "lazy_static",
@@ -2483,7 +2473,7 @@ name = "indexer-selection"
 version = "0.1.0"
 source = "git+https://github.com/edgeandnode/candidate-selection?rev=4b6ce4a#4b6ce4a9241c451fd3fe158c65692bfdde58405d"
 dependencies = [
- "candidate-selection 0.1.0 (git+https://github.com/edgeandnode/candidate-selection?rev=4b6ce4a)",
+ "candidate-selection",
  "custom_debug",
  "rand",
  "thegraph-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,12 @@ axum = { version = "0.7.5", default-features = false, features = [
     "tokio",
     "original-uri",
 ] }
+candidate-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "4b6ce4a" }
+cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3ed34ca" }
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
 headers = "0.4.0"
 hex = "0.4"
+indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "4b6ce4a" }
 primitive-types = "0.12.2"
 rand = { version = "0.8", features = ["small_rng"] }
 receipts = { git = "https://github.com/edgeandnode/receipts", rev = "b12e197" }

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -9,15 +9,17 @@ alloy-sol-types.workspace = true
 anyhow.workspace = true
 axum.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-candidate-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "bcd7909" }
+candidate-selection.workspace = true
+cost-model.workspace = true
 ethers = "2.0.14"
 eventuals = "0.6.7"
 gateway-common = { path = "../gateway-common" }
 headers.workspace = true
 hex.workspace = true
 hickory-resolver = "0.24.0"
-ipnetwork = "0.20.0"
+indexer-selection.workspace = true
 itertools = "0.12.1"
+ipnetwork = "0.20.0"
 lazy_static = "1.4.0"
 ordered-float = "4.2.0"
 primitive-types.workspace = true

--- a/gateway-framework/src/network/discovery.rs
+++ b/gateway-framework/src/network/discovery.rs
@@ -1,0 +1,11 @@
+use alloy_primitives::BlockNumber;
+use cost_model::CostModel;
+use eventuals::Ptr;
+
+#[derive(Clone)]
+pub struct Status {
+    pub block: BlockNumber,
+    pub min_block: Option<BlockNumber>,
+    pub cost_model: Option<Ptr<CostModel>>,
+    pub legacy_scalar: bool,
+}

--- a/gateway-framework/src/network/mod.rs
+++ b/gateway-framework/src/network/mod.rs
@@ -1,2 +1,4 @@
+pub mod discovery;
 pub mod exchange_rate;
+pub mod indexing_performance;
 pub mod network_subgraph;

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -20,7 +20,7 @@ gateway-common = { path = "../gateway-common" }
 gateway-framework = { path = "../gateway-framework" }
 graphql.workspace = true
 headers.workspace = true
-indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "4b6ce4a" }
+indexer-selection.workspace = true
 indoc = "2.0.5"
 itertools = "0.12.1"
 num-traits = "0.2.18"

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -26,6 +26,10 @@ use gateway_framework::{
         Error, IndexerError,
         UnavailableReason::{self, *},
     },
+    network::{
+        discovery::Status,
+        indexing_performance::{IndexingPerformance, Snapshot},
+    },
     reporting::{with_metric, KafkaClient, METRICS},
     scalar::{ReceiptStatus, ScalarReceipt},
 };
@@ -52,8 +56,6 @@ use crate::{
     block_constraints::{resolve_block_requirements, rewrite_query, BlockRequirements},
     chains::ChainReader,
     indexer_client::{check_block_error, IndexerClient, ResponsePayload},
-    indexers::indexing,
-    indexing_performance::{self, IndexingPerformance},
     reports::{self, serialize_attestation},
     topology::{Deployment, GraphNetwork, Subgraph},
     unattestable_errors::{miscategorized_attestable, miscategorized_unattestable},
@@ -541,8 +543,8 @@ async fn handle_client_query_inner(
 #[allow(clippy::too_many_arguments)]
 fn prepare_candidate(
     network: &GraphNetwork,
-    statuses: &HashMap<Indexing, indexing::Status>,
-    perf_snapshots: &HashMap<Indexing, indexing_performance::Snapshot>,
+    statuses: &HashMap<Indexing, Status>,
+    perf_snapshots: &HashMap<Indexing, Snapshot>,
     versions_behind: &BTreeMap<DeploymentId, u8>,
     context: &mut AgoraContext<String>,
     block_requirements: &BlockRequirements,
@@ -597,7 +599,7 @@ struct Perf {
 }
 
 fn perf(
-    snapshot: &indexing_performance::Snapshot,
+    snapshot: &Snapshot,
     block_requirements: &BlockRequirements,
     chain_head: BlockNumber,
     blocks_per_minute: u64,

--- a/graph-gateway/src/client_query/context.rs
+++ b/graph-gateway/src/client_query/context.rs
@@ -4,14 +4,16 @@ use alloy_primitives::Address;
 use alloy_sol_types::Eip712Domain;
 use eventuals::{Eventual, Ptr};
 use gateway_common::types::Indexing;
-use gateway_framework::{budgets::Budgeter, reporting::KafkaClient, scalar::ReceiptSigner};
+use gateway_framework::{
+    budgets::Budgeter,
+    network::{discovery::Status, indexing_performance::IndexingPerformance},
+    reporting::KafkaClient,
+    scalar::ReceiptSigner,
+};
 use ordered_float::NotNan;
 use url::Url;
 
-use crate::{
-    chains::Chains, indexer_client::IndexerClient, indexers::indexing,
-    indexing_performance::IndexingPerformance, topology::GraphNetwork,
-};
+use crate::{chains::Chains, indexer_client::IndexerClient, topology::GraphNetwork};
 
 #[derive(Clone)]
 pub struct Context {
@@ -24,7 +26,7 @@ pub struct Context {
     pub grt_per_usd: Eventual<NotNan<f64>>,
     pub chains: &'static Chains,
     pub network: GraphNetwork,
-    pub indexing_statuses: Eventual<Ptr<HashMap<Indexing, indexing::Status>>>,
+    pub indexing_statuses: Eventual<Ptr<HashMap<Indexing, Status>>>,
     pub indexing_perf: IndexingPerformance,
     pub attestation_domain: &'static Eip712Domain,
     pub bad_indexers: &'static HashSet<Address>,

--- a/graph-gateway/src/indexers/indexing.rs
+++ b/graph-gateway/src/indexers/indexing.rs
@@ -1,11 +1,12 @@
 use std::{collections::HashMap, sync::Arc};
 
-use alloy_primitives::{Address, BlockNumber};
+use alloy_primitives::Address;
 use anyhow::{anyhow, ensure};
 use cost_model::CostModel;
 use eventuals::{Eventual, EventualExt as _, EventualWriter, Ptr};
 use futures::future::join_all;
 use gateway_common::types::Indexing;
+use gateway_framework::network::discovery::Status;
 use semver::Version;
 use thegraph_core::types::DeploymentId;
 use tokio::sync::Mutex;
@@ -16,14 +17,6 @@ use crate::{
     indexers::{cost_models, indexing_statuses, version},
     topology::Deployment,
 };
-
-#[derive(Clone)]
-pub struct Status {
-    pub block: BlockNumber,
-    pub min_block: Option<BlockNumber>,
-    pub cost_model: Option<Ptr<CostModel>>,
-    pub legacy_scalar: bool,
-}
 
 pub async fn statuses(
     deployments: Eventual<Ptr<HashMap<DeploymentId, Arc<Deployment>>>>,

--- a/graph-gateway/src/lib.rs
+++ b/graph-gateway/src/lib.rs
@@ -4,7 +4,6 @@ pub mod client_query;
 pub mod config;
 pub mod indexer_client;
 pub mod indexers;
-pub mod indexing_performance;
 pub mod indexings_blocklist;
 pub mod reports;
 pub mod subgraph_studio;

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -27,7 +27,10 @@ use gateway_framework::{
     budgets::{Budgeter, USD},
     ip_blocker::IpBlocker,
     ipfs, json,
-    network::{exchange_rate, network_subgraph},
+    network::{
+        discovery::Status, exchange_rate, indexing_performance::IndexingPerformance,
+        network_subgraph,
+    },
     reporting::{self, EventFilterFn, EventHandlerFn, KafkaClient, LoggingOptions},
     scalar::{self, ReceiptSigner},
 };
@@ -41,7 +44,6 @@ use graph_gateway::{
     config::{ApiKeys, Config, ExchangeRateProvider},
     indexer_client::IndexerClient,
     indexers::indexing,
-    indexing_performance::IndexingPerformance,
     indexings_blocklist::{self, indexings_blocklist},
     reports::{
         report_client_query, report_indexer_query, CLIENT_QUERY_TARGET, INDEXER_QUERY_TARGET,
@@ -443,7 +445,7 @@ async fn ip_rate_limit(
 async fn update_allocations(
     receipt_signer: &ReceiptSigner,
     deployments: &HashMap<DeploymentId, Arc<Deployment>>,
-    indexing_statuses: &HashMap<Indexing, indexing::Status>,
+    indexing_statuses: &HashMap<Indexing, Status>,
 ) {
     tracing::info!(
         deployments = deployments.len(),


### PR DESCRIPTION
This moves the indexing performance logic and `Status` struct into the `gateway_framework::network` module. That's it.

The PR is based on #673. I'll rebase it once that one has been merged.