### PR TITLE
chore(graph-gateway): enable secrets dependent integration tests in the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,31 @@ jobs:
       - run: cargo check
       - run: cargo clippy -- -D warnings
 
+      ## Tests
+      # Install sops (needed for decrypting tests .env file)
+      - name: Setup sops
+        uses: nhedger/setup-sops@358bac533e4e92f9ce9f9da563d6265929c88cda # v2
+
+      # Install age (needed for decrypting tests .env file)
+      - name: Setup age
+        uses: alessiodionisi/setup-age-action@82b9aea163ade7fe23441552a514cf666b214077 # v1.3.0
+        
       - name: Unit tests
-        run: cargo test --lib
+        uses: LNSD/sops-exec-action@6da1fbca63459d9796097496d5f5e6233555b31a # v1
+        env:
+          SOPS_AGE_KEY: ${{ secrets.IT_TESTS_AGE_KEY }}
+        with:
+          env_file: .env
+          run: cargo test --lib
 
       - name: Integration tests
-        run: cargo test --test '*'
+        uses: LNSD/sops-exec-action@6da1fbca63459d9796097496d5f5e6233555b31a # v1
+        env:
+          SOPS_AGE_KEY: ${{ secrets.IT_TESTS_AGE_KEY }}
+        with:
+          env_file: .env
+          run: cargo test --test '*'
+
   check_formatting:
     name: 'check formatting'
     runs-on: ubuntu-latest


### PR DESCRIPTION
The same way we did in the `edgeandnode/toolshed` repository's PR: https://github.com/edgeandnode/toolshed/pull/132

> Instead of adding every integration test environment variable to the GitHub actions secrets, this PR adds a _SOPS + Age_ encrypted environment file. This reduces the number of environment variables to add to the GHA secrets to 1: `IT_TESTS_AGE_KEY`.
> 
> As the file is encrypted with different Age recipients (read "public keys"), one can add a new environment variable using the `sops` command line and still be able to decrypt it locally and in the CI without the need for the GitHub repository admin rights. For now, the file is encrypted with the following recipients:
> 
> - GHA CI Age key: `age1r9h4sl458nt7f2j44tehw44xujg6rkp8w6vz7yp28aplf0aruq9qkvnapd`
> - LNSD Development key: `age1anjd9665wxhhumzfxyhwzrk6hsrhmvy8tfd3wwx5zjyausagruwql9354g`
> 
> In the CI, the environment is decrypted by the [sops-exec](https://github.com/marketplace/actions/sops-exec) action, which uses `sops` to decrypt and inject the encrypted environment variables into the _cargo test_ command's environment.
> 
> For more information about the tool and how to use it, see: https://github.com/getsops/sops

The cool part is that, now, the instructions on how to manage this encrypted file and how to run the tests locally can be found in the project documentation: https://github.com/edgeandnode/gateway/blob/main/docs/contributing.md#ci-secrets