### PR TITLE
refactor(graph-gateway): shard network indexer host resolver cache lock

### DIFF
--- a/graph-gateway/src/network/internal/indexer_processing.rs
+++ b/graph-gateway/src/network/internal/indexer_processing.rs
@@ -186,7 +186,7 @@ pub(super) async fn process_info<S>(
 ) -> HashMap<Address, Result<IndexerInfo, IndexerError>>
 where
     S: AsRef<Option<AddrBlocklist>>
-        + AsRef<Mutex<HostResolver>>
+        + AsRef<HostResolver>
         + AsRef<Option<HostBlocklist>>
         + AsRef<VersionRequirements>
         + AsRef<VersionResolver>
@@ -401,12 +401,12 @@ fn check_indexer_blocked_by_addr_blocklist(
 /// - If the host blocklist was not configured: the indexer is ALLOWED.
 /// - If the indexer's host is in the blocklist: the indexer is BLOCKED.
 async fn resolve_and_check_indexer_blocked_by_host_blocklist(
-    resolver: &Mutex<HostResolver>,
+    resolver: &HostResolver,
     blocklist: &Option<HostBlocklist>,
     indexer: &IndexerRawInfo,
 ) -> Result<(), IndexerError> {
     // Resolve the indexer's URL, if it fails (or times out), the indexer must be BLOCKED
-    let resolution_result = resolver.lock().await.resolve_url(&indexer.url).await?;
+    let resolution_result = resolver.resolve_url(&indexer.url).await?;
 
     // If the host blocklist was not configured, the indexer must be ALLOWED
     let host_blocklist = match blocklist {

--- a/graph-gateway/src/network/internal/state.rs
+++ b/graph-gateway/src/network/internal/state.rs
@@ -13,7 +13,7 @@ use crate::network::{
 /// Internal type holding the network service state.
 pub struct InternalState {
     pub indexer_addr_blocklist: Option<AddrBlocklist>,
-    pub indexer_host_resolver: Mutex<HostResolver>,
+    pub indexer_host_resolver: HostResolver,
     pub indexer_host_blocklist: Option<HostBlocklist>,
     pub indexer_version_requirements: IndexerVersionRequirements,
     pub indexer_version_resolver: VersionResolver,
@@ -34,8 +34,8 @@ impl AsRef<Option<AddrBlocklist>> for InternalState {
     }
 }
 
-impl AsRef<Mutex<HostResolver>> for InternalState {
-    fn as_ref(&self) -> &Mutex<HostResolver> {
+impl AsRef<HostResolver> for InternalState {
+    fn as_ref(&self) -> &HostResolver {
         &self.indexer_host_resolver
     }
 }

--- a/graph-gateway/src/network/internal/tests/indexer_processing.rs
+++ b/graph-gateway/src/network/internal/tests/indexer_processing.rs
@@ -68,8 +68,7 @@ fn test_service_state(
     min_versions: Option<(Version, Version)>,
 ) -> InternalState {
     let indexers_http_client = reqwest::Client::new();
-    let indexer_host_resolver =
-        Mutex::new(HostResolver::new().expect("Failed to create host resolver"));
+    let indexer_host_resolver = HostResolver::new().expect("Failed to create host resolver");
     let indexer_version_resolver = VersionResolver::with_timeout_and_cache_ttl(
         indexers_http_client.clone(),
         DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT, // 1500 ms

--- a/graph-gateway/src/network/service.rs
+++ b/graph-gateway/src/network/service.rs
@@ -287,7 +287,7 @@ impl NetworkServiceBuilder {
     pub fn build(self) -> NetworkServicePending {
         let internal_state = InternalState {
             indexer_addr_blocklist: self.indexer_addr_blocklist,
-            indexer_host_resolver: Mutex::new(self.indexer_host_resolver),
+            indexer_host_resolver: self.indexer_host_resolver,
             indexer_host_blocklist: self.indexer_host_blocklist,
             indexer_version_requirements: self.indexer_version_requirements,
             indexer_version_resolver: self.indexer_version_resolver,

--- a/graph-gateway/tests/it_network_internal_fetch_update.rs
+++ b/graph-gateway/tests/it_network_internal_fetch_update.rs
@@ -63,8 +63,7 @@ fn test_service_state(
     min_versions: Option<(Version, Version)>,
 ) -> Arc<InternalState> {
     let indexers_http_client = reqwest::Client::new();
-    let indexer_host_resolver =
-        Mutex::new(HostResolver::new().expect("Failed to create host resolver"));
+    let indexer_host_resolver = HostResolver::new().expect("Failed to create host resolver");
     let indexer_version_resolver = VersionResolver::new(indexers_http_client.clone());
     let indexer_indexing_progress_resolver =
         IndexingProgressResolver::new(indexers_http_client.clone());


### PR DESCRIPTION
I am "sharding" the locks of the different indexer information resolvers' caches, one at a time. This way, we can use `parking_lot`'s `RwLock` instead of the `Tokyo`'s `RwLock.