### PR TITLE
refactor(graph-gateway): simplify gateway configuration

### DIFF
--- a/gateway-framework/src/logging.rs
+++ b/gateway-framework/src/logging.rs
@@ -1,6 +1,6 @@
 use tracing_subscriber::{prelude::*, registry, EnvFilter};
 
-pub fn init(executable_name: String, json: bool) {
+pub fn init(executable_name: &str, json: bool) {
     let env_filter = EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| EnvFilter::try_new(format!("info,{executable_name}=debug")).unwrap());
 

--- a/graph-gateway/src/indexers/public_poi.rs
+++ b/graph-gateway/src/indexers/public_poi.rs
@@ -62,6 +62,17 @@ impl ProofOfIndexingInfo {
     }
 }
 
+impl From<((DeploymentId, BlockNumber), ProofOfIndexing)> for ProofOfIndexingInfo {
+    fn from(value: ((DeploymentId, BlockNumber), ProofOfIndexing)) -> Self {
+        let ((deployment_id, block_number), proof_of_indexing) = value;
+        Self {
+            deployment_id,
+            block_number,
+            proof_of_indexing,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct PublicProofOfIndexingRequest {

--- a/graph-gateway/src/network/indexer_host_blocklist.rs
+++ b/graph-gateway/src/network/indexer_host_blocklist.rs
@@ -5,22 +5,10 @@
 //! are resolved to IP addresses using a DNS resolver, and then checked against the blocklist. The
 //! result is cached so that subsequent calls with the same URL will return the same result.
 
-use std::{collections::HashSet, fs, net::IpAddr, path::Path};
+use std::{collections::HashSet, net::IpAddr};
 
-use anyhow::Context as _;
 use gateway_common::blocklist::{Blocklist, Result as BlocklistResult};
 use ipnetwork::IpNetwork;
-
-/// Load the IP blocklist from a CSV file.
-///
-/// The CSV file should contain rows of `IpNetwork,Country`.
-pub fn load_ip_blocklist_conf(db_path: &Path) -> anyhow::Result<HashSet<IpNetwork>> {
-    let db = fs::read_to_string(db_path).context("IP blocklist DB")?;
-    Ok(db
-        .lines()
-        .filter_map(|line| line.split_once(',')?.0.parse().ok())
-        .collect())
-}
 
 /// An IP blocklist for indexers.
 ///

--- a/graph-gateway/src/network/indexer_indexing_poi_blocklist.rs
+++ b/graph-gateway/src/network/indexer_indexing_poi_blocklist.rs
@@ -22,13 +22,16 @@ pub struct PoiBlocklist {
 
 impl PoiBlocklist {
     /// Create a new indexer POI blocklist with the given configuration.
-    pub fn new(conf: HashSet<ProofOfIndexingInfo>) -> Self {
+    pub fn new<TInfo>(conf: impl IntoIterator<Item = TInfo>) -> Self
+    where
+        TInfo: Into<ProofOfIndexingInfo>,
+    {
         // Group the blocked POI info by deployment ID
         let mut conf_map = HashMap::new();
         for info in conf {
-            let deployment_id = info.deployment_id;
+            let info = info.into();
             conf_map
-                .entry(deployment_id)
+                .entry(info.deployment_id)
                 .or_insert_with(HashSet::new)
                 .insert(info);
         }

--- a/graph-gateway/src/network/internal/tests/it_indexer_processing.rs
+++ b/graph-gateway/src/network/internal/tests/it_indexer_processing.rs
@@ -7,7 +7,7 @@ use alloy_primitives::{Address, BlockNumber};
 use assert_matches::assert_matches;
 use ipnetwork::IpNetwork;
 use semver::Version;
-use thegraph_core::types::DeploymentId;
+use thegraph_core::types::{DeploymentId, ProofOfIndexing};
 use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 use url::Url;
 
@@ -15,23 +15,20 @@ use super::{
     indexer_processing::{self, IndexerRawInfo, IndexingRawInfo},
     InternalState,
 };
-use crate::{
-    indexers::public_poi::{ProofOfIndexing, ProofOfIndexingInfo},
-    network::{
-        config::VersionRequirements as IndexerVersionRequirements,
-        errors::{IndexerInfoResolutionError, IndexingInfoResolutionError},
-        indexer_addr_blocklist::AddrBlocklist,
-        indexer_host_blocklist::HostBlocklist,
-        indexer_host_resolver::HostResolver,
-        indexer_indexing_cost_model_compiler::CostModelCompiler,
-        indexer_indexing_cost_model_resolver::CostModelResolver,
-        indexer_indexing_poi_blocklist::PoiBlocklist,
-        indexer_indexing_poi_resolver::PoiResolver,
-        indexer_indexing_progress_resolver::IndexingProgressResolver,
-        indexer_version_resolver::{
-            VersionResolver, DEFAULT_INDEXER_VERSION_CACHE_TTL,
-            DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT,
-        },
+use crate::network::{
+    config::VersionRequirements as IndexerVersionRequirements,
+    errors::{IndexerInfoResolutionError, IndexingInfoResolutionError},
+    indexer_addr_blocklist::AddrBlocklist,
+    indexer_host_blocklist::HostBlocklist,
+    indexer_host_resolver::HostResolver,
+    indexer_indexing_cost_model_compiler::CostModelCompiler,
+    indexer_indexing_cost_model_resolver::CostModelResolver,
+    indexer_indexing_poi_blocklist::PoiBlocklist,
+    indexer_indexing_poi_resolver::PoiResolver,
+    indexer_indexing_progress_resolver::IndexingProgressResolver,
+    indexer_version_resolver::{
+        VersionResolver, DEFAULT_INDEXER_VERSION_CACHE_TTL,
+        DEFAULT_INDEXER_VERSION_RESOLUTION_TIMEOUT,
     },
 };
 
@@ -134,14 +131,6 @@ fn test_service_state(
     }
 
     if !pois_blocklist.is_empty() {
-        let pois_blocklist = pois_blocklist
-            .into_iter()
-            .map(|((deployment_id, block_number), poi)| ProofOfIndexingInfo {
-                deployment_id,
-                block_number,
-                proof_of_indexing: poi,
-            })
-            .collect();
         let pois_blocklist = PoiBlocklist::new(pois_blocklist);
         let pois_resolver = PoiResolver::new(indexers_http_client.clone());
         state.indexer_indexing_pois_blocklist = Some((pois_resolver, pois_blocklist));

--- a/graph-gateway/src/network/service.rs
+++ b/graph-gateway/src/network/service.rs
@@ -11,7 +11,7 @@ use alloy_primitives::{Address, BlockNumber};
 use gateway_common::ttl_hash_map::DEFAULT_TTL;
 use ipnetwork::IpNetwork;
 use semver::Version;
-use thegraph_core::types::{DeploymentId, SubgraphId};
+use thegraph_core::types::{DeploymentId, ProofOfIndexing, SubgraphId};
 use tokio::{sync::watch, time::MissedTickBehavior};
 
 use super::{
@@ -36,7 +36,6 @@ use super::{
     subgraph_client::Client as SubgraphClient,
     ResolutionError,
 };
-use crate::indexers::public_poi::ProofOfIndexingInfo;
 
 /// Default update interval for the network topology information.
 pub const DEFAULT_UPDATE_INTERVAL: Duration = Duration::from_secs(60);
@@ -271,7 +270,10 @@ impl NetworkServiceBuilder {
     }
 
     /// Sets the indexer POIs blocklist.
-    pub fn with_indexer_pois_blocklist(mut self, blocklist: HashSet<ProofOfIndexingInfo>) -> Self {
+    pub fn with_indexer_pois_blocklist(
+        mut self,
+        blocklist: HashSet<((DeploymentId, BlockNumber), ProofOfIndexing)>,
+    ) -> Self {
         let resolver = PoiResolver::with_timeout_and_cache_ttl(
             self.indexer_client.clone(),
             DEFAULT_INDEXER_INDEXING_POIS_RESOLUTION_TIMEOUT, // 5s


### PR DESCRIPTION
This is a ~small~ gardening 🪴 PR aiming to move some configuration runtime checks to the configuration parsing stage, and some other minor code refactorings:

- [x] Add the `config::load_from_file` function to abstract configuration loading.
- [x] Move the IP block list config file load function into the `config` module.
- [x] Deserialize and check `NotNan<f64>` values during the configuration parsing stage.
- [x] Update `reports` constructor to simplify the `Reporter` instantiation.
- [x] Decouple `config`, `network::service` and `main` from the `indexers` POI info type.
- [x] Rename `config` variable names to `conf` to avoid name collision with the `config` module.
- [x] Adde documentation to the different configuration structs.