### PR TITLE
chore(graph-gateway): do not pretty print config to logs

### DIFF
--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -91,7 +91,7 @@ async fn main() {
         .clone()
         .unwrap_or_else(|| Uuid::new_v4().to_string());
 
-    let config_repr = format!("{config:#?}");
+    let config_repr = format!("{config:?}");
 
     // Instantiate the Kafka client
     let kafka_client: &'static KafkaClient = match KafkaClient::new(&config.kafka.into()) {


### PR DESCRIPTION
The pretty formatting of the config string makes the logs hard to read. Here's a snippet of the JSON:

```json
{"config":"Config {\n    api_keys: Some(\n        Endpoint {\n            url: Url {\n                scheme: \"https\",\n                cannot_be_a_base: false,\n                username: \"\",\n                password: None,\n                host: Some(\n                    Domain(\n                        
```

Signed-off-by: Joseph Livesey [joseph@semiotic.ai](mailto:joseph@semiotic.ai)