### PR TITLE
pick versions_behind before indexer-selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "candidate-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=1d6db83#1d6db8399a6a5615a7631437916ae546805d65e6"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=a803471#a80347194e02b7d64644eedf32cde30c1c43e884"
 dependencies = [
  "arrayvec 0.7.4",
  "ordered-float",
@@ -2473,7 +2473,7 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexer-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=1d6db83#1d6db8399a6a5615a7631437916ae546805d65e6"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=a803471#a80347194e02b7d64644eedf32cde30c1c43e884"
 dependencies = [
  "candidate-selection",
  "permutation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.3"
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
 headers = "0.4.0"
 hex = "0.4"
-indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "1d6db83" }
+indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "a803471" }
 primitive-types = "0.12.2"
 rand = { version = "0.8", features = ["small_rng"] }
 receipts = { git = "https://github.com/edgeandnode/receipts", rev = "e94e0f1" }

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -336,7 +336,7 @@ async fn run_indexer_queries(
         let (tx, mut rx) = mpsc::channel(SELECTION_LIMIT);
         let min_fee = *ctx.budgeter.min_indexer_fees.borrow();
         for &selection in &selections {
-            let indexer = selection.id;
+            let indexer = selection..data.id.indexer;
             let deployment = selection.data.id.deployment;
             let url = selection.data.indexer.url.clone();
             let seconds_behind = selection.seconds_behind;


### PR DESCRIPTION
This gets queries by subgraph ID closer to what users expect by selecting a subgraph version to use before indexer selection. We select the latest subgraph version with the most indexers at most 1 hour behind chain head. The downside is that this relies on reported indexer statuses. But I'm confident that this will result in fewer bad consumer outcomes than relying on indexer-selection, due to the impacts of factors that either shouldn't impact the selected version (like latency) or are subject to information decay causing bad outcomes (success rate).