### PR TITLE
feat: log all response error messages

### DIFF
--- a/gateway-framework/src/errors.rs
+++ b/gateway-framework/src/errors.rs
@@ -36,6 +36,7 @@ pub enum Error {
 
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
+        tracing::info!(response_err = %self);
         graphql::error_response(self).into_response()
     }
 }


### PR DESCRIPTION
This makes sure we log all error responses back to the client, even if it doesn't fall into the main client query handler. Not sure if there's a cleaner way to do this.