### PR TITLE
chore(graph-gateway): handle query response errors

### DIFF
--- a/graph-gateway/src/indexers/public_poi.rs
+++ b/graph-gateway/src/indexers/public_poi.rs
@@ -77,8 +77,11 @@ pub async fn merge_queries(
 
     let response_map: HashMap<(DeploymentId, BlockNumber), ProofOfIndexing> = responses
         .into_iter()
-        // TODO: Handle errors (e.g., log them with trace level).
-        .filter_map(|response| response.ok())
+        .filter_map(|response| {
+            response
+                .map_err(|e| tracing::trace!("Error querying public proof of indexing: {}", e))
+                .ok()
+        })
         .flat_map(|response| response.public_proofs_of_indexing)
         .filter_map(|response| {
             // If the response is missing the POI field, skip it.


### PR DESCRIPTION
This checks off a `TODO` in the code, logging query response errors at trace level when merging.

Signed-off-by: Joseph Livesey [joseph@semiotic.ai](mailto:joseph@semiotic.ai)