### PR TITLE
feat(gateway-common): add cheap clone and compare ptr type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ name = "gateway-common"
 version = "0.0.1"
 dependencies = [
  "alloy-primitives",
+ "by_address",
  "headers",
  "http 1.1.0",
  "siphasher 1.0.1",

--- a/gateway-common/Cargo.toml
+++ b/gateway-common/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.1"
 
 [dependencies]
 alloy-primitives.workspace = true
+by_address = "1.2.1"
 headers.workspace = true
 http = "1.1.0"
 siphasher.workspace = true

--- a/gateway-common/src/lib.rs
+++ b/gateway-common/src/lib.rs
@@ -1,3 +1,6 @@
+extern crate core;
+
 pub mod blocklist;
+pub mod ptr;
 pub mod ttl_hash_map;
 pub mod utils;

--- a/gateway-common/src/ptr.rs
+++ b/gateway-common/src/ptr.rs
@@ -1,0 +1,146 @@
+//! The [`Ptr`] type is a thin wrapper around `T` to enable cheap clone and comparisons.
+//!
+//! Internally it contains an [`Arc`] that is compared by address instead of by the implementation
+//! of the pointed to value.
+
+// The present piece of code is a modified version of the `eventuals` crate
+// (https://crates.io/crates/eventuals) which is licensed under the MIT license.
+//
+// The original code can be found at:
+// https://github.com/edgeandnode/eventuals/blob/2b552f5257a59c8e50f2adb74952059152307b8f/src/eventual/ptr.rs
+
+use core::fmt;
+use std::{
+    borrow::Borrow,
+    cmp::Ordering,
+    convert::AsRef,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    sync::Arc,
+};
+
+use by_address::ByAddress;
+
+/// a thin wrapper around T to enable cheap clone and comparisons.
+#[repr(transparent)]
+#[derive(Default)]
+pub struct Ptr<T: ?Sized> {
+    inner: ByAddress<Arc<T>>,
+}
+
+impl<T> Ptr<T> {
+    /// Constructs a new `Ptr<T>`.
+    #[inline]
+    pub fn new(wrapped: T) -> Self {
+        Self {
+            inner: ByAddress(Arc::new(wrapped)),
+        }
+    }
+}
+
+impl<T: ?Sized> Deref for Ptr<T> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.inner.deref()
+    }
+}
+
+impl<T: ?Sized> Borrow<T> for Ptr<T> {
+    #[inline]
+    fn borrow(&self) -> &T {
+        self.inner.borrow()
+    }
+}
+
+impl<T: ?Sized> AsRef<T> for Ptr<T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        Arc::as_ref(&self.inner)
+    }
+}
+
+impl<T: ?Sized + Hash> Hash for Ptr<T> {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.hash(state)
+    }
+}
+
+impl<T: ?Sized + PartialEq> PartialEq for Ptr<T> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.eq(&other.inner)
+    }
+}
+
+impl<T: ?Sized + PartialOrd> PartialOrd for Ptr<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.inner.partial_cmp(&other.inner)
+    }
+}
+
+impl<T: ?Sized + Ord> Ord for Ptr<T> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.inner.cmp(&other.inner)
+    }
+}
+
+impl<T: ?Sized + Eq> Eq for Ptr<T> {}
+
+impl<T> Clone for Ptr<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T: ?Sized + fmt::Display> fmt::Display for Ptr<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for Ptr<T> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+impl<T: ?Sized> fmt::Pointer for Ptr<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Arc::fmt(&self.inner, f)
+    }
+}
+
+impl<T: ?Sized> From<ByAddress<Arc<T>>> for Ptr<T> {
+    #[inline]
+    fn from(inner: ByAddress<Arc<T>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T: ?Sized> From<Arc<T>> for Ptr<T> {
+    #[inline]
+    fn from(arc: Arc<T>) -> Self {
+        Self {
+            inner: ByAddress(arc),
+        }
+    }
+}
+
+impl<T> From<T> for Ptr<T> {
+    /// Converts a `T` into an `Ptr<T>`
+    ///
+    /// The conversion moves the value into a newly allocated `Ptr`. It is equivalent to
+    /// calling `Ptr::new(t)`.
+    #[inline]
+    fn from(t: T) -> Self {
+        Self::new(t)
+    }
+}

--- a/graph-gateway/src/network/indexer_indexing_cost_model_compiler.rs
+++ b/graph-gateway/src/network/indexer_indexing_cost_model_compiler.rs
@@ -9,8 +9,7 @@
 use std::time::Duration;
 
 use cost_model::{CompileError, CostModel};
-use eventuals::Ptr;
-use gateway_common::ttl_hash_map::TtlHashMap;
+use gateway_common::{ptr::Ptr, ttl_hash_map::TtlHashMap};
 
 use crate::indexers::cost_models::CostModelSource;
 

--- a/graph-gateway/src/network/internal/indexer_processing.rs
+++ b/graph-gateway/src/network/internal/indexer_processing.rs
@@ -6,8 +6,7 @@ use std::{
 use alloy_primitives::{Address, BlockNumber};
 use cost_model::CostModel;
 use custom_debug::CustomDebug;
-use eventuals::Ptr;
-use gateway_common::blocklist::Blocklist as _;
+use gateway_common::{blocklist::Blocklist as _, ptr::Ptr};
 use semver::Version;
 use thegraph_core::types::DeploymentId;
 use tokio::sync::Mutex;

--- a/graph-gateway/src/network/internal/snapshot.rs
+++ b/graph-gateway/src/network/internal/snapshot.rs
@@ -10,7 +10,7 @@ use std::{
 use alloy_primitives::{Address, BlockNumber};
 use cost_model::CostModel;
 use custom_debug::CustomDebug;
-use eventuals::Ptr;
+use gateway_common::ptr::Ptr;
 use semver::Version;
 use thegraph_core::types::{DeploymentId, SubgraphId};
 use url::Url;


### PR DESCRIPTION
As the `eventuals` crate is not maintained and the `Ptr` type provides a valuable optimization, I have added the `Ptr` type to the `gateway-common` crate.

This is an initial step to remove the dependency on the `eventuals` crate. Note that not all the `Ptr` usages can be replaced yet as some of them are tied to an associated _eventual_ type.