### PR TITLE
refactor(graph-gateway): differentiate indexer urls

### DIFF
--- a/graph-gateway/src/indexers/cost_models.rs
+++ b/graph-gateway/src/indexers/cost_models.rs
@@ -5,6 +5,8 @@ use thegraph_graphql_http::{
     http_client::{RequestError, ReqwestExt, ResponseError},
 };
 
+use super::urls::CostUrl;
+
 const COST_MODEL_QUERY_DOCUMENT: &str = indoc::indoc! {r#"
     query costModels($deployments: [String!]!) {
         costModels(deployments: $deployments) {
@@ -36,11 +38,11 @@ pub enum Error {
 /// Send a request to the indexer to get the cost models of the given deployments.
 pub async fn send_request(
     client: &reqwest::Client,
-    cost_url: reqwest::Url,
+    url: CostUrl,
     deployments: impl IntoIterator<Item = &DeploymentId>,
 ) -> Result<Vec<CostModelSource>, Error> {
     let resp = client
-        .post(cost_url)
+        .post(url.into_inner())
         .send_graphql::<Response>(Request::new(deployments))
         .await
         .map_err(|err| match err {

--- a/graph-gateway/src/indexers/indexing_progress.rs
+++ b/graph-gateway/src/indexers/indexing_progress.rs
@@ -7,6 +7,8 @@ use thegraph_graphql_http::{
     http_client::{RequestError, ReqwestExt as _, ResponseError},
 };
 
+use super::urls::StatusUrl;
+
 const INDEXING_PROGRESS_QUERY_DOCUMENT: &str = indoc::indoc! {r#"
     query indexingProgress($deployments: [String!]!) {
         indexingStatuses(subgraphs: $deployments) {
@@ -41,11 +43,11 @@ pub enum Error {
 /// Send a request to the indexer to get the indexing status of the given deployments.
 pub async fn send_request(
     client: &reqwest::Client,
-    status_url: reqwest::Url,
+    url: StatusUrl,
     deployments: impl IntoIterator<Item = &DeploymentId>,
 ) -> Result<Vec<IndexingStatusResponse>, Error> {
     let resp = client
-        .post(status_url)
+        .post(url.into_inner())
         .send_graphql::<Response>(Request::new(deployments))
         .await
         .map_err(|err| match err {

--- a/graph-gateway/src/indexers/public_poi.rs
+++ b/graph-gateway/src/indexers/public_poi.rs
@@ -7,7 +7,8 @@ use thegraph_graphql_http::{
     graphql::{Document, IntoDocument, IntoDocumentWithVariables},
     http_client::{RequestError, ReqwestExt, ResponseError},
 };
-use url::Url;
+
+use super::urls::StatusUrl;
 
 const PUBLIC_PROOF_OF_INDEXING_QUERY_DOCUMENT: &str = indoc! {
     r#"query publicPois($requests: [PublicProofOfIndexingRequest!]!) {
@@ -80,11 +81,11 @@ impl From<(DeploymentId, BlockNumber)> for PublicProofOfIndexingRequest {
 /// Send a request to the indexer to get the Public POIs of the given deployment-block number pairs.
 pub async fn send_request(
     client: &reqwest::Client,
-    status_url: Url,
+    url: StatusUrl,
     pois: impl IntoIterator<Item = &(DeploymentId, BlockNumber)>,
 ) -> Result<Vec<PublicProofOfIndexingResult>, Error> {
     let resp = client
-        .post(status_url)
+        .post(url.into_inner())
         .send_graphql::<Response>(Request::new(pois))
         .await
         .map_err(|err| match err {

--- a/graph-gateway/src/network/indexer_indexing_poi_resolver.rs
+++ b/graph-gateway/src/network/indexer_indexing_poi_resolver.rs
@@ -198,7 +198,7 @@ impl PoiResolver {
 /// an error if the request failed.
 async fn send_requests(
     client: &reqwest::Client,
-    status_url: &Url,
+    url: &indexers::StatusUrl,
     poi_requests: &[(DeploymentId, BlockNumber)],
     batch_size: usize,
 ) -> HashMap<(DeploymentId, BlockNumber), Result<ProofOfIndexing, PublicPoiFetchError>> {
@@ -207,10 +207,9 @@ async fn send_requests(
 
     // Create a request for each batch
     let requests = batches.map(|batch| {
-        let status_url = status_url.clone();
         async move {
             // Request the indexings' POIs
-            let response = indexers::public_poi::send_request(client, status_url, batch).await;
+            let response = indexers::public_poi::send_request(client, url.clone(), batch).await;
 
             let result = match response {
                 Err(err) => {

--- a/graph-gateway/src/network/indexer_indexing_progress_resolver.rs
+++ b/graph-gateway/src/network/indexer_indexing_progress_resolver.rs
@@ -246,7 +246,7 @@ impl IndexingProgressResolver {
 /// as failed. The function returns a map of deployment IDs to the indexing progress information.
 async fn send_requests(
     client: &reqwest::Client,
-    status_url: &Url,
+    url: &indexers::StatusUrl,
     indexings: &[DeploymentId],
     batch_size: usize,
 ) -> HashMap<DeploymentId, Result<Vec<ChainStatus>, IndexingProgressFetchError>> {
@@ -256,11 +256,10 @@ async fn send_requests(
     let request_batches = indexings.chunks(batch_size);
 
     let requests = request_batches.map(|deployments| {
-        let status_url = status_url.clone();
         async move {
             // Request the indexing progress of the deployments in the batch
             let result =
-                indexers::indexing_progress::send_request(client, status_url, deployments).await;
+                indexers::indexing_progress::send_request(client, url.clone(), deployments).await;
 
             let result = match result {
                 Err(err) => {

--- a/graph-gateway/src/network/indexer_version_resolver.rs
+++ b/graph-gateway/src/network/indexer_version_resolver.rs
@@ -39,7 +39,6 @@ pub enum ResolutionError {
 /// The resolver is responsible for fetching the versions of the indexer service and graph-node
 /// services. If the version takes more than the timeout to resolve, the resolver will return an
 /// error.
-// TODO: Cache the result with TTL in case the resolution fails.
 #[derive(Clone)]
 pub struct VersionResolver {
     /// The indexer client.
@@ -96,10 +95,13 @@ impl VersionResolver {
     }
 
     /// Fetches the indexer service version from the given URL.
-    async fn fetch_indexer_service_version(&self, url: &Url) -> Result<Version, ResolutionError> {
+    async fn fetch_indexer_service_version(
+        &self,
+        url: &indexers::VersionUrl,
+    ) -> Result<Version, ResolutionError> {
         tokio::time::timeout(
             self.indexer_service_version_resolution_timeout,
-            indexers::version::query_indexer_service_version(&self.client, url.clone()),
+            indexers::version::fetch_indexer_service_version(&self.client, url.clone()),
         )
         .await
         .map_err(|_| ResolutionError::Timeout)?
@@ -107,10 +109,13 @@ impl VersionResolver {
     }
 
     /// Fetches the indexer graph-node version from the given URL.
-    async fn fetch_graph_node_version(&self, url: &Url) -> Result<Version, ResolutionError> {
+    async fn fetch_graph_node_version(
+        &self,
+        url: &indexers::StatusUrl,
+    ) -> Result<Version, ResolutionError> {
         tokio::time::timeout(
             self.graph_node_version_resolution_timeout,
-            indexers::version::query_graph_node_version(&self.client, url.clone()),
+            indexers::version::fetch_graph_node_version(&self.client, url.clone()),
         )
         .await
         .map_err(|_| ResolutionError::Timeout)?
@@ -124,21 +129,21 @@ impl VersionResolver {
         &self,
         url: &Url,
     ) -> Result<Version, ResolutionError> {
+        let url_string = url.to_string();
         let version_url = indexers::version_url(url);
-        let version_url_string = version_url.to_string();
 
         let version = match self.fetch_indexer_service_version(&version_url).await {
             Ok(version) => version,
             Err(err) => {
                 tracing::debug!(
-                    version_url = version_url_string,
+                    version_url = url_string,
                     error = ?err,
                     "indexer service version resolution failed"
                 );
 
                 // Try to get the version from the cache, otherwise return the fetch error
                 let cache = self.indexer_service_version_cache.read();
-                return if let Some(version) = cache.get(&version_url_string) {
+                return if let Some(version) = cache.get(&url_string) {
                     Ok(version.clone())
                 } else {
                     Err(err)
@@ -149,7 +154,7 @@ impl VersionResolver {
         // Update the cache with the resolved version
         {
             let mut cache = self.indexer_service_version_cache.write();
-            cache.insert(version_url_string, version.clone());
+            cache.insert(url_string, version.clone());
         }
 
         Ok(version)
@@ -159,21 +164,21 @@ impl VersionResolver {
     ///
     /// The version resolution time is upper-bounded by the configured timeout.
     pub async fn resolve_graph_node_version(&self, url: &Url) -> Result<Version, ResolutionError> {
+        let url_string = url.to_string();
         let status_url = indexers::status_url(url);
-        let status_url_string = status_url.to_string();
 
         let version = match self.fetch_graph_node_version(&status_url).await {
             Ok(version) => version,
             Err(err) => {
                 tracing::debug!(
-                    version_url = status_url_string,
+                    version_url = url_string,
                     error = ?err,
                     "indexer graph-node version resolution failed"
                 );
 
                 // Try to get the version from the cache, otherwise return the fetch error
                 let cache = self.graph_node_version_cache.read();
-                return if let Some(version) = cache.get(&status_url_string) {
+                return if let Some(version) = cache.get(&url_string) {
                     Ok(version.clone())
                 } else {
                     Err(err)
@@ -184,7 +189,7 @@ impl VersionResolver {
         // Update the cache with the resolved version
         {
             let mut cache = self.graph_node_version_cache.write();
-            cache.insert(status_url_string, version.clone());
+            cache.insert(url_string, version.clone());
         }
 
         Ok(version)

--- a/graph-gateway/tests/it_indexers_status_version.rs
+++ b/graph-gateway/tests/it_indexers_status_version.rs
@@ -18,13 +18,37 @@ fn test_indexer_url() -> Url {
 async fn query_indexer_service_version() {
     //* Given
     let client = reqwest::Client::new();
-    let version_url = indexers::version_url(test_indexer_url());
+    let url = indexers::version_url(test_indexer_url());
 
     //* When
-    let request = version::query_indexer_service_version(&client, version_url);
-    let response = timeout(Duration::from_secs(60), request)
-        .await
-        .expect("timeout");
+    let response = timeout(
+        Duration::from_secs(60),
+        version::fetch_indexer_service_version(&client, url),
+    )
+    .await
+    .expect("Request timed out");
+
+    //* Then
+    // Assert version is present and greater than 0.1.0
+    assert_matches!(response, Ok(version) => {
+        assert!(version > semver::Version::new(0, 1, 0));
+    });
+}
+
+#[test_with::env(IT_TEST_TESTNET_INDEXER_URL)]
+#[tokio::test]
+async fn query_graph_node_version() {
+    //* Given
+    let client = reqwest::Client::new();
+    let url = indexers::status_url(test_indexer_url());
+
+    //* When
+    let response = timeout(
+        Duration::from_secs(60),
+        version::fetch_graph_node_version(&client, url),
+    )
+    .await
+    .expect("Request timed out");
 
     //* Then
     // Assert version is present and greater than 0.1.0


### PR DESCRIPTION
Recently, we had some bugs because we were querying the wrong endpoint. I added some `Url` new types to prevent this kind of bug.