### PR TITLE
feat: add TooFarBehind error

### DIFF
--- a/gateway-framework/src/errors.rs
+++ b/gateway-framework/src/errors.rs
@@ -114,6 +114,10 @@ pub enum UnavailableReason {
     #[error("{}", .0.message())]
     MissingBlock(MissingBlockError),
 
+    /// The indexer is too far behind chain head for an unconstrained query.
+    #[error("too far behind")]
+    TooFarBehind,
+
     /// An internal error occurred.
     #[error("internal error: {0}")]
     Internal(&'static str),

--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -598,6 +598,14 @@ fn build_candidates_list(
             }
         };
 
+        if block_requirements.latest && (perf.seconds_behind > (60 * 30)) {
+            candidates_errors.insert(
+                indexing_id.indexer,
+                IndexerError::Unavailable(UnavailableReason::TooFarBehind),
+            );
+            continue;
+        }
+
         // Check if the indexer is within the required block range
         if let Some((min_block, max_block)) = &block_requirements.range {
             // Allow indexers if their last reported block is "close enough" to the required block


### PR DESCRIPTION
User expectation is that, by default, indexers far behind chain head should not be responding. Especially when other indexers experience intermittent failures or timeouts.