### PR TITLE
feat: add sql enabled detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 [[package]]
 name = "cost-model"
 version = "0.1.0"
-source = "git+https://github.com/graphprotocol/agora?rev=3ed34ca#3ed34cae6dadded9c8c6ca34356309c98f0f0578"
+source = "git+https://github.com/graphprotocol/agora?rev=b824745#b8247452bd4774859671334c0ef6cab8103da854"
 dependencies = [
  "firestorm",
  "fraction",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ axum = { version = "0.7.5", default-features = false, features = [
     "original-uri",
 ] }
 candidate-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "ce9de97" }
-cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3ed34ca" }
+cost-model = { git = "https://github.com/graphprotocol/agora", rev = "b824745" }
 futures = "0.3"
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
 headers = "0.4.0"

--- a/gateway-framework/src/errors.rs
+++ b/gateway-framework/src/errors.rs
@@ -64,6 +64,9 @@ pub enum UnavailableReason {
     /// The indexer's cost model did not produce a fee for the GraphQL document.
     #[error("no fee")]
     NoFee,
+    /// The indexer is unable to receive SQL queries.
+    #[error("no sql")]
+    NoSql,
     /// The indexer did not have a block required by the query.
     #[error("missing block")]
     MissingBlock,

--- a/gateway-framework/src/network/discovery.rs
+++ b/gateway-framework/src/network/discovery.rs
@@ -8,4 +8,5 @@ pub struct Status {
     pub min_block: Option<BlockNumber>,
     pub cost_model: Option<Ptr<CostModel>>,
     pub legacy_scalar: bool,
+    pub sql_enabled: bool,
 }

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -9,7 +9,7 @@ alloy-sol-types.workspace = true
 anyhow.workspace = true
 axum = { workspace = true, features = ["tokio", "http1"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3ed34ca" }
+cost-model.workspace = true
 custom_debug = "0.6.1"
 eventuals = "0.6.7"
 futures.workspace = true


### PR DESCRIPTION
Looking to efforts to add [Subgraph Sql Service](https://github.com/graphprotocol/graph-node/pull/5382) to Graph Node, this PR enables detecting SQL queries and rejecting them for now.

