### PR TITLE
feat: workaround subgraphError allow

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -294,6 +294,7 @@ async fn run_indexer_queries(
 
         (chain_head, blocks_per_minute, block_requirements)
     };
+    let allow_errors = block_requirements.allow_errors;
     tracing::debug!(chain_head, blocks_per_minute, ?block_requirements);
 
     let mut indexer_errors = IndexerErrors::default();
@@ -394,6 +395,7 @@ async fn run_indexer_queries(
                             &receipt,
                             ctx.attestation_domain,
                             &indexer_query,
+                            allow_errors,
                         )
                         .in_current_span()
                         .await;

--- a/graph-gateway/src/indexer_client.rs
+++ b/graph-gateway/src/indexer_client.rs
@@ -40,6 +40,7 @@ impl IndexerClient {
         receipt: &Receipt,
         attestation_domain: &Eip712Domain,
         query: &str,
+        allow_errors: bool,
     ) -> Result<IndexerResponse, IndexerError> {
         let url = url
             .join(&format!("subgraphs/id/{:?}", deployment))
@@ -122,6 +123,8 @@ impl IndexerClient {
                     return Err(BadResponse(format!("bad attestation: {err}")));
                 }
             }
+            // TODO: this is a hack to workaround the indexer-service mishandling `subgraphError:allow`
+            None if allow_errors => (),
             None => {
                 let message = if !errors.is_empty() {
                     format!(


### PR DESCRIPTION
When the client query contains `subgraphError:allow` as a field of the top-level selection set, the indexer-service returns a response without an attestation