### PR TITLE
fix(receipts): reduce legacy receipt overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "receipts"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/receipts?rev=b12e197#b12e1971db9aac813a339e1ac75178a7cb3883bd"
+source = "git+https://github.com/edgeandnode/receipts?rev=e94e0f1#e94e0f11c41632328b349394b15c3d93fbda1d4b"
 dependencies = [
  "itertools 0.12.1",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hex = "0.4"
 indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "9737d67" }
 primitive-types = "0.12.2"
 rand = { version = "0.8", features = ["small_rng"] }
-receipts = { git = "https://github.com/edgeandnode/receipts", rev = "b12e197" }
+receipts = { git = "https://github.com/edgeandnode/receipts", rev = "e94e0f1" }
 reqwest = { version = "0.12", default-features = false, features = [
     "json",
     "default-tls",


### PR DESCRIPTION
- remove the redundant allocations tracking in the receipts lib
- stop holding `legacy_pools` read lock while waiting for inner mutex
- stop duplicating the signer key for all receipt pools