### PR TITLE
fix: use {client,indexer}_request and request_id everywhere

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -32,7 +32,7 @@ use gateway_framework::{
         discovery::Status,
         indexing_performance::{IndexingPerformance, Snapshot},
     },
-    reporting::{with_metric, KafkaClient, METRICS},
+    reporting::{with_metric, KafkaClient, CLIENT_REQUEST_TARGET, INDEXER_REQUEST_TARGET, METRICS},
     scalar::{ReceiptStatus, ScalarReceipt},
     topology::network::{Deployment, GraphNetwork, Subgraph},
 };
@@ -170,7 +170,7 @@ pub async fn handle_query(
         };
         let (legacy_status_message, legacy_status_code) = reports::legacy_status(&result);
         tracing::info!(
-            target: reports::CLIENT_QUERY_TARGET,
+            target: CLIENT_REQUEST_TARGET,
             start_time_ms = timestamp,
             deployment,
             %status_message,
@@ -241,7 +241,7 @@ async fn handle_client_query_inner(
         .last()
         .map(|deployment| deployment.manifest.network.clone())
         .ok_or_else(|| Error::SubgraphNotFound(anyhow!("no matching deployments")))?;
-    tracing::info!(target: reports::CLIENT_QUERY_TARGET, subgraph_chain);
+    tracing::info!(target: CLIENT_REQUEST_TARGET, subgraph_chain);
 
     let manifest_min_block = deployments.last().unwrap().manifest.min_block;
     let chain = ctx.chains.chain(&subgraph_chain).await;
@@ -284,7 +284,7 @@ async fn handle_client_query_inner(
     let mut context = AgoraContext::new(&payload.query, &variables)
         .map_err(|err| Error::BadQuery(anyhow!("{err}")))?;
     tracing::info!(
-        target: reports::CLIENT_QUERY_TARGET,
+        target: CLIENT_REQUEST_TARGET,
         query = %payload.query,
         %variables,
     );
@@ -305,7 +305,7 @@ async fn handle_client_query_inner(
         budget = (*(user_budget_usd * grt_per_usd * one_grt) as u128).min(max_budget);
     }
     tracing::info!(
-        target: reports::CLIENT_QUERY_TARGET,
+        target: CLIENT_REQUEST_TARGET,
         query_count = 1,
         budget_grt = (budget as f64 * 1e-18) as f32,
     );
@@ -481,8 +481,8 @@ async fn handle_client_query_inner(
             // there's a race between creating this span and another indexer responding which will
             // close the outer client_query span.
             let span = tracing::info_span!(
-                target: reports::INDEXER_QUERY_TARGET,
-                "indexer_query",
+                target: INDEXER_REQUEST_TARGET,
+                "indexer_request",
                 indexer = ?selection.indexing.indexer,
             );
             let receipt_signer = ctx.receipt_signer;
@@ -511,7 +511,7 @@ async fn handle_client_query_inner(
         let total_indexer_fees_usd =
             USD(NotNan::new(total_indexer_fees_grt as f64 * 1e-18).unwrap() / grt_per_usd);
         tracing::info!(
-            target: reports::CLIENT_QUERY_TARGET,
+            target: CLIENT_REQUEST_TARGET,
             indexer_fees_grt = (total_indexer_fees_grt as f64 * 1e-18) as f32,
             indexer_fees_usd = *total_indexer_fees_usd.0 as f32,
         );
@@ -644,7 +644,7 @@ async fn handle_indexer_query(
 
     let latency_ms = ctx.response_time.as_millis() as u32;
     tracing::info!(
-        target: reports::INDEXER_QUERY_TARGET,
+        target: INDEXER_REQUEST_TARGET,
         %deployment,
         url = %selection.url,
         blocks_behind = selection.blocks_behind,
@@ -714,7 +714,7 @@ async fn handle_indexer_query_inner(
         .collect::<Vec<&str>>()
         .join("; ");
     tracing::info!(
-        target: reports::INDEXER_QUERY_TARGET,
+        target: INDEXER_REQUEST_TARGET,
         indexer_errors = errors_repr,
     );
 

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -2,7 +2,7 @@ use alloy_primitives::Address;
 use gateway_common::utils::timestamp::unix_timestamp;
 use gateway_framework::{
     errors::{self, IndexerError},
-    reporting::{error_log, KafkaClient},
+    reporting::{error_log, KafkaClient, CLIENT_REQUEST_TARGET, INDEXER_REQUEST_TARGET},
 };
 use prost::Message as _;
 use serde::Deserialize;
@@ -12,13 +12,10 @@ use toolshed::concat_bytes;
 
 use crate::indexer_client::ResponsePayload;
 
-pub const CLIENT_QUERY_TARGET: &str = "client_query";
-pub const INDEXER_QUERY_TARGET: &str = "indexer_query";
-
 pub fn report_client_query(kafka: &KafkaClient, fields: Map<String, serde_json::Value>) {
     #[derive(Deserialize)]
     struct Fields {
-        query_id: String,
+        request_id: String,
         graph_env: String,
         legacy_status_message: String,
         legacy_status_code: u32,
@@ -36,7 +33,7 @@ pub fn report_client_query(kafka: &KafkaClient, fields: Map<String, serde_json::
         Ok(fields) => fields,
         Err(err) => {
             error_log(
-                CLIENT_QUERY_TARGET,
+                CLIENT_REQUEST_TARGET,
                 &format!("failed to report client query: {}", err),
             );
             return;
@@ -48,13 +45,13 @@ pub fn report_client_query(kafka: &KafkaClient, fields: Map<String, serde_json::
 
     // data science: bigquery datasets still rely on this log line
     let log = serde_json::to_string(&json!({
-        "target": CLIENT_QUERY_TARGET,
+        "target": CLIENT_REQUEST_TARGET,
         "level": "INFO",
         "timestamp": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
         "fields": {
             "message": "Client query result",
-            "query_id": &fields.query_id,
-            "ray_id": &fields.query_id, // In production this will be the Ray ID.
+            "request_id": &fields.request_id,
+            "ray_id": &fields.request_id, // In production this will be the Ray ID.
             "deployment": fields.deployment.as_deref().unwrap_or(""),
             "network": fields.subgraph_chain.as_deref().unwrap_or(""),
             "user": &fields.user_address,
@@ -72,8 +69,8 @@ pub fn report_client_query(kafka: &KafkaClient, fields: Map<String, serde_json::
     println!("{log}");
 
     let kafka_msg = json!({
-        "query_id": &fields.query_id,
-        "ray_id": &fields.query_id, // In production this will be the Ray ID.
+        "request_id": &fields.request_id,
+        "ray_id": &fields.request_id, // In production this will be the Ray ID.
         "graph_env": &fields.graph_env,
         "timestamp": timestamp,
         "user": &fields.user_address,
@@ -98,7 +95,7 @@ pub fn report_client_query(kafka: &KafkaClient, fields: Map<String, serde_json::
 pub fn report_indexer_query(kafka: &KafkaClient, fields: Map<String, serde_json::Value>) {
     #[derive(Deserialize)]
     struct Fields {
-        query_id: String,
+        request_id: String,
         graph_env: String,
         api_key: Option<String>,
         user_address: Option<String>,
@@ -119,7 +116,7 @@ pub fn report_indexer_query(kafka: &KafkaClient, fields: Map<String, serde_json:
         Ok(fields) => fields,
         Err(err) => {
             error_log(
-                INDEXER_QUERY_TARGET,
+                INDEXER_REQUEST_TARGET,
                 &format!("failed to report indexer query: {}", err),
             );
             return;
@@ -128,13 +125,13 @@ pub fn report_indexer_query(kafka: &KafkaClient, fields: Map<String, serde_json:
 
     // data science: bigquery datasets still rely on this log line
     let log = serde_json::to_string(&json!({
-        "target": INDEXER_QUERY_TARGET,
+        "target": INDEXER_REQUEST_TARGET,
         "level": "INFO",
         "timestamp": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true),
         "fields": {
             "message": "Indexer attempt",
-            "query_id": &fields.query_id,
-            "ray_id": &fields.query_id, // In production this will be the Ray ID.
+            "request_id": &fields.request_id,
+            "ray_id": &fields.request_id, // In production this will be the Ray ID.
             "deployment": &fields.deployment,
             "indexer": &fields.indexer,
             "url": &fields.url,
@@ -153,8 +150,8 @@ pub fn report_indexer_query(kafka: &KafkaClient, fields: Map<String, serde_json:
     println!("{log}");
 
     let kafka_msg = json!({
-        "query_id": &fields.query_id,
-        "ray_id": &fields.query_id, // In production this will be the Ray ID.
+        "request_id": &fields.request_id,
+        "ray_id": &fields.request_id, // In production this will be the Ray ID.
         "graph_env": &fields.graph_env,
         "timestamp": unix_timestamp(),
         "api_key": fields.api_key.as_deref().unwrap_or(""),


### PR DESCRIPTION
Instead of having a mix of `client_query`, `client_request`, `indexer_query`, `indexer_request`, `query_id` and `request_id` all over the place."

This changes external logging and reporting in the following ways:
- It uses `client_request` and `indexer_request` instead of `client_query` and `indexer_query` as targets.
- It uses `request_id` instead of `query_id`

I'm not sure if this only fixes missing reports and query/request IDs or also fixes the missing API keys in reports. The way those are passed to reports should not have changed recently.