### PR TITLE
release 20.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "graph-gateway"
-version = "20.1.1"
+version = "20.1.2"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/gateway-framework/src/subscriptions/subgraph.rs
+++ b/gateway-framework/src/subscriptions/subgraph.rs
@@ -19,6 +19,7 @@ pub struct Client {
 impl Client {
     pub async fn create(
         subgraph_client: subgraph_client::Client,
+        allow_empty: bool,
     ) -> watch::Receiver<HashMap<Address, Subscription>> {
         let (tx, mut rx) = watch::channel(Default::default());
         let mut client = Client {
@@ -39,9 +40,11 @@ impl Client {
             }
         });
 
-        rx.wait_for(|subscriptions| !subscriptions.is_empty())
-            .await
-            .unwrap();
+        if !allow_empty {
+            rx.wait_for(|subscriptions| !subscriptions.is_empty())
+                .await
+                .unwrap();
+        }
         rx
     }
 

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "20.1.1"
+version = "20.1.2"
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -196,6 +196,9 @@ pub struct Subscriptions {
     /// e.g. If 0.01 USDC (6 decimals) is required per query per minute, then this should be set to
     /// 10000.
     pub rate_per_query: u128,
+    /// Allow startup with no active subscriptions.
+    #[serde(default)]
+    pub allow_empty: bool,
 }
 
 #[serde_as]

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -485,6 +485,7 @@ async fn init_auth_service(
                 )
                 .with_auth_token(subscriptions.ticket.clone())
                 .build(),
+                subscriptions.allow_empty,
             )
             .await
         }


### PR DESCRIPTION
# Release Notes
- fix(receipts): reduce legacy receipt overhead (#732)
- fix: reduce some unnecessary scheduler pressure (#727, #728, #729, #730, #733)
- update indexer-selection (#723)
  - use u16 for ms latency (https://github.com/edgeandnode/candidate-selection/commit/8b18b43b3a8c3cbf3cfeb5d935b1e898d9caf773)
  - rework perf decay (https://github.com/edgeandnode/candidate-selection/commit/f4f41e9c1d5a7f55f653a68fe24cb874df6c0748)
  - increase decay rate (https://github.com/edgeandnode/candidate-selection/commit/fa044123c57d0b8c3f0da3e1ba087de5de2f7bdc)
  - add slow decay frame (https://github.com/edgeandnode/candidate-selection/commit/303ea8806c58e501026c8db6fea9863517efe803)
  - use 99th percentile in slow frame (https://github.com/edgeandnode/candidate-selection/commit/396c112b8b36bb863f7a3fbdaeabb26762da3375)
  - remove alpha filter (https://github.com/edgeandnode/candidate-selection/commit/9737d6744cf90c4e71ac3862bd32cb925d2f0cc1)
