### PR TITLE
refactor(graph-gateway): relocate indexers pois merge_queries logic

### DIFF
--- a/graph-gateway/src/network/indexer_indexing_poi_resolver.rs
+++ b/graph-gateway/src/network/indexer_indexing_poi_resolver.rs
@@ -10,10 +10,14 @@ use std::{collections::HashMap, time::Duration};
 
 use alloy_primitives::BlockNumber;
 use gateway_common::ttl_hash_map::TtlHashMap;
+use itertools::Itertools as _;
 use thegraph_core::types::{DeploymentId, ProofOfIndexing};
 use url::Url;
 
-use crate::indexers;
+use crate::{
+    indexers,
+    indexers::public_poi::{PublicProofOfIndexingQuery, PublicProofOfIndexingRequest},
+};
 
 /// The default TTL for cache entries is 20 minutes. Entries are considered expired after this time.
 pub const DEFAULT_CACHE_TLL: Duration = Duration::from_secs(20 * 60); // 20 minutes
@@ -22,7 +26,8 @@ pub const DEFAULT_CACHE_TLL: Duration = Duration::from_secs(20 * 60); // 20 minu
 pub const DEFAULT_INDEXER_INDEXING_POIS_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The number of Public POIs to query in a single request.
-const POIS_QUERY_BATCH_SIZE: usize = 10;
+// TODO: Change visibility once integration tests are moved
+pub const POIS_QUERY_BATCH_SIZE: usize = 10;
 
 /// Error that can occur during POI resolution.
 #[derive(Debug, thiserror::Error)]
@@ -73,7 +78,7 @@ impl PoiResolver {
         // TODO: Handle the different errors once the indexers client module reports them
         tokio::time::timeout(
             self.timeout,
-            indexers::public_poi::merge_queries(
+            merge_queries(
                 self.client.clone(),
                 indexer_status_url,
                 pois,
@@ -110,4 +115,47 @@ impl PoiResolver {
             }
         }
     }
+}
+
+// TODO: Change visibility once integration tests are moved
+pub async fn merge_queries(
+    client: reqwest::Client,
+    status_url: Url,
+    requests: &[(DeploymentId, BlockNumber)],
+    batch_size: usize,
+) -> HashMap<(DeploymentId, BlockNumber), ProofOfIndexing> {
+    // Build the query batches and create the futures
+    let queries = requests
+        .iter()
+        .map(|(deployment, block_number)| PublicProofOfIndexingRequest {
+            deployment: *deployment,
+            block_number: *block_number,
+        })
+        .chunks(batch_size)
+        .into_iter()
+        .map(|requests| PublicProofOfIndexingQuery {
+            requests: requests.collect(),
+        })
+        .map(|query| indexers::public_poi::query(client.clone(), status_url.clone(), query))
+        .collect::<Vec<_>>();
+
+    // Send all queries concurrently
+    let responses = futures::future::join_all(queries).await;
+
+    let response_map: HashMap<(DeploymentId, BlockNumber), ProofOfIndexing> = responses
+        .into_iter()
+        .filter_map(|response| {
+            response
+                .map_err(|e| tracing::trace!("Error querying public proof of indexing: {}", e))
+                .ok()
+        })
+        .flat_map(|response| response.public_proofs_of_indexing)
+        .filter_map(|response| {
+            // If the response is missing the POI field, skip it.
+            let poi = response.proof_of_indexing?;
+            Some(((response.deployment, response.block.number), poi))
+        })
+        .collect::<HashMap<_, _>>();
+
+    response_map
 }


### PR DESCRIPTION
Move the `merge_queries` function within the module where it is used. This makes the `indexers::public_pois` module a simple _pulic POIs_ client.