### PR TITLE
docs(metrics): fix broken link

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,4 +2,4 @@
 
 Prometheus metrics are served at `:${METRICS_PORT}/metrics`
 
-The available metrics are defined in [metrics.rs](../gateway-framework/src/metrics.rs).
+The available metrics are defined in [metrics.rs](../gateway-framework/src/reporting/metrics.rs). 


### PR DESCRIPTION
I was just reading through the docs and the [link to the metrics module](https://github.com/edgeandnode/gateway/blob/main/docs/metrics.md) in the metrics docs is incorrect. I guess the module must've been moved.