### PR TITLE
release 21.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "graph-gateway"
-version = "21.2.3"
+version = "21.2.4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "candidate-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=1d6db83#1d6db8399a6a5615a7631437916ae546805d65e6"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=89dc460#89dc460a695a40810fd75038797e40b9604b5802"
 dependencies = [
  "arrayvec 0.7.4",
  "ordered-float",
@@ -2564,7 +2564,7 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexer-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=1d6db83#1d6db8399a6a5615a7631437916ae546805d65e6"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=89dc460#89dc460a695a40810fd75038797e40b9604b5802"
 dependencies = [
  "candidate-selection",
  "permutation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
 headers = "0.4.0"
 hex = "0.4"
-indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "1d6db83" }
+indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "89dc460" }
 parking_lot = "0.12.3"
 primitive-types = "0.12.2"
 rand = { version = "0.8", features = ["small_rng"] }

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "21.2.3"
+version = "21.2.4"
 
 [dependencies]
 alloy-primitives.workspace = true

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -70,8 +70,7 @@ impl Reporter {
 
         let (tx, mut rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
-            loop {
-                let msg = rx.recv().await.expect("channel closed");
+            while let Some(msg) = rx.recv().await {
                 if let Err(report_err) = reporter.report(msg) {
                     tracing::error!(%report_err);
                 }


### PR DESCRIPTION
# Release Notes
- fix(chain): improve block rate calculation for arbitrum-one
- update indexer-selection (increase `seconds_behind` sensitivity)
- fix(resports): avoid panic on shutdown
- feat(graph-gateway): rework network resolution error reporting (#839, #841)