### PR TITLE
feat: add hosted service fallback

### DIFF
--- a/graph-gateway/src/client_query/context.rs
+++ b/graph-gateway/src/client_query/context.rs
@@ -23,6 +23,7 @@ pub struct Context {
     pub receipt_signer: &'static ReceiptSigner,
     pub kafka_client: &'static KafkaClient,
     pub budgeter: &'static Budgeter,
+    pub hosted_service_fallback: bool,
     pub indexer_selection_retry_limit: usize,
     pub l2_gateway: Option<Url>,
     pub grt_per_usd: Eventual<NotNan<f64>>,

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -43,6 +43,10 @@ pub struct Config {
     pub gateway_id: Option<String>,
     /// Graph network environment identifier, inserted into Kafka messages
     pub graph_env_id: String,
+    /// Attempt queries by deployment ID on the hosted service if there are no active allocations on
+    /// the deployment.
+    #[serde(default)]
+    pub hosted_service_fallback: bool,
     /// Rounds of indexer selection and queries to attempt. Note that indexer queries have a 20s
     /// timeout, so setting this to 5 for example would result in a 100s worst case response time
     /// for a client query.

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -273,6 +273,7 @@ async fn main() {
         receipt_signer,
         kafka_client,
         budgeter,
+        hosted_service_fallback: config.hosted_service_fallback,
         indexer_selection_retry_limit: config.indexer_selection_retry_limit,
         l2_gateway: config.l2_gateway,
         chains: Box::leak(Box::new(Chains::new(config.chain_aliases))),


### PR DESCRIPTION
This adds an optional feature to attempt queries by deployment ID on the hosted service if there are no active allocations on the deployment. Under these conditions, a response with 200 status from the hosted service with be returned to the user. If any errors are encountered while attempting to query the hosted service, then the query will continue along the normal client query path.