### PR TITLE
refactor: update header name for tap receipts

### DIFF
--- a/gateway-framework/src/scalar/receipts.rs
+++ b/gateway-framework/src/scalar/receipts.rs
@@ -42,6 +42,13 @@ impl ScalarReceipt {
             ScalarReceipt::TAP(receipt) => serde_json::to_string(&receipt).unwrap(),
         }
     }
+
+    pub fn header_name(&self) -> &'static str {
+        match self {
+            ScalarReceipt::Legacy(_, _) => "Scalar-Receipt",
+            ScalarReceipt::TAP(_) => "Tap-Receipt",
+        }
+    }
 }
 
 /// Scalar TAP signer.

--- a/graph-gateway/src/indexer_client.rs
+++ b/graph-gateway/src/indexer_client.rs
@@ -50,7 +50,7 @@ impl IndexerClient {
             .client
             .post(url)
             .header("Content-Type", "application/json")
-            .header("Scalar-Receipt", receipt.serialize())
+            .header(receipt.header_name(), receipt.serialize())
             .body(query.to_string())
             .send()
             .await


### PR DESCRIPTION
Tap Receipts now have their own header instead of sharing the header name with Scalar. This is due to a decision that TAP is a ground-up protocol instead of a continuation of Scalar.