### PR TITLE
refactor: move auth module and some middleware into the framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1826,18 +1826,23 @@ dependencies = [
  "candidate-selection 0.1.0 (git+https://github.com/edgeandnode/candidate-selection?rev=b58f057)",
  "chrono",
  "cost-model",
+ "dashmap",
  "ethers",
  "eventuals",
+ "faster-hex",
  "futures",
  "gateway-common",
  "headers",
  "hex",
  "hickory-resolver",
+ "http-body-util",
+ "hyper 1.2.0",
  "indexer-selection",
  "ipnetwork",
  "itertools 0.12.1",
  "lazy_static",
  "ordered-float",
+ "pin-project",
  "primitive-types",
  "prometheus",
  "rand",
@@ -1848,6 +1853,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "serde_yaml",
+ "simple-rate-limiter",
  "siphasher 1.0.1",
  "tap_core",
  "test-with",
@@ -1855,7 +1862,11 @@ dependencies = [
  "thegraph-graphql-http",
  "thiserror",
  "tokio",
+ "tokio-test",
  "toolshed",
+ "tower",
+ "tower-http",
+ "tower-test",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4358,6 +4369,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5322,6 +5346,12 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,8 +1853,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serde_yaml",
- "simple-rate-limiter",
  "siphasher 1.0.1",
  "tap_core",
  "test-with",
@@ -1865,7 +1863,6 @@ dependencies = [
  "tokio-test",
  "toolshed",
  "tower",
- "tower-http",
  "tower-test",
  "tracing",
  "tracing-subscriber",
@@ -1930,9 +1927,7 @@ dependencies = [
  "chrono",
  "cost-model",
  "custom_debug",
- "dashmap",
  "eventuals",
- "faster-hex",
  "futures",
  "gateway-common",
  "gateway-framework",
@@ -1945,7 +1940,6 @@ dependencies = [
  "itertools 0.12.1",
  "num-traits",
  "ordered-float",
- "pin-project",
  "prometheus",
  "prost",
  "rand",
@@ -1960,7 +1954,6 @@ dependencies = [
  "snmalloc-rs",
  "thegraph-core",
  "thegraph-graphql-http",
- "thiserror",
  "tokio",
  "tokio-test",
  "toolshed",
@@ -4369,19 +4362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.2.6",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5346,12 +5326,6 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,6 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.115", features = ["raw_value"] }
 serde_with = "3.7.0"
-serde_yaml = "0.9"
-simple-rate-limiter = "1.0"
 siphasher = "1.0.1"
 thegraph-core = "0.3.0"
 thegraph-graphql-http = "0.2.0"
@@ -54,7 +52,6 @@ tokio = { version = "1.37", features = [
 ] }
 toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "toolshed-v0.6.0" }
 tower = "0.4.13"
-tower-http = { version = "0.5.2", features = ["cors"] }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.115", features = ["raw_value"] }
 serde_with = "3.7.0"
+serde_yaml = "0.9"
+simple-rate-limiter = "1.0"
 siphasher = "1.0.1"
 thegraph-core = "0.3.0"
 thegraph-graphql-http = "0.2.0"
@@ -51,6 +53,8 @@ tokio = { version = "1.37", features = [
     "time",
 ] }
 toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "toolshed-v0.6.0" }
+tower = "0.4.13"
+tower-http = { version = "0.5.2", features = ["cors"] }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -36,8 +36,6 @@ secp256k1.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 serde_with.workspace = true
-serde_yaml.workspace = true
-simple-rate-limiter.workspace = true
 siphasher.workspace = true
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "c179dfe" }
 thegraph-core = { workspace = true, features = ["subgraph-client"] }
@@ -46,7 +44,6 @@ thiserror.workspace = true
 tokio.workspace = true
 toolshed.workspace = true
 tower.workspace = true
-tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url = "2.5.0"

--- a/gateway-framework/Cargo.toml
+++ b/gateway-framework/Cargo.toml
@@ -11,8 +11,10 @@ axum.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 candidate-selection.workspace = true
 cost-model.workspace = true
+dashmap = "5.5.3"
 ethers = "2.0.14"
 eventuals = "0.6.7"
+faster-hex = "0.9.0"
 futures.workspace = true
 gateway-common = { path = "../gateway-common" }
 headers.workspace = true
@@ -23,6 +25,7 @@ itertools = "0.12.1"
 ipnetwork = "0.20.0"
 lazy_static = "1.4.0"
 ordered-float = "4.2.0"
+pin-project = "1.1.5"
 primitive-types.workspace = true
 prometheus = "0.13.3"
 rand.workspace = true
@@ -33,6 +36,8 @@ secp256k1.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
 serde_with.workspace = true
+serde_yaml.workspace = true
+simple-rate-limiter.workspace = true
 siphasher.workspace = true
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "c179dfe" }
 thegraph-core = { workspace = true, features = ["subgraph-client"] }
@@ -40,10 +45,16 @@ thegraph-graphql-http.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toolshed.workspace = true
+tower.workspace = true
+tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url = "2.5.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+http-body-util = "0.1.1"
+hyper = "1.2.0"
 test-with = { version = "0.12.6", default-features = false }
+tokio-test = "0.4.4"
+tower-test = "0.4.0"

--- a/gateway-framework/src/auth/context.rs
+++ b/gateway-framework/src/auth/context.rs
@@ -85,7 +85,7 @@ impl AuthContext {
             return Err(anyhow::anyhow!("not found"));
         }
 
-        // First, parse the bearer token as it was an API key
+        // First, parse the bearer token as if it is an API key
         let ctx = api_keys::AuthContext::from_ref(self);
         if let Ok((auth, query_settings, rate_limit_settings)) =
             api_keys::parse_auth_token(&ctx, input)

--- a/gateway-framework/src/auth/methods/common.rs
+++ b/gateway-framework/src/auth/methods/common.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use gateway_framework::topology::network::Deployment;
 use thegraph_core::types::{DeploymentId, SubgraphId};
+
+use crate::topology::network::Deployment;
 
 /// Check if the given deployments are authorized by the given authorized deployments.
 ///

--- a/gateway-framework/src/auth/methods/mod.rs
+++ b/gateway-framework/src/auth/methods/mod.rs
@@ -1,0 +1,3 @@
+pub mod api_keys;
+pub mod common;
+pub mod subscriptions;

--- a/gateway-framework/src/auth/methods/subscriptions.rs
+++ b/gateway-framework/src/auth/methods/subscriptions.rs
@@ -5,7 +5,6 @@ use std::{
 
 use alloy_primitives::Address;
 use eventuals::{Eventual, Ptr};
-use gateway_framework::{subscriptions::Subscription, topology::network::Deployment};
 use thegraph_core::{
     subscriptions::auth::{
         parse_auth_token as parse_bearer_token, verify_auth_token_claims, AuthTokenClaims,
@@ -14,7 +13,10 @@ use thegraph_core::{
 };
 
 use super::common;
-use crate::client_query::{query_settings::QuerySettings, rate_limiter::RateLimitSettings};
+use crate::{
+    auth::QuerySettings, http::middleware::RateLimitSettings, subscriptions::Subscription,
+    topology::network::Deployment,
+};
 
 /// Auth token wrapper around the Subscriptions auth token claims and the subscription.
 #[derive(Debug, Clone)]

--- a/gateway-framework/src/http/middleware/mod.rs
+++ b/gateway-framework/src/http/middleware/mod.rs
@@ -1,0 +1,5 @@
+mod rate_limiter;
+mod require_auth;
+
+pub use rate_limiter::{AddRateLimiterLayer, RateLimitSettings, RateLimiter};
+pub use require_auth::{RequireAuthorization, RequireAuthorizationLayer};

--- a/gateway-framework/src/http/middleware/rate_limiter.rs
+++ b/gateway-framework/src/http/middleware/rate_limiter.rs
@@ -8,10 +8,10 @@ use alloy_primitives::Address;
 use axum::http::Request;
 use dashmap::DashMap;
 use eventuals::EventualExt;
-use gateway_framework::{errors::Error, graphql};
 use tower::Service;
 
 use self::future::ResponseFuture;
+use crate::{errors::Error, graphql};
 
 /// Rate limit settings.
 ///
@@ -237,7 +237,7 @@ mod tests {
     use http_body_util::BodyExt;
     use tokio_test::assert_ready_ok;
 
-    use crate::client_query::rate_limiter::{AddRateLimiterLayer, RateLimitSettings};
+    use super::{AddRateLimiterLayer, RateLimitSettings};
 
     /// Helper function to parse an address string into an `Address`.
     fn test_address(addr: &str) -> Address {

--- a/gateway-framework/src/http/middleware/require_auth.rs
+++ b/gateway-framework/src/http/middleware/require_auth.rs
@@ -14,6 +14,7 @@ use crate::{
     auth::{AuthContext, AuthToken},
     errors::Error,
     graphql,
+    reporting::CLIENT_REQUEST_TARGET,
 };
 
 #[pin_project::pin_project(project = KindProj)]
@@ -142,12 +143,12 @@ where
 
         match &auth_token {
             AuthToken::ApiKey(auth) => tracing::info!(
-                target: "client_request",
+                target: CLIENT_REQUEST_TARGET,
                 user_address = ?auth.user(),
                 api_key = %auth.key(),
             ),
             AuthToken::SubscriptionsAuthToken(auth) => tracing::info!(
-                target: "client_request",
+                target: CLIENT_REQUEST_TARGET,
                 user_address = ?auth.user(),
             ),
         };

--- a/gateway-framework/src/http/mod.rs
+++ b/gateway-framework/src/http/mod.rs
@@ -1,0 +1,1 @@
+pub mod middleware;

--- a/gateway-framework/src/lib.rs
+++ b/gateway-framework/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod blocks;
 pub mod budgets;
 pub mod chain;
@@ -5,6 +6,7 @@ pub mod chains;
 pub mod config;
 pub mod errors;
 pub mod graphql;
+pub mod http;
 pub mod ip_blocker;
 pub mod json;
 pub mod network;

--- a/gateway-framework/src/reporting/kafka.rs
+++ b/gateway-framework/src/reporting/kafka.rs
@@ -31,8 +31,6 @@ impl KafkaClient {
     }
 }
 
-pub type EventFilterFn = tracing_subscriber::filter::FilterFn;
-
 pub struct EventHandlerFn<
     F = fn(&KafkaClient, &tracing::Metadata<'_>, Map<String, serde_json::Value>),
 >(F);

--- a/gateway-framework/src/reporting/mod.rs
+++ b/gateway-framework/src/reporting/mod.rs
@@ -2,6 +2,6 @@ mod kafka;
 mod logging;
 mod metrics;
 
-pub use kafka::{EventFilterFn, EventHandlerFn, KafkaClient};
-pub use logging::{error_log, init, LoggingOptions};
+pub use kafka::{EventHandlerFn, KafkaClient};
+pub use logging::{error_log, init, LoggingOptions, CLIENT_REQUEST_TARGET, INDEXER_REQUEST_TARGET};
 pub use metrics::{with_metric, METRICS};

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -11,9 +11,7 @@ axum = { workspace = true, features = ["tokio", "http1"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3ed34ca" }
 custom_debug = "0.6.1"
-dashmap = "5.5.3"
 eventuals = "0.6.7"
-faster-hex = "0.9.0"
 futures.workspace = true
 gateway-common = { path = "../gateway-common" }
 gateway-framework = { path = "../gateway-framework" }
@@ -24,7 +22,6 @@ indoc = "2.0.5"
 itertools = "0.12.1"
 num-traits = "0.2.18"
 ordered-float = "4.2.0"
-pin-project = "1.1.5"
 prometheus = { version = "0.13", default-features = false }
 prost = "0.12.4"
 rand.workspace = true
@@ -42,7 +39,6 @@ thegraph-core = { workspace = true, features = [
     "subscriptions",
 ] }
 thegraph-graphql-http.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
 toolshed.workspace = true
 tower = "0.4.13"

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -8,14 +8,17 @@ use std::{
 
 use alloy_primitives::{Address, U256};
 use custom_debug::CustomDebug;
-use gateway_framework::config::{Hidden, HiddenSecretKey};
+use gateway_framework::{
+    auth::methods::api_keys::APIKey,
+    config::{Hidden, HiddenSecretKey},
+};
 use secp256k1::SecretKey;
 use semver::Version;
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr};
 use url::Url;
 
-use crate::{indexers::public_poi::ProofOfIndexingInfo, subgraph_studio::APIKey};
+use crate::indexers::public_poi::ProofOfIndexingInfo;
 
 #[serde_as]
 #[derive(CustomDebug, Deserialize)]

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -24,8 +24,10 @@ use axum::{
 use eventuals::{Eventual, EventualExt as _, Ptr};
 use gateway_common::types::Indexing;
 use gateway_framework::{
+    auth::AuthContext,
     budgets::{Budgeter, USD},
     chains::Chains,
+    http::middleware::{AddRateLimiterLayer, RequireAuthorizationLayer},
     ip_blocker::IpBlocker,
     json,
     network::{
@@ -39,9 +41,8 @@ use gateway_framework::{
 };
 use graph_gateway::{
     client_query::{
-        self, auth::AuthContext, context::Context, legacy_auth_adapter::legacy_auth_adapter,
+        self, context::Context, legacy_auth_adapter::legacy_auth_adapter,
         query_id::SetQueryIdLayer, query_tracing::QueryTracingLayer,
-        rate_limiter::AddRateLimiterLayer, require_auth::RequireAuthorizationLayer,
     },
     config::{ApiKeys, Config, ExchangeRateProvider},
     indexer_client::IndexerClient,

--- a/graph-gateway/src/subgraph_studio.rs
+++ b/graph-gateway/src/subgraph_studio.rs
@@ -2,37 +2,11 @@ use std::{collections::HashMap, error::Error, sync::Arc};
 
 use alloy_primitives::Address;
 use eventuals::{self, Eventual, EventualExt as _, EventualWriter, Ptr};
+use gateway_framework::auth::methods::api_keys::{APIKey, QueryStatus};
 use ordered_float::NotNan;
 use serde::Deserialize;
-use serde_with::serde_as;
-use thegraph_core::types::{DeploymentId, SubgraphId};
 use tokio::{sync::Mutex, time::Duration};
 use url::Url;
-
-#[serde_as]
-#[derive(Clone, Debug, Default, Deserialize)]
-pub struct APIKey {
-    pub key: String,
-    pub user_address: Address,
-    pub query_status: QueryStatus,
-    #[serde_as(as = "Option<serde_with::TryFromInto<f64>>")]
-    #[serde(rename = "max_budget")]
-    pub max_budget_usd: Option<NotNan<f64>>,
-    #[serde(default)]
-    pub deployments: Vec<DeploymentId>,
-    #[serde(default)]
-    pub subgraphs: Vec<SubgraphId>,
-    #[serde(default)]
-    pub domains: Vec<String>,
-}
-
-#[derive(Clone, Copy, Debug, Default, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum QueryStatus {
-    #[default]
-    Active,
-    ServiceShutoff,
-}
 
 pub fn api_keys(
     client: reqwest::Client,


### PR DESCRIPTION
One step closer with the refactorings. This moves the `client_query/auth` module from the gateway into the framework. Along with this, the rate limiter and require auth middleware are also moved.

Small changes to API keys: the `APIKey` and `QueryStatus` types are moved into the framework, while the `AuthToken::StudioApiKey` enum variant is renamed to `AuthToken::ApiKey`. I think we can be opinionated here and establish the two forms of auth and this API key format as standard for other studios.

Based on #679, will need rebasing after that one is merged.