### PR TITLE
feat(graph-gateway): rework network resolution error reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: sudo apt-get install -y lld librdkafka-dev libsasl2-dev
 
       - run: cargo check
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy -- -Dwarnings --force-warn deprecated --force-warn dead-code
 
       ## Tests
       # Install sops (needed for decrypting tests .env file)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid 1.8.0",
- "vec1",
 ]
 
 [[package]]
@@ -5496,12 +5495,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec1"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
 
 [[package]]
 name = "version_check"

--- a/gateway-framework/src/errors.rs
+++ b/gateway-framework/src/errors.rs
@@ -87,7 +87,7 @@ pub enum UnavailableReason {
     #[error("blocked")]
     Blocked,
     /// The indexer deployment was blocked since it reported a POI blocked by the gateway (bad POI).
-    #[error("blocked (bad poi)")]
+    #[error("blocked (bad POI)")]
     BlockedBadPOI,
 
     /// The indexer version is not supported (e.g., the indexer service version is below the minimum

--- a/gateway-framework/src/errors.rs
+++ b/gateway-framework/src/errors.rs
@@ -82,16 +82,16 @@ pub enum IndexerError {
 
 #[derive(thiserror::Error, Clone, Debug)]
 pub enum UnavailableReason {
-    /// The indexer is blocked by one of the block lists.
+    /// The indexer is blocked by one of the block lists (e.g., the indexer address is blocked by
+    /// the gateway, the indexer host IP address is blocked by the gateway, etc.).
     #[error("blocked")]
     Blocked,
+    /// The indexer deployment was blocked since it reported a POI blocked by the gateway (bad POI).
+    #[error("blocked (bad poi)")]
+    BlockedBadPOI,
 
-    /// The indexer deployment was blocked since it reported a bad POI blocked by the gateway.
-    #[error("blocked: bad POI")]
-    BlockedBadPOIs,
-
-    /// The indexer version is not supported (e.g., the indexer service version is below the
-    /// minimum version required by the gateway, etc.)
+    /// The indexer version is not supported (e.g., the indexer service version is below the minimum
+    /// version required by the gateway, etc.)
     #[error("not supported: {0}")]
     NotSupported(String),
 
@@ -115,7 +115,7 @@ pub enum UnavailableReason {
 
     /// An internal error occurred.
     #[error("internal error: {0}")]
-    Internal(String),
+    Internal(&'static str),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -55,7 +55,6 @@ tower-http = { version = "0.5.2", features = ["cors"] }
 tracing.workspace = true
 url = "2.5.0"
 uuid = { version = "1.8", default-features = false, features = ["v4"] }
-vec1 = "1.12.0"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/graph-gateway/src/indexer_client.rs
+++ b/graph-gateway/src/indexer_client.rs
@@ -42,7 +42,7 @@ impl IndexerClient {
     ) -> Result<IndexerResponse, IndexerError> {
         let url = url
             .join(&format!("subgraphs/id/{:?}", deployment))
-            .map_err(|_| Unavailable(UnavailableReason::Internal("bad indexer url".to_string())))?;
+            .map_err(|_| Unavailable(UnavailableReason::Internal("bad indexer url")))?;
 
         let result = self
             .client

--- a/graph-gateway/src/network.rs
+++ b/graph-gateway/src/network.rs
@@ -2,14 +2,16 @@
 //! provides information about the subgraphs (and subgraph deployments) registered in the network
 //! smart contract, as well as the indexers that are indexing them.
 
-pub use internal::{
-    DeploymentError, Indexer, IndexerError, Indexing, IndexingError, IndexingId, SubgraphError,
-    UnavailableReason,
+pub use errors::{
+    DeploymentError, IndexingError, ResolutionError, SubgraphError, UnavailableReason,
 };
+pub use internal::{Indexer, Indexing, IndexingId};
 pub use service::{
     NetworkService, NetworkServiceBuilder, NetworkServicePending, ResolvedSubgraphInfo,
 };
 
+mod config;
+mod errors;
 pub mod indexer_addr_blocklist;
 pub mod indexer_host_blocklist;
 pub mod indexer_host_resolver;

--- a/graph-gateway/src/network/config.rs
+++ b/graph-gateway/src/network/config.rs
@@ -3,7 +3,7 @@ use semver::Version;
 /// The minimum version requirements for the indexer.
 #[derive(Debug, Clone)]
 pub struct VersionRequirements {
-    /// The minimum indexer  version.
+    /// The minimum indexer version.
     pub min_indexer_service_version: Version,
     /// The minimum graph node version.
     pub min_graph_node_version: Version,

--- a/graph-gateway/src/network/config.rs
+++ b/graph-gateway/src/network/config.rs
@@ -1,0 +1,19 @@
+use semver::Version;
+
+/// The minimum version requirements for the indexer.
+#[derive(Debug, Clone)]
+pub struct VersionRequirements {
+    /// The minimum indexer  version.
+    pub min_indexer_service_version: Version,
+    /// The minimum graph node version.
+    pub min_graph_node_version: Version,
+}
+
+impl Default for VersionRequirements {
+    fn default() -> Self {
+        Self {
+            min_indexer_service_version: Version::new(0, 0, 0),
+            min_graph_node_version: Version::new(0, 0, 0),
+        }
+    }
+}

--- a/graph-gateway/src/network/errors.rs
+++ b/graph-gateway/src/network/errors.rs
@@ -51,7 +51,7 @@ pub enum UnavailableReason {
     #[error("blocked")]
     Blocked,
     /// The indexing was blocked since it reported a bad POI blocked by the gateway.
-    #[error("blocked (bad poi)")]
+    #[error("blocked (bad POI)")]
     BlockedBadPOI,
 
     /// The indexing is unavailable due to an [`IndexerInfoResolutionError`].
@@ -84,12 +84,12 @@ impl From<IndexingError> for ResolutionError {
                         tracing::debug!(error=?err, "host resolution failed");
 
                         let reason = match err {
-                            HostResolutionError::InvalidUrl(_) => "invalid indexer url",
+                            HostResolutionError::InvalidUrl(_) => "invalid indexer URL",
                             HostResolutionError::DnsResolutionError(_) => {
-                                "indexer url dns resolution failed"
+                                "indexer URL DNS resolution failed"
                             }
                             HostResolutionError::Timeout => {
-                                "indexer url dns resolution failed (timeout)"
+                                "indexer URL DNS resolution failed (timeout)"
                             }
                         };
                         UnavailableReason::IndexerResolutionError(reason)
@@ -195,7 +195,7 @@ pub enum IndexerInfoResolutionError {
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum IndexingInfoResolutionError {
     /// The indexing has been blocked by the public POIs blocklist.
-    #[error("indexing blocked by POIs blocklist")]
+    #[error("indexing blocked by POI blocklist")]
     BlockedByPoiBlocklist,
 
     /// The indexing progress information was not found.

--- a/graph-gateway/src/network/errors.rs
+++ b/graph-gateway/src/network/errors.rs
@@ -1,0 +1,204 @@
+use semver::Version;
+use thegraph_core::types::SubgraphId;
+
+use crate::network::{
+    indexer_host_resolver::ResolutionError as HostResolutionError,
+    indexer_version_resolver::ResolutionError as VersionResolutionError,
+};
+
+/// Subgraph validation error.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum SubgraphError {
+    /// The subgraph was transferred to L2.
+    #[error("transferred to L2")]
+    TransferredToL2 { id_on_l2: Option<SubgraphId> },
+
+    /// No allocations were found for the subgraph.
+    #[error("no allocations")]
+    NoAllocations,
+
+    /// All subgraph versions were marked as invalid.
+    #[error("no valid versions")]
+    NoValidVersions,
+}
+
+/// Deployment validation error
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum DeploymentError {
+    /// The subgraph was transferred to L2.
+    #[error("transferred to L2")]
+    TransferredToL2,
+
+    /// No allocations were found for the subgraph.
+    #[error("no allocations")]
+    NoAllocations,
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ResolutionError {
+    /// The indexing is unavailable.
+    #[error(transparent)]
+    Unavailable(UnavailableReason),
+
+    /// Errors that should only occur in exceptional conditions.
+    #[error("internal error: {0}")]
+    Internal(&'static str),
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum UnavailableReason {
+    /// Blocked by one of the blocklists.
+    #[error("blocked")]
+    Blocked,
+    /// The indexing was blocked since it reported a bad POI blocked by the gateway.
+    #[error("blocked (bad poi)")]
+    BlockedBadPOI,
+
+    /// The indexing is unavailable due to an [`IndexerInfoResolutionError`].
+    #[error("{0}")]
+    IndexerResolutionError(&'static str),
+
+    /// Indexer service version is below the minimum required.
+    #[error("indexer service version below the minimum required")]
+    IndexerServiceVersionBelowMin,
+    /// Graph node version is below the minimum required.
+    #[error("graph node version below the minimum required")]
+    GraphNodeVersionBelowMin,
+
+    /// The indexing progress information was not found.
+    ///
+    /// The resolution failed, and it was not available in the cache.
+    #[error("indexing progress not found")]
+    IndexingProgressNotFound,
+}
+
+impl From<IndexingError> for ResolutionError {
+    fn from(error: IndexingError) -> Self {
+        match error {
+            IndexingError::Indexer(err) => {
+                let reason = match err {
+                    IndexerInfoResolutionError::BlockedByAddrBlocklist => {
+                        UnavailableReason::Blocked
+                    }
+                    IndexerInfoResolutionError::HostResolutionFailed(err) => {
+                        tracing::debug!(error=?err, "host resolution failed");
+
+                        let reason = match err {
+                            HostResolutionError::InvalidUrl(_) => "invalid indexer url",
+                            HostResolutionError::DnsResolutionError(_) => {
+                                "indexer url dns resolution failed"
+                            }
+                            HostResolutionError::Timeout => {
+                                "indexer url dns resolution failed (timeout)"
+                            }
+                        };
+                        UnavailableReason::IndexerResolutionError(reason)
+                    }
+                    IndexerInfoResolutionError::BlockedByHostBlocklist => {
+                        UnavailableReason::Blocked
+                    }
+                    IndexerInfoResolutionError::IndexerServiceVersionResolutionFailed(err) => {
+                        tracing::debug!(error=?err, "indexer service version resolution failed");
+
+                        let reason = match err {
+                            VersionResolutionError::FetchError(_) => {
+                                "indexer service version resolution failed"
+                            }
+                            VersionResolutionError::Timeout => {
+                                "indexer service version resolution failed (timeout)"
+                            }
+                        };
+                        UnavailableReason::IndexerResolutionError(reason)
+                    }
+                    IndexerInfoResolutionError::IndexerServiceVersionBelowMin(..) => {
+                        UnavailableReason::IndexerServiceVersionBelowMin
+                    }
+                    IndexerInfoResolutionError::GraphNodeVersionResolutionFailed(err) => {
+                        tracing::debug!(error=?err, "graph node version resolution failed");
+
+                        let reason = match err {
+                            VersionResolutionError::FetchError(_) => {
+                                "graph node version resolution failed"
+                            }
+                            VersionResolutionError::Timeout => {
+                                "graph node version resolution failed (timeout)"
+                            }
+                        };
+                        UnavailableReason::IndexerResolutionError(reason)
+                    }
+                    IndexerInfoResolutionError::GraphNodeVersionBelowMin(..) => {
+                        UnavailableReason::GraphNodeVersionBelowMin
+                    }
+                };
+                ResolutionError::Unavailable(reason)
+            }
+            IndexingError::Indexing(err) => {
+                let reason = match err {
+                    IndexingInfoResolutionError::BlockedByPoiBlocklist => {
+                        UnavailableReason::Blocked
+                    }
+                    IndexingInfoResolutionError::IndexingProgressNotFound => {
+                        UnavailableReason::IndexingProgressNotFound
+                    }
+                };
+                ResolutionError::Unavailable(reason)
+            }
+            IndexingError::Internal(reason) => ResolutionError::Internal(reason),
+        }
+    }
+}
+
+/// Indexing error.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum IndexingError {
+    #[error(transparent)]
+    Indexer(#[from] IndexerInfoResolutionError),
+
+    #[error(transparent)]
+    Indexing(#[from] IndexingInfoResolutionError),
+
+    #[error("internal error: {0}")]
+    Internal(&'static str),
+}
+
+/// Errors when processing the indexer information.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum IndexerInfoResolutionError {
+    /// The indexer was blocked by the addrProgressNotFoundess blocklist.
+    #[error("indexer address blocked by blocklist")]
+    BlockedByAddrBlocklist,
+
+    /// The indexer's host resolution failed.
+    #[error("indexer host resolution failed: {0}")]
+    HostResolutionFailed(#[from] HostResolutionError),
+    /// The indexer was blocked by the host blocklist.
+    #[error("indexer host blocked by blocklist")]
+    BlockedByHostBlocklist,
+
+    /// The indexer's service version resolution failed.
+    #[error("indexer service version resolution failed: {0}")]
+    IndexerServiceVersionResolutionFailed(VersionResolutionError),
+    /// The indexer's service version is below the minimum required.
+    #[error("service version {0} below the minimum required {1}")]
+    IndexerServiceVersionBelowMin(Version, Version),
+
+    /// The indexer's graph node version resolution failed.
+    #[error("graph node version resolution failed: {0}")]
+    #[allow(dead_code)] // TODO: Remove once the graph node version requirement is enforced
+    GraphNodeVersionResolutionFailed(VersionResolutionError),
+    /// The indexer's graph node version is below the minimum required.
+    #[error("graph node version {0} below the minimum required {1}")]
+    GraphNodeVersionBelowMin(Version, Version),
+}
+
+/// Error when processing the indexer's indexing information.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum IndexingInfoResolutionError {
+    /// The indexing has been blocked by the public POIs blocklist.
+    #[error("indexing blocked by POIs blocklist")]
+    BlockedByPoiBlocklist,
+
+    /// The indexing progress information was not found.
+    #[error("indexing progress information not found")]
+    IndexingProgressNotFound,
+}

--- a/graph-gateway/src/network/internal.rs
+++ b/graph-gateway/src/network/internal.rs
@@ -9,19 +9,9 @@ use self::{
     subgraph_processing::{DeploymentRawInfo, SubgraphRawInfo},
 };
 pub use self::{
-    indexer_processing::{
-        IndexerError, IndexerIndexingError, IndexerIndexingInfo, IndexerInfo, IndexingProgressInfo,
-        VersionRequirements,
-    },
-    snapshot::{
-        Indexer, Indexing, IndexingError, IndexingId, IndexingProgress, NetworkTopologySnapshot,
-        UnavailableReason,
-    },
+    snapshot::{Indexer, Indexing, IndexingId, IndexingProgress, NetworkTopologySnapshot},
     state::InternalState,
-    subgraph_processing::{
-        AllocationInfo, DeploymentError, DeploymentInfo, SubgraphError, SubgraphInfo,
-        SubgraphVersionInfo,
-    },
+    subgraph_processing::{AllocationInfo, DeploymentInfo, SubgraphInfo, SubgraphVersionInfo},
 };
 use super::subgraph_client::Client as SubgraphClient;
 
@@ -101,7 +91,9 @@ async fn fetch_and_pre_process_subgraph_info(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    mod it_fetch_update;
     mod it_indexer_processing;
-    mod pre_processing;
-    mod subgraph_processing;
+    mod tests_pre_processing;
+    mod tests_subgraph_processing;
 }

--- a/graph-gateway/src/network/internal/pre_processing.rs
+++ b/graph-gateway/src/network/internal/pre_processing.rs
@@ -7,7 +7,7 @@ use url::Url;
 
 use crate::network::{
     internal::{
-        indexer_processing::{IndexerIndexingRawInfo, IndexerRawInfo},
+        indexer_processing::{IndexerRawInfo, IndexingRawInfo},
         subgraph_processing::{DeploymentRawInfo, SubgraphRawInfo, SubgraphVersionRawInfo},
         AllocationInfo,
     },
@@ -71,14 +71,13 @@ pub fn into_internal_indexers_raw_info<'a>(
             };
 
             // Update the indexer's indexings info
-            let indexing =
-                indexer
-                    .indexings
-                    .entry(deployment_id)
-                    .or_insert(IndexerIndexingRawInfo {
-                        largest_allocation: allocation.id,
-                        total_allocated_tokens: 0,
-                    });
+            let indexing = indexer
+                .indexings
+                .entry(deployment_id)
+                .or_insert(IndexingRawInfo {
+                    largest_allocation: allocation.id,
+                    total_allocated_tokens: 0,
+                });
 
             indexing.largest_allocation = indexing_largest_allocation;
             indexing.total_allocated_tokens = indexing

--- a/graph-gateway/src/network/internal/state.rs
+++ b/graph-gateway/src/network/internal/state.rs
@@ -1,5 +1,5 @@
-use super::indexer_processing::VersionRequirements as IndexerVersionRequirements;
 use crate::network::{
+    config::VersionRequirements as IndexerVersionRequirements,
     indexer_addr_blocklist::AddrBlocklist, indexer_host_blocklist::HostBlocklist,
     indexer_host_resolver::HostResolver, indexer_indexing_cost_model_compiler::CostModelCompiler,
     indexer_indexing_cost_model_resolver::CostModelResolver,

--- a/graph-gateway/src/network/internal/subgraph_processing.rs
+++ b/graph-gateway/src/network/internal/subgraph_processing.rs
@@ -3,6 +3,8 @@ use std::collections::{HashMap, HashSet};
 use alloy_primitives::{Address, BlockNumber};
 use thegraph_core::types::{DeploymentId, SubgraphId};
 
+use crate::network::errors::{DeploymentError, SubgraphError};
+
 /// Internal representation of the fetched subgraph information.
 ///
 /// This is not the final representation of the subgraph.
@@ -75,22 +77,6 @@ pub struct AllocationInfo {
     pub id: Address,
     // The indexer ID.
     pub indexer: Address,
-}
-
-/// Subgraph validation error.
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum SubgraphError {
-    /// The subgraph was transferred to L2.
-    #[error("transferred to L2")]
-    TransferredToL2 { id_on_l2: Option<SubgraphId> },
-
-    /// No allocations were found for the subgraph.
-    #[error("no allocations")]
-    NoAllocations,
-
-    /// All subgraph versions were marked as invalid.
-    #[error("no valid versions")]
-    NoValidVersions,
 }
 
 /// Process the fetched subgraphs' information.
@@ -187,18 +173,6 @@ fn check_subgraph_has_allocations(subgraph: &SubgraphRawInfo) -> Result<(), Subg
     } else {
         Ok(())
     }
-}
-
-/// Deployment validation error
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum DeploymentError {
-    /// The subgraph was transferred to L2.
-    #[error("transferred to L2")]
-    TransferredToL2,
-
-    /// No allocations were found for the subgraph.
-    #[error("no allocations")]
-    NoAllocations,
 }
 
 /// Process the fetched deployments' information.

--- a/graph-gateway/src/network/internal/tests/tests_pre_processing.rs
+++ b/graph-gateway/src/network/internal/tests/tests_pre_processing.rs
@@ -3,10 +3,8 @@ use serde_json::json;
 use thegraph_core::types::{DeploymentId, SubgraphId};
 use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 
-use crate::network::{
-    internal::{indexer_processing::IndexerIndexingRawInfo, pre_processing},
-    subgraph_client::types::Subgraph as SubgraphData,
-};
+use super::{indexer_processing::IndexingRawInfo, pre_processing};
+use crate::network::subgraph_client::types::Subgraph as SubgraphData;
 
 /// Test method to initialize the tests tracing subscriber.
 fn init_test_tracing() {
@@ -260,19 +258,19 @@ fn indexers_data_pre_processing() {
         .get(&deployment_id_4)
         .expect("indexing info not found");
 
-    let expected_indexer_1_indexing_1_info = IndexerIndexingRawInfo {
+    let expected_indexer_1_indexing_1_info = IndexingRawInfo {
         largest_allocation: parse_address("0xcc3f326bdbfcb6fc730e04d859e6103f31cd691c"),
         total_allocated_tokens: 0,
     };
-    let expected_indexer_1_indexing_2_info = IndexerIndexingRawInfo {
+    let expected_indexer_1_indexing_2_info = IndexingRawInfo {
         largest_allocation: parse_address("0xa51c172268db23b0ec7bcf36b60d4cec374c1783"),
         total_allocated_tokens: 0,
     };
-    let expected_indexer_1_indexing_3_info = IndexerIndexingRawInfo {
+    let expected_indexer_1_indexing_3_info = IndexingRawInfo {
         largest_allocation: parse_address("0x28220d396bf2c22717b07f4d767429b7d5b72b03"),
         total_allocated_tokens: 0,
     };
-    let expected_indexer_1_indexing_4_info = IndexerIndexingRawInfo {
+    let expected_indexer_1_indexing_4_info = IndexingRawInfo {
         largest_allocation: parse_address("0x070b3036035489055d59f93efb63b80c7031ebca"),
         total_allocated_tokens: 0,
     };
@@ -300,7 +298,7 @@ fn indexers_data_pre_processing() {
         .get(&deployment_id_1)
         .expect("indexing info not found");
 
-    let expected_indexer_2_indexing_1_info = IndexerIndexingRawInfo {
+    let expected_indexer_2_indexing_1_info = IndexingRawInfo {
         largest_allocation: parse_address("0x8de241c35f8bc02ae9ad635e273372dd083f6520"),
         total_allocated_tokens: 3000000000000000000,
     };

--- a/graph-gateway/src/network/internal/tests/tests_subgraph_processing.rs
+++ b/graph-gateway/src/network/internal/tests/tests_subgraph_processing.rs
@@ -5,10 +5,10 @@ use assert_matches::assert_matches;
 use thegraph_core::types::{DeploymentId, SubgraphId};
 use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 
-use crate::network::internal::subgraph_processing::{
-    self, AllocationInfo, DeploymentError, DeploymentRawInfo, SubgraphError, SubgraphRawInfo,
-    SubgraphVersionRawInfo,
+use super::subgraph_processing::{
+    self, AllocationInfo, DeploymentRawInfo, SubgraphRawInfo, SubgraphVersionRawInfo,
 };
+use crate::network::errors::{DeploymentError, SubgraphError};
 
 // Test method to initialize the tests tracing subscriber.
 fn init_test_tracing() {


### PR DESCRIPTION
This is a major code iteration with the main goal of disambiguating the error messages returned by the gateway.

- [x] Relocate all errors under `network::errors`
- [x] Use type-state pattern in `indexer_processing` module to ensure the type safety of the generated data. Refactor the code, splitting the indexing processing into a separate function
- [x] Relocate integration tests in-tree (`it_network_internal_fetch_update`)
- [x] Add `network::config` module to co-locate all config types
- [x] Remove various unused fields