### PR TITLE
fix(graph-gateway): use status endpoint for public pois resolution

### DIFF
--- a/graph-gateway/src/network/indexer_indexing_poi_blocklist.rs
+++ b/graph-gateway/src/network/indexer_indexing_poi_blocklist.rs
@@ -44,9 +44,10 @@ impl PoiBlocklist {
     /// querying the indexer for POIs if none of its deployments is affected.
     pub fn affected_pois_metadata<'a>(
         &self,
-        deployments: impl Iterator<Item = &'a DeploymentId>,
+        deployments: impl IntoIterator<Item = &'a DeploymentId>,
     ) -> Vec<(DeploymentId, BlockNumber)> {
         deployments
+            .into_iter()
             .flat_map(|deployment_id| {
                 self.blocklist
                     .get(deployment_id)

--- a/graph-gateway/src/network/internal/indexer_processing.rs
+++ b/graph-gateway/src/network/internal/indexer_processing.rs
@@ -190,7 +190,7 @@ where
         + AsRef<Option<HostBlocklist>>
         + AsRef<VersionRequirements>
         + AsRef<VersionResolver>
-        + AsRef<Option<(PoiBlocklist, PoiResolver)>>
+        + AsRef<Option<(PoiResolver, PoiBlocklist)>>
         + AsRef<IndexingProgressResolver>
         + AsRef<(CostModelResolver, Mutex<CostModelCompiler>)>,
 {
@@ -466,19 +466,19 @@ async fn resolve_and_check_indexer_blocked_by_version(
 
 /// Resolve and check if any of the indexer's deployments should be blocked by POI.
 async fn resolve_and_check_indexer_indexings_blocked_by_poi(
-    blocklist: &Option<(PoiBlocklist, PoiResolver)>,
+    blocklist: &Option<(PoiResolver, PoiBlocklist)>,
     indexings: &[DeploymentId],
     indexer: &IndexerRawInfo,
 ) -> Result<HashSet<DeploymentId>, IndexerError> {
     // If the POI blocklist was not configured, the indexer must be ALLOWED
-    let (pois_blocklist, pois_resolver) = match blocklist {
+    let (pois_resolver, pois_blocklist) = match blocklist {
         Some((blocklist, resolver)) => (blocklist, resolver),
         _ => return Ok(HashSet::new()),
     };
 
     // Get the list of affected POIs to resolve for the indexer's deployments
     // If none of the deployments are affected, the indexer must be ALLOWED
-    let indexer_affected_pois = pois_blocklist.affected_pois_metadata(indexer.indexings.keys());
+    let indexer_affected_pois = pois_blocklist.affected_pois_metadata(indexings);
     if indexer_affected_pois.is_empty() {
         return Ok(HashSet::new());
     }

--- a/graph-gateway/src/network/internal/state.rs
+++ b/graph-gateway/src/network/internal/state.rs
@@ -17,7 +17,7 @@ pub struct InternalState {
     pub indexer_host_blocklist: Option<HostBlocklist>,
     pub indexer_version_requirements: IndexerVersionRequirements,
     pub indexer_version_resolver: VersionResolver,
-    pub indexer_indexing_pois_blocklist: Option<(PoiBlocklist, PoiResolver)>,
+    pub indexer_indexing_pois_blocklist: Option<(PoiResolver, PoiBlocklist)>,
     pub indexer_indexing_progress_resolver: IndexingProgressResolver,
     pub indexer_indexing_cost_model_resolver: (CostModelResolver, Mutex<CostModelCompiler>),
 }
@@ -52,8 +52,8 @@ impl AsRef<VersionResolver> for InternalState {
     }
 }
 
-impl AsRef<Option<(PoiBlocklist, PoiResolver)>> for InternalState {
-    fn as_ref(&self) -> &Option<(PoiBlocklist, PoiResolver)> {
+impl AsRef<Option<(PoiResolver, PoiBlocklist)>> for InternalState {
+    fn as_ref(&self) -> &Option<(PoiResolver, PoiBlocklist)> {
         &self.indexer_indexing_pois_blocklist
     }
 }

--- a/graph-gateway/src/network/service.rs
+++ b/graph-gateway/src/network/service.rs
@@ -186,7 +186,7 @@ pub struct NetworkServiceBuilder {
     indexer_host_blocklist: Option<HostBlocklist>,
     indexer_version_requirements: IndexerVersionRequirements,
     indexer_version_resolver: VersionResolver,
-    indexer_indexing_pois_blocklist: Option<(PoiBlocklist, PoiResolver)>,
+    indexer_indexing_pois_blocklist: Option<(PoiResolver, PoiBlocklist)>,
     indexer_indexing_progress_resolver: IndexingProgressResolver,
     indexer_indexing_cost_model_resolver: CostModelResolver,
     indexer_indexing_cost_model_compiler: CostModelCompiler,
@@ -277,7 +277,7 @@ impl NetworkServiceBuilder {
         );
         let blocklist = PoiBlocklist::new(blocklist);
 
-        self.indexer_indexing_pois_blocklist = Some((blocklist, resolver));
+        self.indexer_indexing_pois_blocklist = Some((resolver, blocklist));
         self
     }
 


### PR DESCRIPTION
This fixes a regression in which the public POI resolver sent requests to the indexer's base URL instead of the `/status` endpoint.