### PR TITLE
refactor(exchange_rate): replace eventual with watch

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -289,10 +289,7 @@ async fn handle_client_query_inner(
         %variables,
     );
 
-    let grt_per_usd = ctx
-        .grt_per_usd
-        .value_immediate()
-        .ok_or_else(|| Error::Internal(anyhow!("missing exchange rate")))?;
+    let grt_per_usd = *ctx.grt_per_usd.borrow();
     let one_grt = NotNan::new(1e18).unwrap();
     let mut budget = *(ctx.budgeter.query_fees_target.0 * grt_per_usd * one_grt) as u128;
     let query_settings = query_settings.unwrap_or_default();

--- a/graph-gateway/src/client_query/context.rs
+++ b/graph-gateway/src/client_query/context.rs
@@ -13,6 +13,7 @@ use gateway_framework::{
     topology::network::GraphNetwork,
 };
 use ordered_float::NotNan;
+use tokio::sync::watch;
 use url::Url;
 
 use crate::indexer_client::IndexerClient;
@@ -25,7 +26,7 @@ pub struct Context {
     pub budgeter: &'static Budgeter,
     pub indexer_selection_retry_limit: usize,
     pub l2_gateway: Option<Url>,
-    pub grt_per_usd: Eventual<NotNan<f64>>,
+    pub grt_per_usd: watch::Receiver<NotNan<f64>>,
     pub chains: &'static Chains,
     pub network: GraphNetwork,
     pub indexing_statuses: Eventual<Ptr<HashMap<Indexing, Status>>>,


### PR DESCRIPTION
This is the first step in my intentions to move away from eventuals. Based on how we use them, they provide little value while making it difficult to observe using standard tokio runtime tools.