### PR TITLE
feat(graph-gateway): debounce network indexer info resolution errors

### DIFF
--- a/gateway-common/src/caching.rs
+++ b/gateway-common/src/caching.rs
@@ -1,0 +1,109 @@
+//! Cache related types and traits.
+
+use std::ops::Deref;
+
+/// The [`Freshness`] type represents the freshness of the data returned by the resolver's cache:
+/// all the data returned by the resolver is either [`Fresh`](Freshness::Fresh)
+/// or [`Cached`](Freshness::Cached).
+///
+/// If the data is fresh, it means that the data was successfully fetched. Otherwise, after
+/// failing to fetch the data, the data was returned from the cache.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Freshness<T> {
+    /// The data is fresh.
+    ///
+    /// The data was successfully fetched from the indexer.
+    Fresh(T),
+    /// The data was fetched from the cache.
+    ///
+    /// In the case the resolver failed to fetch the data, it returned the cached data.
+    Cached(T),
+}
+
+impl<T> Freshness<T> {
+    /// Returns `true` if the data is fresh.
+    ///
+    /// See also [`is_cached`](Freshness::is_cached).
+    #[must_use]
+    #[inline]
+    pub fn is_fresh(&self) -> bool {
+        matches!(self, Freshness::Fresh(_))
+    }
+
+    /// Returns `true` if the data was fetched from the cache.
+    ///
+    /// See also [`is_fresh`](Freshness::is_fresh).
+    #[must_use]
+    #[inline]
+    pub fn is_cached(&self) -> bool {
+        matches!(self, Freshness::Cached(_))
+    }
+
+    /// If the data is fresh, returns `Some` with the data, otherwise returns `None`.
+    ///
+    /// See also [`as_cached`](Freshness::as_cached).
+    #[must_use]
+    #[inline]
+    pub fn as_fresh(&self) -> Option<&T> {
+        match self {
+            Freshness::Fresh(data) => Some(data),
+            Freshness::Cached(_) => None,
+        }
+    }
+
+    /// If the data was fetched from the cache, returns `Some`, otherwise returns `None`.
+    ///
+    /// See also [`as_fresh`](Freshness::as_fresh).
+    #[must_use]
+    #[inline]
+    pub fn as_cached(&self) -> Option<&T> {
+        match self {
+            Freshness::Fresh(_) => None,
+            Freshness::Cached(data) => Some(data),
+        }
+    }
+
+    /// Converts from `DataFreshness<T>` to `DataFreshness<&T>`.
+    #[must_use]
+    #[inline]
+    pub fn as_ref(&self) -> Freshness<&T> {
+        match *self {
+            Freshness::Fresh(ref data) => Freshness::Fresh(data),
+            Freshness::Cached(ref data) => Freshness::Cached(data),
+        }
+    }
+
+    /// Returns the contained data, consuming the `self` value.
+    #[must_use]
+    #[inline]
+    pub fn into_inner(self) -> T {
+        match self {
+            Freshness::Fresh(data) | Freshness::Cached(data) => data,
+        }
+    }
+
+    /// Maps a `Freshness<T>` to `Fresnes<U>` by applying a function to a contained value.
+    #[must_use]
+    #[inline]
+    pub fn map<U, F>(self, f: F) -> Freshness<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            Freshness::Fresh(data) => Freshness::Fresh(f(data)),
+            Freshness::Cached(data) => Freshness::Cached(f(data)),
+        }
+    }
+}
+
+impl<T> Deref for Freshness<T> {
+    type Target = T;
+
+    #[must_use]
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Freshness::Fresh(data) | Freshness::Cached(data) => data,
+        }
+    }
+}

--- a/gateway-common/src/lib.rs
+++ b/gateway-common/src/lib.rs
@@ -1,6 +1,5 @@
-extern crate core;
-
 pub mod blocklist;
+pub mod caching;
 pub mod ptr;
 pub mod ttl_hash_map;
 pub mod utils;

--- a/graph-gateway/src/network.rs
+++ b/graph-gateway/src/network.rs
@@ -2,6 +2,10 @@
 //! provides information about the subgraphs (and subgraph deployments) registered in the network
 //! smart contract, as well as the indexers that are indexing them.
 
+pub use internal::{
+    DeploymentError, Indexer, IndexerError, Indexing, IndexingError, IndexingId, SubgraphError,
+    UnavailableReason,
+};
 pub use service::{
     NetworkService, NetworkServiceBuilder, NetworkServicePending, ResolvedSubgraphInfo,
 };

--- a/graph-gateway/src/network/indexer_indexing_cost_model_resolver.rs
+++ b/graph-gateway/src/network/indexer_indexing_cost_model_resolver.rs
@@ -4,13 +4,22 @@
 
 use std::{collections::HashMap, time::Duration};
 
+use eventuals::Ptr;
+use gateway_common::ttl_hash_map::TtlHashMap;
 use thegraph_core::types::DeploymentId;
+use tokio::sync::RwLock;
 use url::Url;
 
 use crate::{indexers, indexers::cost_models::CostModelSource};
 
 /// The default timeout for the indexer indexings' cost model resolution.
 pub const DEFAULT_INDEXER_INDEXING_COST_MODEL_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The default TTL (time-to-live) for the cached indexer's cost model sources: 5 minutes.
+///
+/// The cache TTL is the maximum time that the cached cost model sources are valid.
+pub const DEFAULT_INDEXER_INDEXING_COST_MODEL_RESOLUTION_CACHE_TTL: Duration =
+    Duration::from_secs(300);
 
 /// Error that can occur during cost model resolution.
 #[derive(Debug, thiserror::Error)]
@@ -29,6 +38,7 @@ pub enum ResolutionError {
 pub struct CostModelResolver {
     client: reqwest::Client,
     timeout: Duration,
+    cache: RwLock<TtlHashMap<(String, DeploymentId), Ptr<CostModelSource>>>,
 }
 
 impl CostModelResolver {
@@ -37,15 +47,26 @@ impl CostModelResolver {
         Self {
             client,
             timeout: DEFAULT_INDEXER_INDEXING_COST_MODEL_RESOLUTION_TIMEOUT,
+            cache: RwLock::new(TtlHashMap::with_ttl(
+                DEFAULT_INDEXER_INDEXING_COST_MODEL_RESOLUTION_CACHE_TTL,
+            )),
         }
     }
 
-    /// Creates a new [`CostModelResolver`] with the given HTTP client and timeout.
-    pub fn with_timeout(client: reqwest::Client, timeout: Duration) -> Self {
-        Self { client, timeout }
+    /// Creates a new [`CostModelResolver`] with the given HTTP client, timeout, and cache TTL.
+    pub fn with_timeout_and_cache_ttl(
+        client: reqwest::Client,
+        timeout: Duration,
+        cache_ttl: Duration,
+    ) -> Self {
+        Self {
+            client,
+            timeout,
+            cache: RwLock::new(TtlHashMap::with_ttl(cache_ttl)),
+        }
     }
 
-    async fn resolve_cost_model(
+    async fn fetch_cost_model_sources(
         &self,
         url: &Url,
         indexings: &[DeploymentId],
@@ -61,6 +82,99 @@ impl CostModelResolver {
         .map_err(ResolutionError::FetchError)
     }
 
+    /// Gets the cached cost model sources for the given indexings.
+    ///
+    /// This method locks the cache in read mode and returns the cached data for the given URL and
+    /// given indexings.
+    async fn get_from_cache(
+        &self,
+        url: &str,
+        indexings: impl IntoIterator<Item = &DeploymentId>,
+    ) -> HashMap<DeploymentId, Ptr<CostModelSource>> {
+        let read_cache = self.cache.read().await;
+        let mut result = HashMap::new();
+
+        for deployment in indexings {
+            match read_cache.get(&(url.to_owned(), *deployment)) {
+                Some(data) => {
+                    result.insert(*deployment, data.clone());
+                }
+                None => continue,
+            }
+        }
+
+        result
+    }
+
+    /// Updates the cache with the given cost model sources.
+    ///
+    /// This method locks the cache in write mode and updates the cache with the given progress
+    /// information.
+    async fn update_cache(
+        &self,
+        url: &str,
+        progress: &HashMap<DeploymentId, Ptr<CostModelSource>>,
+    ) {
+        let mut write_cache = self.cache.write().await;
+        for (deployment, data) in progress.iter() {
+            write_cache.insert((url.to_owned(), *deployment), data.clone());
+        }
+    }
+
+    /// Resolves the indexing progress of the given deployments.
+    ///
+    /// If the request successfully returns the data, the cached data is updated and the new data is
+    /// returned, otherwise the cached data is returned.
+    async fn resolve_with_cache(
+        &self,
+        url: &Url,
+        indexings: &[DeploymentId],
+    ) -> Result<HashMap<DeploymentId, Ptr<CostModelSource>>, ResolutionError> {
+        let url_string = url.to_string();
+
+        let fetched = match self.fetch_cost_model_sources(url, indexings).await {
+            Ok(fetched) => fetched.into_iter().map(Ptr::new).collect::<Vec<_>>(),
+            Err(err) => {
+                tracing::debug!(error=%err, "cost model sources fetch failed");
+
+                // If the data fetch failed, return the cached data
+                // If no cached data is available, return the error
+                let cached_progress = self.get_from_cache(&url_string, indexings).await;
+                return if cached_progress.is_empty() {
+                    Err(err)
+                } else {
+                    Ok(cached_progress)
+                };
+            }
+        };
+
+        let fresh_sources = fetched
+            .into_iter()
+            .map(|resp| (resp.deployment, resp))
+            .collect::<HashMap<_, _>>();
+
+        // Update the cache with the fetched data, if any
+        if !fresh_sources.is_empty() {
+            self.update_cache(&url_string, &fresh_sources).await;
+        }
+
+        // Get the cached data for the missing deployments
+        let cached_sources = {
+            // Get the list of deployments that are missing from the fetched data
+            let missing_indexings = fresh_sources
+                .keys()
+                .filter(|deployment| !indexings.contains(deployment));
+
+            // Get the cached data for the missing deployments
+            self.get_from_cache(&url_string, missing_indexings).await
+        };
+
+        // Merge the fetched and cached data
+        let fresh_sources = fresh_sources.into_iter();
+        let cached_progress = cached_sources.into_iter();
+        Ok(HashMap::from_iter(cached_progress.chain(fresh_sources)))
+    }
+
     /// Fetches the cost model sources for the given deployments from the indexer.
     ///
     /// Returns a map of deployment IDs to the retrieved cost model sources. If certain deployment
@@ -69,17 +183,7 @@ impl CostModelResolver {
         &self,
         url: &Url,
         indexings: &[DeploymentId],
-    ) -> anyhow::Result<HashMap<DeploymentId, CostModelSource>> {
-        let sources = self
-            .resolve_cost_model(url, indexings)
-            .await?
-            .into_iter()
-            .map(|model| {
-                let deployment_id = model.deployment;
-                (deployment_id, model)
-            })
-            .collect::<HashMap<_, _>>();
-
-        Ok(sources)
+    ) -> Result<HashMap<DeploymentId, Ptr<CostModelSource>>, ResolutionError> {
+        self.resolve_with_cache(url, indexings).await
     }
 }

--- a/graph-gateway/src/network/indexer_version_resolver.rs
+++ b/graph-gateway/src/network/indexer_version_resolver.rs
@@ -7,17 +7,20 @@
 //! The resolver will perform better if the client provided has a connection pool with the different
 //! indexers, as it will be able to reuse already established connections.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
+use gateway_common::ttl_hash_map::TtlHashMap;
 use semver::Version;
+use tokio::sync::RwLock;
 use url::Url;
 
 use crate::indexers;
 
-/// The default indexer version resolution timeout.
-///
-/// This timeout is applied \*independently\* for the agent and graph node versions fetches.
+/// The default indexer version resolution timeout: 1.5 seconds.
 pub const DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(1_500);
+
+/// The default TTL (time-to-live) for cache entries: 20 minutes.
+pub const DEFAULT_INDEXER_VERSION_CACHE_TTL: Duration = Duration::from_secs(20 * 60);
 
 /// The error that can occur while resolving the indexer versions.
 #[derive(Debug, thiserror::Error)]
@@ -50,28 +53,68 @@ pub struct VersionResolver {
     agent_version_resolution_timeout: Duration,
     /// The indexer graph-node version resolution timeout.
     graph_node_version_resolution_timeout: Duration,
+
+    /// Cache for the resolved indexer agent versions.
+    agent_version_cache: Arc<RwLock<TtlHashMap<String, Version>>>,
+    /// Cache for the resolved indexer graph-node versions.
+    graph_node_version_cache: Arc<RwLock<TtlHashMap<String, Version>>>,
 }
 
 impl VersionResolver {
     /// Creates a new [`VersionResolver`] instance with the provided client.
     ///
     /// The resolver will use the default indexer version resolution timeout,
-    /// [`DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT`].
+    /// [`DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT`] (1.5 seconds), and cache TTL,
+    /// [`DEFAULT_INDEXER_VERSION_CACHE_TTL`] (20 minutes).
     pub fn new(client: reqwest::Client) -> Self {
         Self {
             client,
             agent_version_resolution_timeout: DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT,
             graph_node_version_resolution_timeout: DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT,
+            agent_version_cache: Arc::new(RwLock::new(TtlHashMap::with_ttl(
+                DEFAULT_INDEXER_VERSION_CACHE_TTL,
+            ))),
+            graph_node_version_cache: Arc::new(RwLock::new(TtlHashMap::with_ttl(
+                DEFAULT_INDEXER_VERSION_CACHE_TTL,
+            ))),
         }
     }
 
-    /// Creates a new [`VersionResolver`] instance with the provided client and timeout.
-    pub fn with_timeout(client: reqwest::Client, timeout: Duration) -> Self {
+    /// Creates a new [`VersionResolver`] instance with the provided client, timeout and cache TTL.
+    pub fn with_timeout_and_cache_ttl(
+        client: reqwest::Client,
+        timeout: Duration,
+        cache_ttl: Duration,
+    ) -> Self {
         Self {
             client,
             agent_version_resolution_timeout: timeout,
             graph_node_version_resolution_timeout: timeout,
+            agent_version_cache: Arc::new(RwLock::new(TtlHashMap::with_ttl(cache_ttl))),
+            graph_node_version_cache: Arc::new(RwLock::new(TtlHashMap::with_ttl(cache_ttl))),
         }
+    }
+
+    /// Fetches the indexer agent version from the given URL.
+    async fn fetch_agent_version(&self, url: &Url) -> Result<Version, ResolutionError> {
+        tokio::time::timeout(
+            self.agent_version_resolution_timeout,
+            indexers::version::query_indexer_service_version(&self.client, url.clone()),
+        )
+        .await
+        .map_err(|_| ResolutionError::Timeout)?
+        .map_err(ResolutionError::FetchError)
+    }
+
+    /// Fetches the indexer graph-node version from the given URL.
+    async fn fetch_graph_node_version(&self, url: &Url) -> Result<Version, ResolutionError> {
+        tokio::time::timeout(
+            self.graph_node_version_resolution_timeout,
+            indexers::version::query_graph_node_version(&self.client, url.clone()),
+        )
+        .await
+        .map_err(|_| ResolutionError::Timeout)?
+        .map_err(ResolutionError::FetchError)
     }
 
     /// Resolves the indexer agent version.
@@ -79,33 +122,71 @@ impl VersionResolver {
     /// The version resolution time is upper-bounded by the configured timeout.
     pub async fn resolve_agent_version(&self, url: &Url) -> Result<Version, ResolutionError> {
         let indexer_agent_version_url = indexers::version_url(url);
+        let indexer_agent_version_url_string = indexer_agent_version_url.to_string();
 
-        tokio::time::timeout(
-            self.agent_version_resolution_timeout,
-            indexers::version::query_indexer_service_version(
-                &self.client,
-                indexer_agent_version_url,
-            ),
-        )
-        .await
-        .map_err(|_| ResolutionError::Timeout)?
-        .map_err(ResolutionError::FetchError)
+        let version = match self.fetch_agent_version(&indexer_agent_version_url).await {
+            Ok(version) => version,
+            Err(err) => {
+                tracing::debug!(
+                    version_url = indexer_agent_version_url_string,
+                    error = ?err,
+                    "indexer agent version resolution failed"
+                );
+
+                // Try to get the version from the cache, otherwise return the fetch error
+                let cache = self.agent_version_cache.read().await;
+                return if let Some(version) = cache.get(&indexer_agent_version_url_string) {
+                    Ok(version.clone())
+                } else {
+                    Err(err)
+                };
+            }
+        };
+
+        // Update the cache with the resolved version
+        {
+            let mut cache = self.agent_version_cache.write().await;
+            cache.insert(indexer_agent_version_url_string, version.clone());
+        }
+
+        Ok(version)
     }
 
     /// Resolves the indexer graph-node version.
     ///
     /// The version resolution time is upper-bounded by the configured timeout.
     pub async fn resolve_graph_node_version(&self, url: &Url) -> Result<Version, ResolutionError> {
-        let indexer_graph_node_version_url = indexers::status_url(url);
-        tokio::time::timeout(
-            self.graph_node_version_resolution_timeout,
-            indexers::version::query_graph_node_version(
-                &self.client,
-                indexer_graph_node_version_url,
-            ),
-        )
-        .await
-        .map_err(|_| ResolutionError::Timeout)?
-        .map_err(ResolutionError::FetchError)
+        let indexer_graph_node_version_url = indexers::version_url(url);
+        let indexer_graph_node_version_url_string = indexer_graph_node_version_url.to_string();
+
+        let version = match self
+            .fetch_graph_node_version(&indexer_graph_node_version_url)
+            .await
+        {
+            Ok(version) => version,
+            Err(err) => {
+                tracing::debug!(
+                    version_url = indexer_graph_node_version_url_string,
+                    error = ?err,
+                    "indexer graph-node version resolution failed"
+                );
+
+                // Try to get the version from the cache, otherwise return the fetch error
+                let cache = self.graph_node_version_cache.read().await;
+                return if let Some(version) = cache.get(&indexer_graph_node_version_url_string) {
+                    Ok(version.clone())
+                } else {
+                    Err(err)
+                };
+            }
+        };
+
+        // Update the cache with the resolved version
+        {
+            let mut cache = self.graph_node_version_cache.write().await;
+            cache.insert(indexer_graph_node_version_url_string, version.clone());
+        }
+
+        Ok(version)
     }
 }

--- a/graph-gateway/src/network/internal.rs
+++ b/graph-gateway/src/network/internal.rs
@@ -15,6 +15,7 @@ pub use self::{
     },
     snapshot::{
         Indexer, Indexing, IndexingError, IndexingId, IndexingProgress, NetworkTopologySnapshot,
+        UnavailableReason,
     },
     state::InternalState,
     subgraph_processing::{

--- a/graph-gateway/src/network/internal/tests/indexer_processing.rs
+++ b/graph-gateway/src/network/internal/tests/indexer_processing.rs
@@ -19,7 +19,10 @@ use crate::network::{
     indexer_indexing_cost_model_compiler::CostModelCompiler,
     indexer_indexing_cost_model_resolver::CostModelResolver,
     indexer_indexing_progress_resolver::IndexingProgressResolver,
-    indexer_version_resolver::{VersionResolver, DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT},
+    indexer_version_resolver::{
+        VersionResolver, DEFAULT_INDEXER_VERSION_CACHE_TTL,
+        DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT,
+    },
     internal::{
         indexer_processing::{self, IndexerIndexingRawInfo, IndexerRawInfo},
         IndexerError, InternalState, VersionRequirements as IndexerVersionRequirements,
@@ -67,9 +70,10 @@ fn test_service_state(
     let indexers_http_client = reqwest::Client::new();
     let indexer_host_resolver =
         Mutex::new(HostResolver::new().expect("Failed to create host resolver"));
-    let indexer_version_resolver = VersionResolver::with_timeout(
+    let indexer_version_resolver = VersionResolver::with_timeout_and_cache_ttl(
         indexers_http_client.clone(),
         DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT, // 1500 ms
+        DEFAULT_INDEXER_VERSION_CACHE_TTL,          // 20 minutes
     );
     let indexer_indexing_progress_resolver =
         IndexingProgressResolver::new(indexers_http_client.clone());

--- a/graph-gateway/tests/it_network_internal_fetch_update.rs
+++ b/graph-gateway/tests/it_network_internal_fetch_update.rs
@@ -8,7 +8,7 @@ use graph_gateway::network::{
     indexer_indexing_cost_model_compiler::CostModelCompiler,
     indexer_indexing_cost_model_resolver::CostModelResolver,
     indexer_indexing_progress_resolver::IndexingProgressResolver,
-    indexer_version_resolver::{VersionResolver, DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT},
+    indexer_version_resolver::VersionResolver,
     internal::{
         fetch_update as internal_fetch_update, IndexingError, InternalState,
         NetworkTopologySnapshot,
@@ -65,10 +65,7 @@ fn test_service_state(
     let indexers_http_client = reqwest::Client::new();
     let indexer_host_resolver =
         Mutex::new(HostResolver::new().expect("Failed to create host resolver"));
-    let indexer_version_resolver = VersionResolver::with_timeout(
-        indexers_http_client.clone(),
-        DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT, // 1500 ms
-    );
+    let indexer_version_resolver = VersionResolver::new(indexers_http_client.clone());
     let indexer_indexing_progress_resolver =
         IndexingProgressResolver::new(indexers_http_client.clone());
     let indexer_indexing_cost_model_resolver = (


### PR DESCRIPTION
The indexer's information resolution process is susceptible to errors. For instance, an indexer can be overloaded and fail to respond at a specific moment, marking it as unavailable.

To prevent these information resolution errors from affecting the gateway's normal performance. To mitigate this issue, a TTL-limited caching mechanism has been implemented for different indexer information resolvers.

- The cache info is updated/refreshed if the info fetch is successful.
- If the info fetch fails, the data is fetched from the cache; if it is unavailable (or has expired), the fetch error is returned.

This PR is one of the remaining pieces of work before integrating the `network` service into the gateway.