### PR TITLE
refactor: cleanup client_query module

### DIFF
--- a/gateway-framework/src/errors.rs
+++ b/gateway-framework/src/errors.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, BlockNumber};
 use axum::response::{IntoResponse, Response};
 
 use crate::{blocks::UnresolvedBlock, graphql};
@@ -66,5 +66,19 @@ pub enum UnavailableReason {
     NoFee,
     /// The indexer did not have a block required by the query.
     #[error("missing block")]
-    MissingBlock,
+    MissingBlock(MissingBlockError),
 }
+
+#[derive(Clone, Debug, PartialOrd, Ord)]
+pub struct MissingBlockError {
+    pub missing: Option<BlockNumber>,
+    pub latest: Option<BlockNumber>,
+}
+
+impl PartialEq for MissingBlockError {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for MissingBlockError {}

--- a/gateway-framework/src/reporting/metrics.rs
+++ b/gateway-framework/src/reporting/metrics.rs
@@ -11,7 +11,7 @@ lazy_static! {
 }
 
 pub struct Metrics {
-    pub client_query: ResponseMetricVecs,
+    pub client_query: ResponseMetrics,
     pub avg_query_fees: Gauge,
     pub indexer_query: ResponseMetricVecs,
     pub collect_receipts: ResponseMetrics,
@@ -23,11 +23,7 @@ pub struct Metrics {
 impl Metrics {
     fn new() -> Self {
         Self {
-            client_query: ResponseMetricVecs::new(
-                "gw_client_query",
-                "client query",
-                &["deployment"],
-            ),
+            client_query: ResponseMetrics::new("gw_client_query", "client query"),
             avg_query_fees: register_gauge!(
                 "gw_avg_query_fees",
                 "average indexer fees per query, in USD"

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -10,8 +10,6 @@ use serde_json::{json, Map};
 use thegraph_core::types::attestation::Attestation;
 use toolshed::concat_bytes;
 
-use crate::indexer_client::ResponsePayload;
-
 pub fn report_client_query(kafka: &KafkaClient, fields: Map<String, serde_json::Value>) {
     #[derive(Deserialize)]
     struct Fields {
@@ -199,7 +197,7 @@ pub fn legacy_status<T>(result: &Result<T, errors::Error>) -> (String, u32) {
 
 // Like much of this file. This is maintained is a partially backward-compatible state for data
 // science, and should be deleted ASAP.
-pub fn indexer_attempt_status_code(result: &Result<ResponsePayload, IndexerError>) -> u32 {
+pub fn indexer_attempt_status_code<T>(result: &Result<T, IndexerError>) -> u32 {
     let (prefix, data) = match &result {
         Ok(_) => (0x0, 200_u32.to_be()),
         Err(IndexerError::Internal(_)) => (0x1, 0x0),


### PR DESCRIPTION
This is some prep for upcoming changes to reporting in the client_query module.
- remove the deployment label from client_query metrics: we are not using it in our gateway dashboard
- move parts of `handle_indexer_query_inner` into the `indexer_client` that are useful for indexer queries isolated from client queries.