### PR TITLE
refactor(graph-gateway): encapsulate the auth service initialization

### DIFF
--- a/gateway-framework/src/auth/context.rs
+++ b/gateway-framework/src/auth/context.rs
@@ -76,6 +76,17 @@ impl AuthContext {
         }
     }
 
+    /// Waits for the API keys to be fetched.
+    ///
+    /// Internally, it waits for the `api_keys` eventual value to resolve.
+    pub async fn wait_for_api_keys(&self) -> anyhow::Result<()> {
+        self.api_keys
+            .value()
+            .await
+            .map_err(|_| anyhow::anyhow!("api keys fetch failed"))?;
+        Ok(())
+    }
+
     pub fn parse_auth_token(
         &self,
         input: &str,


### PR DESCRIPTION
This PR is a minor refactoring (read, gardening 🪴) that moves all the initialization logic of the `AuthContext` (a.k.a. auth service) inside a function in the `main.rs` file.

~The PR also introduces the following minor reliability/robustness change:~

~- [x] Concurrently wait for the studio API keys and subscriptions to be fetched with a timeout of the 90s. If the credentials fetch fails or takes more than the timeout, the gateway will panic, indicating the failure cause.~