### PR TITLE
fix: inefficiencies in processing Agora contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 [[package]]
 name = "cost-model"
 version = "0.1.0"
-source = "git+https://github.com/graphprotocol/agora?rev=50bb942#50bb94235b10cb8eb13e3f09a324e90724396d57"
+source = "git+https://github.com/graphprotocol/agora?rev=deacb09#deacb0907e660a430009fed16c128a8a79d26233"
 dependencies = [
  "firestorm",
  "fraction",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.5",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -201,7 +201,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.5",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.4.0",
@@ -234,7 +234,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -246,7 +246,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -271,7 +271,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.5",
+ "num-bigint",
 ]
 
 [[package]]
@@ -826,7 +826,7 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 [[package]]
 name = "cost-model"
 version = "0.1.0"
-source = "git+https://github.com/graphprotocol/agora?rev=3ed34ca#3ed34cae6dadded9c8c6ca34356309c98f0f0578"
+source = "git+https://github.com/graphprotocol/agora?rev=50bb942#50bb94235b10cb8eb13e3f09a324e90724396d57"
 dependencies = [
  "firestorm",
  "fraction",
@@ -834,7 +834,7 @@ dependencies = [
  "itertools 0.12.1",
  "lazy_static",
  "nom",
- "num-bigint 0.2.6",
+ "num-bigint",
  "num-traits",
  "serde_json",
 ]
@@ -1666,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.6.3"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27f0e7512f6915c9bc38594725e33d7673da9308fea0abf4cc258c281cdbb2a"
+checksum = "0f158e3ff0a1b334408dc9fb811cd99b446986f4d8b741bb08f9df1604085ae7"
 dependencies = [
  "lazy_static",
  "num",
@@ -2897,26 +2897,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.2.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint 0.2.6",
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -2932,11 +2921,10 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -2968,12 +2956,11 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3951,7 +3938,7 @@ dependencies = [
  "ark-ff 0.4.2",
  "bytes",
  "fastrlp",
- "num-bigint 0.4.5",
+ "num-bigint",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
@@ -4466,7 +4453,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint",
  "num-traits",
  "thiserror",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ axum = { git = "https://github.com/tokio-rs/axum", rev = "50c035c", default-feat
     "tokio",
     "original-uri",
 ] }
-cost-model = { git = "https://github.com/graphprotocol/agora", rev = "50bb942" }
+cost-model = { git = "https://github.com/graphprotocol/agora", rev = "deacb09" }
 futures = "0.3"
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
 headers = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ axum = { git = "https://github.com/tokio-rs/axum", rev = "50c035c", default-feat
     "tokio",
     "original-uri",
 ] }
-cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3ed34ca" }
+cost-model = { git = "https://github.com/graphprotocol/agora", rev = "50bb942" }
 futures = "0.3"
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
 headers = "0.4.0"

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -9,7 +9,7 @@ alloy-sol-types.workspace = true
 anyhow.workspace = true
 axum = { workspace = true, features = ["tokio", "http1"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-cost-model = { git = "https://github.com/graphprotocol/agora", rev = "3ed34ca" }
+cost-model.workspace = true
 custom_debug = "0.6.1"
 eventuals = "0.6.7"
 futures.workspace = true

--- a/graph-gateway/src/block_constraints.rs
+++ b/graph-gateway/src/block_constraints.rs
@@ -206,7 +206,7 @@ pub fn rewrite_query<'q>(
                 } else if let Some(block) = &latest_block {
                     write!(buf, "{{ hash: \"{}\" }}", block.hash).unwrap();
                 } else {
-                    buf.push_str("{}");
+                    buf.push_str("null");
                 }
                 for (name, value) in &field.arguments {
                     if *name != "block" {


### PR DESCRIPTION
This changes the Agora context to only rely on a `&str` into the client request document to avoid unnecessary `String` allocations, and removes the need to copy the context for every indexer selected. Most of the changes are dedicated to indexer request rewrites, to avoid the need for `Context<_, String>`, while relying on `graphql_parser` to serialize everything below the top-level selection set fields.