### PR TITLE
fix(graph-gateway): remove indexing progress query field alias

### DIFF
--- a/graph-gateway/src/indexers/indexing_progress.rs
+++ b/graph-gateway/src/indexers/indexing_progress.rs
@@ -10,7 +10,7 @@ use thegraph_graphql_http::{
 const INDEXING_PROGRESS_QUERY_DOCUMENT: &str = indoc::indoc! {r#"
     query indexingProgress($deployments: [String!]!) {
         indexingStatuses(subgraphs: $deployments) {
-            deploymentId: subgraph
+            subgraph
             chains {
                 network
                 latestBlock { number }
@@ -115,8 +115,8 @@ struct Response {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct IndexingStatusResponse {
+    #[serde(rename = "subgraph")]
     pub deployment_id: DeploymentId,
     pub chains: Vec<ChainStatus>,
 }
@@ -146,7 +146,7 @@ mod tests {
         let response = serde_json::json!({
             "indexingStatuses": [
                 {
-                    "deploymentId": "QmZTy9EJHu8rfY9QbEk3z1epmmvh5XHhT2Wqhkfbyt8k9Z",
+                    "subgraph": "QmZTy9EJHu8rfY9QbEk3z1epmmvh5XHhT2Wqhkfbyt8k9Z",
                     "chains": [
                         {
                             "network": "rinkeby",
@@ -162,7 +162,7 @@ mod tests {
                     ]
                 },
                 {
-                    "deploymentId": "QmSLQfPFcz2pKRJZUH16Sk26EFpRgdxTYGnMiKvWgKRM2a",
+                    "subgraph": "QmSLQfPFcz2pKRJZUH16Sk26EFpRgdxTYGnMiKvWgKRM2a",
                     "chains": [
                         {
                             "network": "rinkeby"

--- a/graph-gateway/src/network/indexer_indexing_progress_resolver.rs
+++ b/graph-gateway/src/network/indexer_indexing_progress_resolver.rs
@@ -228,6 +228,7 @@ impl IndexingProgressResolver {
             .map(|(k, v)| (k, Freshness::Cached(v)));
         Ok(HashMap::from_iter(cached_progress.chain(fresh_progress)))
     }
+
     /// Resolves the indexing progress of the given deployments.
     ///
     /// Returns a map of deployment IDs to their indexing progress information.


### PR DESCRIPTION
Old versions of the indexer service do not support using field aliases in the GraphQL queries.
- Version: `0.21.1` (https://indexer.upgrade.thegraph.com/version) -> Supported
- Version: `0.20.12` (https://mainnet-indexer-02-europe-west.thegraph.com/version) --> No support