### PR TITLE
fix: success rate cutoff at fixed time behind chain head

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -704,7 +704,7 @@ fn perf(
     // Since our gateway is specialized for frontends, add an additional penalty for candidates
     // far behind chain head. This compensates for the impacts of information decay and the sharp
     // dropoff of our `seconds_behind` curve.
-    if (seconds_behind as u64) > (blocks_per_minute * 60 * 30) {
+    if seconds_behind > (60 * 30) {
         response.success_rate = Normalized::ZERO;
     }
 


### PR DESCRIPTION
The original intention of this was to apply this penalty when an indexer is more than 30 minutes behind chain head.