### PR TITLE
chore(deps): update hyper-related rust crates to v1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,19 +389,19 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "headers",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -412,7 +412,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tower",
  "tower-layer",
@@ -421,19 +421,45 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
 dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -611,7 +637,7 @@ dependencies = [
 [[package]]
 name = "candidate-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=b48f3dc#b48f3dc55d27e64a04c3f0dc80c4e8ce8712eb2f"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=4b6ce4a#4b6ce4a9241c451fd3fe158c65692bfdde58405d"
 dependencies = [
  "arrayvec 0.7.4",
  "ordered-float",
@@ -1349,7 +1375,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "syn 2.0.58",
@@ -1411,7 +1437,7 @@ checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
  "ethers-core",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -1436,7 +1462,7 @@ dependencies = [
  "futures-locks",
  "futures-util",
  "instant",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -1463,12 +1489,12 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hashers",
- "http",
+ "http 0.2.12",
  "instant",
  "jsonwebtoken",
  "once_cell",
  "pin-project",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "thiserror",
@@ -1806,7 +1832,7 @@ version = "0.0.1"
 dependencies = [
  "alloy-primitives",
  "headers",
- "http",
+ "http 1.1.0",
  "siphasher 1.0.1",
  "thegraph-core",
  "tracing-subscriber",
@@ -1836,7 +1862,7 @@ dependencies = [
  "prometheus",
  "rand",
  "receipts",
- "reqwest",
+ "reqwest 0.12.3",
  "secp256k1",
  "serde",
  "serde_json",
@@ -1909,6 +1935,7 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "axum",
+ "axum-extra",
  "chrono",
  "cost-model",
  "custom_debug",
@@ -1920,7 +1947,8 @@ dependencies = [
  "gateway-framework",
  "graphql 0.3.0",
  "headers",
- "hyper",
+ "http-body-util",
+ "hyper 1.2.0",
  "indexer-selection",
  "indoc",
  "itertools 0.12.1",
@@ -1931,7 +1959,7 @@ dependencies = [
  "prost",
  "rand",
  "rdkafka",
- "reqwest",
+ "reqwest 0.12.3",
  "secp256k1",
  "semver 1.0.22",
  "serde",
@@ -2007,7 +2035,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.1.0",
  "indexmap 2.2.6",
  "slab",
  "tokio",
@@ -2044,14 +2091,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -2059,11 +2106,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2185,21 +2232,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
+name = "http-body"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "httparse"
@@ -2223,9 +2298,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -2238,14 +2313,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.12",
+ "hyper 0.14.28",
  "rustls",
  "tokio",
  "tokio-rustls",
@@ -2253,15 +2349,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
- "hyper",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.2.0",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2360,9 +2479,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexer-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=b48f3dc#b48f3dc55d27e64a04c3f0dc80c4e8ce8712eb2f"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=4b6ce4a#4b6ce4a9241c451fd3fe158c65692bfdde58405d"
 dependencies = [
- "candidate-selection 0.1.0 (git+https://github.com/edgeandnode/candidate-selection?rev=b48f3dc)",
+ "candidate-selection 0.1.0 (git+https://github.com/edgeandnode/candidate-selection?rev=4b6ce4a)",
  "custom_debug",
  "rand",
  "thegraph-core",
@@ -2424,7 +2543,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -3643,18 +3762,60 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+dependencies = [
+ "async-compression",
+ "base64 0.22.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.4",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -3663,24 +3824,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3883,6 +4041,22 @@ checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.0",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
 
 [[package]]
 name = "rustls-webpki"
@@ -4492,7 +4666,7 @@ dependencies = [
  "fs2",
  "hex",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.27",
  "semver 1.0.22",
  "serde",
  "serde_json",
@@ -4541,6 +4715,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -4642,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "thegraph-core"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bc4de6918f6436f78300b2f4a974cbcaa869dc63d47f492e160da99986a076"
+checksum = "bf9f477fea2546838b51a67011fdc7b5e8c7197cfa1e10f2d4bcc78f9f078fc6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -4655,7 +4835,7 @@ dependencies = [
  "ethers-core",
  "indoc",
  "lazy_static",
- "reqwest",
+ "reqwest 0.12.3",
  "serde",
  "serde_cbor_2",
  "serde_json",
@@ -4668,12 +4848,12 @@ dependencies = [
 
 [[package]]
 name = "thegraph-graphql-http"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2145a61657c371657e8540bfeb5fae38f5c4495880d6b78415c5eae34364ea9f"
+checksum = "013ce559c2fc1427dc22aacd2b6eb66f63be5680c04fa5e1b9ac9a79fb275937"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.12.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -4960,17 +5140,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.5.0",
  "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -5103,7 +5281,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.12",
  "httparse",
  "log",
  "rand",
@@ -5575,6 +5753,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,18 @@ debug = true
 anyhow = "1.0"
 alloy-primitives = { version = "0.7.0", features = ["serde"] }
 alloy-sol-types = "0.7.0"
-axum = { version = "0.6.20", default-features = false, features = [
+axum = { version = "0.7.5", default-features = false, features = [
     "json",
     "tokio",
     "original-uri",
 ] }
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
+headers = "0.4.0"
 hex = "0.4"
 primitive-types = "0.12.2"
 rand = { version = "0.8", features = ["small_rng"] }
 receipts = { git = "https://github.com/edgeandnode/receipts", rev = "8bc8f13" }
-reqwest = { version = "0.11", default-features = false, features = [
+reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "default-tls",
     "gzip",
@@ -32,8 +33,8 @@ secp256k1 = { version = "0.28", default-features = false }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 siphasher = "1.0.1"
-thegraph-core = "0.2.3"
-thegraph-graphql-http = "0.1.1"
+thegraph-core = "0.3.0"
+thegraph-graphql-http = "0.2.0"
 thiserror = "1.0.58"
 tokio = { version = "1.37", features = [
     "macros",

--- a/gateway-common/Cargo.toml
+++ b/gateway-common/Cargo.toml
@@ -5,8 +5,8 @@ version = "0.0.1"
 
 [dependencies]
 alloy-primitives.workspace = true
-headers = "0.3.9"
-http = "0.2.12"
+headers.workspace = true
+http = "1.1.0"
 siphasher.workspace = true
 thegraph-core.workspace = true
 tracing-subscriber.workspace = true

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -12,7 +12,7 @@ candidate-selection = { git = "https://github.com/edgeandnode/candidate-selectio
 ethers = "2.0.14"
 eventuals = "0.6.7"
 gateway-common = { path = "../gateway-common" }
-headers = "0.3.9"
+headers.workspace = true
 hex.workspace = true
 hickory-resolver = "0.24.0"
 ipnetwork = "0.20.0"

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -7,7 +7,8 @@ version = "20.0.2"
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 anyhow.workspace = true
-axum = { workspace = true, features = ["headers"] }
+axum = { workspace = true, features = ["tokio", "http1"] }
+axum-extra = "0.9.3"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3ed34ca" }
 custom_debug = "0.6.1"
@@ -18,8 +19,8 @@ futures = "0.3"
 gateway-common = { path = "../gateway-common" }
 gateway-framework = { path = "../gateway-framework" }
 graphql.workspace = true
-headers = "0.3.9"
-indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "b48f3dc" }
+headers.workspace = true
+indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "4b6ce4a" }
 indoc = "2.0.5"
 itertools = "0.12.1"
 num-traits = "0.2.18"
@@ -44,7 +45,7 @@ thiserror.workspace = true
 tokio.workspace = true
 toolshed.workspace = true
 tower = "0.4.13"
-tower-http = { version = "0.4.0", features = ["cors"] }
+tower-http = { version = "0.5.2", features = ["cors"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url = "2.5.0"
@@ -52,6 +53,7 @@ uuid = { version = "1.8", default-features = false, features = ["v4"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-hyper = "0.14.28"
+http-body-util = "0.1.1"
+hyper = "1.2.0"
 tokio-test = "0.4.4"
 tower-test = "0.4.0"

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -854,7 +854,7 @@ mod tests {
 
         use assert_matches::assert_matches;
         use axum::{
-            body::BoxBody,
+            body::Body,
             http::{Method, Request, StatusCode},
             middleware,
             routing::post,
@@ -862,7 +862,7 @@ mod tests {
         };
         use eventuals::{Eventual, Ptr};
         use headers::{Authorization, ContentType, HeaderMapExt};
-        use hyper::Body;
+        use http_body_util::BodyExt;
         use tower::ServiceExt;
 
         use super::{
@@ -949,18 +949,18 @@ mod tests {
 
         /// Deserialize a GraphQL response body.
         async fn deserialize_graphql_response_body<T>(
-            body: &mut BoxBody,
+            body: &mut Body,
         ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
         where
             for<'de> T: serde::Deserialize<'de>,
         {
-            let body = hyper::body::to_bytes(body).await.expect("valid body");
+            let body = body.collect().await.expect("valid body").to_bytes();
             serde_json::from_slice(body.as_ref())
         }
 
         /// Parse text response body.
-        async fn parse_text_response_body(body: &mut BoxBody) -> anyhow::Result<String> {
-            let body = hyper::body::to_bytes(body).await.expect("valid body");
+        async fn parse_text_response_body(body: &mut Body) -> anyhow::Result<String> {
+            let body = body.collect().await.expect("valid body").to_bytes();
             let text = String::from_utf8(body.to_vec())?;
             Ok(text)
         }

--- a/graph-gateway/src/client_query/query_selector.rs
+++ b/graph-gateway/src/client_query/query_selector.rs
@@ -91,10 +91,11 @@ where
 mod tests {
     use assert_matches::assert_matches;
     use axum::{
-        body::{Body, BoxBody},
+        body::Body,
         http::{Method, Request},
         Router,
     };
+    use http_body_util::BodyExt;
     use thegraph_core::types::{DeploymentId, SubgraphId};
     use tower::ServiceExt;
 
@@ -129,18 +130,18 @@ mod tests {
 
     /// Deserialize a GraphQL response body.
     async fn deserialize_graphql_response_body<T>(
-        body: &mut BoxBody,
+        body: &mut Body,
     ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
     where
         for<'de> T: serde::Deserialize<'de>,
     {
-        let body = hyper::body::to_bytes(body).await.expect("valid body");
+        let body = body.collect().await.expect("valid body").to_bytes();
         serde_json::from_slice(body.as_ref())
     }
 
     /// Parse text response body.
-    async fn parse_text_response_body(body: &mut BoxBody) -> anyhow::Result<String> {
-        let body = hyper::body::to_bytes(body).await.expect("valid body");
+    async fn parse_text_response_body(body: &mut Body) -> anyhow::Result<String> {
+        let body = body.collect().await.expect("valid body").to_bytes();
         let text = String::from_utf8(body.to_vec())?;
         Ok(text)
     }

--- a/graph-gateway/src/client_query/rate_limiter.rs
+++ b/graph-gateway/src/client_query/rate_limiter.rs
@@ -232,8 +232,9 @@ mod tests {
 
     use alloy_primitives::Address;
     use assert_matches::assert_matches;
-    use axum::{body::BoxBody, http};
+    use axum::{body::Body, http};
     use headers::{ContentType, HeaderMapExt};
+    use http_body_util::BodyExt;
     use tokio_test::assert_ready_ok;
 
     use crate::client_query::rate_limiter::{AddRateLimiterLayer, RateLimitSettings};
@@ -257,12 +258,12 @@ mod tests {
 
     /// Deserialize a GraphQL response body.
     async fn deserialize_graphql_response_body<T>(
-        body: &mut BoxBody,
+        body: &mut Body,
     ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
     where
         for<'de> T: serde::Deserialize<'de>,
     {
-        let body = hyper::body::to_bytes(body).await.expect("valid body");
+        let body = body.collect().await.expect("valid body").to_bytes();
         serde_json::from_slice(body.as_ref())
     }
 

--- a/graph-gateway/src/client_query/require_auth.rs
+++ b/graph-gateway/src/client_query/require_auth.rs
@@ -213,9 +213,10 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use assert_matches::assert_matches;
-    use axum::body::BoxBody;
+    use axum::body::Body;
     use eventuals::{Eventual, Ptr};
     use headers::{Authorization, ContentType, HeaderMapExt};
+    use http_body_util::BodyExt;
     use hyper::http;
     use ordered_float::NotNan;
     use tokio_test::assert_ready_ok;
@@ -293,12 +294,12 @@ mod tests {
 
     /// Deserialize a GraphQL response body.
     async fn deserialize_graphql_response_body<T>(
-        body: &mut BoxBody,
+        body: &mut Body,
     ) -> serde_json::Result<thegraph_graphql_http::http::response::ResponseBody<T>>
     where
         for<'de> T: serde::Deserialize<'de>,
     {
-        let body = hyper::body::to_bytes(body).await.expect("valid body");
+        let body = body.collect().await.expect("valid body").to_bytes();
         serde_json::from_slice(body.as_ref())
     }
 

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -372,7 +372,7 @@ async fn main() {
         app_listener,
         router.into_make_service_with_connect_info::<SocketAddr>(),
     )
-    // Wait until https://github.com/tokio-rs/axum/pull/2653 is released
+    // TODO: Wait until https://github.com/tokio-rs/axum/pull/2653 is released
     // // disable Nagel's algorithm
     // .tcp_nodelay(true)
     .with_graceful_shutdown(await_shutdown_signals())

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -278,7 +278,7 @@ async fn main() {
         .await
         .expect("Failed to bind metrics server");
         axum::serve(metrics_listener, router.into_make_service())
-            // Wait until https://github.com/tokio-rs/axum/pull/2653 is released
+            // TODO: Wait until https://github.com/tokio-rs/axum/pull/2653 is released
             // // disable Nagel's algorithm
             // .tcp_nodelay(true)
             .await


### PR DESCRIPTION
Upgrade all the hyper-related crates to the v1 era. This includes the following crates: `http`, `headers`, `hyper`, `tower-http`, `axum` and `axum-extra`, `reqwest`, and all the crates that have a transitive dependency on the hyper crate.

This PR resolves #541 