### PR TITLE
refactor(graph-gateway): shard remaining network indexer resolves cache locks

### DIFF
--- a/graph-gateway/src/network/indexer_indexing_cost_model_resolver.rs
+++ b/graph-gateway/src/network/indexer_indexing_cost_model_resolver.rs
@@ -5,8 +5,8 @@
 use std::{collections::HashMap, time::Duration};
 
 use gateway_common::{ptr::Ptr, ttl_hash_map::TtlHashMap};
+use parking_lot::RwLock;
 use thegraph_core::types::DeploymentId;
-use tokio::sync::RwLock;
 use url::Url;
 
 use crate::{
@@ -87,18 +87,18 @@ impl CostModelResolver {
     ///
     /// This method locks the cache in read mode and returns the cached data for the given URL and
     /// given indexings.
-    async fn get_from_cache(
+    fn get_from_cache<'a>(
         &self,
         url: &str,
-        indexings: impl IntoIterator<Item = &DeploymentId>,
+        keys: impl IntoIterator<Item = &'a DeploymentId>,
     ) -> HashMap<DeploymentId, Ptr<CostModelSource>> {
-        let read_cache = self.cache.read().await;
+        let read_cache = self.cache.read();
         let mut result = HashMap::new();
 
-        for deployment in indexings {
-            match read_cache.get(&(url.to_owned(), *deployment)) {
+        for key in keys {
+            match read_cache.get(&(url.to_owned(), *key)) {
                 Some(data) => {
-                    result.insert(*deployment, data.clone());
+                    result.insert(*key, data.to_owned());
                 }
                 None => continue,
             }
@@ -111,14 +111,14 @@ impl CostModelResolver {
     ///
     /// This method locks the cache in write mode and updates the cache with the given progress
     /// information.
-    async fn update_cache(
+    fn update_cache<'a>(
         &self,
         url: &str,
-        progress: &HashMap<DeploymentId, Ptr<CostModelSource>>,
+        data: impl IntoIterator<Item = (&'a DeploymentId, &'a Ptr<CostModelSource>)>,
     ) {
-        let mut write_cache = self.cache.write().await;
-        for (deployment, data) in progress.iter() {
-            write_cache.insert((url.to_owned(), *deployment), data.clone());
+        let mut write_cache = self.cache.write();
+        for (key, value) in data {
+            write_cache.insert((url.to_owned(), *key), value.clone());
         }
     }
 
@@ -140,7 +140,7 @@ impl CostModelResolver {
 
                 // If the data fetch failed, return the cached data
                 // If no cached data is available, return the error
-                let cached_progress = self.get_from_cache(&url_string, indexings).await;
+                let cached_progress = self.get_from_cache(&url_string, indexings);
                 return if cached_progress.is_empty() {
                     Err(err)
                 } else {
@@ -156,7 +156,7 @@ impl CostModelResolver {
 
         // Update the cache with the fetched data, if any
         if !fresh_sources.is_empty() {
-            self.update_cache(&url_string, &fresh_sources).await;
+            self.update_cache(&url_string, fresh_sources.iter());
         }
 
         // Get the cached data for the missing deployments
@@ -167,7 +167,7 @@ impl CostModelResolver {
                 .filter(|deployment| !indexings.contains(deployment));
 
             // Get the cached data for the missing deployments
-            self.get_from_cache(&url_string, missing_indexings).await
+            self.get_from_cache(&url_string, missing_indexings)
         };
 
         // Merge the fetched and cached data

--- a/graph-gateway/src/network/internal/state.rs
+++ b/graph-gateway/src/network/internal/state.rs
@@ -1,5 +1,3 @@
-use tokio::sync::Mutex;
-
 use super::indexer_processing::VersionRequirements as IndexerVersionRequirements;
 use crate::network::{
     indexer_addr_blocklist::AddrBlocklist, indexer_host_blocklist::HostBlocklist,
@@ -19,7 +17,7 @@ pub struct InternalState {
     pub indexer_version_resolver: VersionResolver,
     pub indexer_indexing_pois_blocklist: Option<(PoiResolver, PoiBlocklist)>,
     pub indexer_indexing_progress_resolver: IndexingProgressResolver,
-    pub indexer_indexing_cost_model_resolver: (CostModelResolver, Mutex<CostModelCompiler>),
+    pub indexer_indexing_cost_model_resolver: (CostModelResolver, CostModelCompiler),
 }
 
 impl AsRef<IndexerVersionRequirements> for InternalState {
@@ -64,8 +62,8 @@ impl AsRef<IndexingProgressResolver> for InternalState {
     }
 }
 
-impl AsRef<(CostModelResolver, Mutex<CostModelCompiler>)> for InternalState {
-    fn as_ref(&self) -> &(CostModelResolver, Mutex<CostModelCompiler>) {
+impl AsRef<(CostModelResolver, CostModelCompiler)> for InternalState {
+    fn as_ref(&self) -> &(CostModelResolver, CostModelCompiler) {
         &self.indexer_indexing_cost_model_resolver
     }
 }

--- a/graph-gateway/src/network/internal/tests/indexer_processing.rs
+++ b/graph-gateway/src/network/internal/tests/indexer_processing.rs
@@ -8,7 +8,6 @@ use assert_matches::assert_matches;
 use ipnetwork::IpNetwork;
 use semver::Version;
 use thegraph_core::types::DeploymentId;
-use tokio::sync::Mutex;
 use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 use url::Url;
 
@@ -90,7 +89,7 @@ fn test_service_state(
         IndexingProgressResolver::new(indexers_http_client.clone());
     let indexer_indexing_cost_model_resolver = (
         CostModelResolver::new(indexers_http_client.clone()),
-        Mutex::new(CostModelCompiler::default()),
+        CostModelCompiler::default(),
     );
 
     let mut state = InternalState {

--- a/graph-gateway/src/network/service.rs
+++ b/graph-gateway/src/network/service.rs
@@ -13,10 +13,7 @@ use gateway_common::ttl_hash_map::DEFAULT_TTL;
 use ipnetwork::IpNetwork;
 use semver::Version;
 use thegraph_core::types::{DeploymentId, SubgraphId};
-use tokio::{
-    sync::{watch, Mutex},
-    time::MissedTickBehavior,
-};
+use tokio::{sync::watch, time::MissedTickBehavior};
 use vec1::{vec1, Vec1};
 
 use super::{
@@ -295,7 +292,7 @@ impl NetworkServiceBuilder {
             indexer_indexing_progress_resolver: self.indexer_indexing_progress_resolver,
             indexer_indexing_cost_model_resolver: (
                 self.indexer_indexing_cost_model_resolver,
-                Mutex::new(self.indexer_indexing_cost_model_compiler),
+                self.indexer_indexing_cost_model_compiler,
             ),
         };
 

--- a/graph-gateway/tests/it_network_internal_fetch_update.rs
+++ b/graph-gateway/tests/it_network_internal_fetch_update.rs
@@ -18,7 +18,6 @@ use graph_gateway::network::{
 use ipnetwork::IpNetwork;
 use semver::Version;
 use thegraph_core::client::Client as SubgraphClient;
-use tokio::sync::Mutex;
 use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 use url::Url;
 
@@ -69,7 +68,7 @@ fn test_service_state(
         IndexingProgressResolver::new(indexers_http_client.clone());
     let indexer_indexing_cost_model_resolver = (
         CostModelResolver::new(indexers_http_client.clone()),
-        Mutex::new(CostModelCompiler::default()),
+        CostModelCompiler::default(),
     );
 
     let mut state = InternalState {


### PR DESCRIPTION
This is a follow-up of #829 