### PR TITLE
feat(graph-gateway): add internal query client to network subgraph service

### DIFF
--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{BTreeMap, HashSet},
-    fmt::{self, Display},
+    fmt,
     path::{Path, PathBuf},
 };
 
@@ -65,10 +65,8 @@ pub struct Config {
     /// Minimum indexer-service version that will receive queries
     #[serde_as(as = "DisplayFromStr")]
     pub min_indexer_version: Version,
-    /// Network subgraph query path
-    #[debug(with = Display::fmt)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub network_subgraph: Url,
+    /// Network subgraph discovery service configuration
+    pub network: NetworkSubgraphServiceConfig,
     /// Check payment state of client (disable for testnets)
     pub payment_required: bool,
     /// POI blocklist
@@ -204,7 +202,7 @@ pub struct Scalar {
 /// Proof of indexing info for the POI blocklist.
 ///
 /// See [`Config`]'s [`poi_blocklist`](struct.Config.html#structfield.poi_blocklist).
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ProofOfIndexingInfo {
     /// POI deployment ID (the IPFS Hash in the Graph Network Subgraph).
     pub deployment_id: DeploymentId,
@@ -221,6 +219,29 @@ impl From<ProofOfIndexingInfo> for ((DeploymentId, BlockNumber), ProofOfIndexing
             info.proof_of_indexing,
         )
     }
+}
+
+/// Network service configuration.
+#[derive(Debug, Deserialize)]
+pub struct NetworkSubgraphServiceConfig {
+    /// Deployment ID of the network subgraph.
+    pub deployment_id: DeploymentId,
+    /// List of network subgraph update candidates.
+    pub indexers: Vec<NetworkSubgraphIndexer>,
+}
+
+/// Network subgraph update candidate.
+#[serde_as]
+#[derive(CustomDebug, Deserialize)]
+pub struct NetworkSubgraphIndexer {
+    /// The indexer's ID.
+    pub id: Address,
+    /// The indexer base URL.
+    #[debug(with = std::fmt::Display::fmt)]
+    #[serde_as(as = "DisplayFromStr")]
+    pub url: Url,
+    /// The indexer's free query auth token.
+    pub auth: String,
 }
 
 /// Load the configuration from a JSON file.

--- a/graph-gateway/src/network/internal/tests/it_fetch_update.rs
+++ b/graph-gateway/src/network/internal/tests/it_fetch_update.rs
@@ -3,7 +3,6 @@ use std::{collections::HashSet, sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use ipnetwork::IpNetwork;
 use semver::Version;
-use thegraph_core::client::Client as SubgraphClient;
 use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 use url::Url;
 
@@ -12,11 +11,15 @@ use super::{
     NetworkTopologySnapshot,
 };
 use crate::network::{
-    indexer_addr_blocklist::AddrBlocklist, indexer_host_blocklist::HostBlocklist,
-    indexer_host_resolver::HostResolver, indexer_indexing_cost_model_compiler::CostModelCompiler,
+    indexer_addr_blocklist::AddrBlocklist,
+    indexer_host_blocklist::HostBlocklist,
+    indexer_host_resolver::HostResolver,
+    indexer_indexing_cost_model_compiler::CostModelCompiler,
     indexer_indexing_cost_model_resolver::CostModelResolver,
     indexer_indexing_progress_resolver::IndexingProgressResolver,
-    indexer_version_resolver::VersionResolver, subgraph_client::Client, IndexingError,
+    indexer_version_resolver::VersionResolver,
+    subgraph_client::{core_paginated_client::Client as SubgraphClient, Client},
+    IndexingError,
 };
 
 // Test method to initialize the tests tracing subscriber.
@@ -107,9 +110,7 @@ async fn fetch_update(service: &InternalState) -> anyhow::Result<NetworkTopology
 
     let client = {
         let http_client = reqwest::Client::new();
-        let subgraph_client = SubgraphClient::builder(http_client, subgraph_url)
-            .with_auth_token(Some(auth_token))
-            .build();
+        let subgraph_client = SubgraphClient::new(http_client, subgraph_url, Some(auth_token));
         Client::new(subgraph_client, true)
     };
 

--- a/graph-gateway/src/network/subgraph_client/core_paginated_client.rs
+++ b/graph-gateway/src/network/subgraph_client/core_paginated_client.rs
@@ -1,0 +1,34 @@
+use serde::de::DeserializeOwned;
+use thegraph_core::client::Client as CoreClient;
+use thegraph_graphql_http::graphql::Document;
+use url::Url;
+
+use super::paginated_client::PaginatedClient;
+
+/// A `thegraph-core` client that fetches subgraph data in a paginated way.
+pub struct Client {
+    inner: CoreClient,
+}
+
+impl Client {
+    /// Creates a new `Client`.
+    pub fn new(client: reqwest::Client, url: Url, auth_token: Option<String>) -> Self {
+        Self {
+            inner: CoreClient::builder(client, url)
+                .with_auth_token(auth_token)
+                .build(),
+        }
+    }
+}
+
+impl PaginatedClient for Client {
+    async fn paginated_query<T>(&self, query: Document, page_size: usize) -> Result<Vec<T>, String>
+    where
+        T: for<'de> DeserializeOwned + Send,
+    {
+        self.inner
+            .paginated_query::<T>(query, page_size)
+            .await
+            .map_err(|e| e.to_string())
+    }
+}

--- a/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client.rs
+++ b/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client.rs
@@ -1,0 +1,93 @@
+//! A paginated query subgraph client that supports querying the indexer endpoint directly.
+//!
+//! The client inserts an `Authorization` header with the indexer's free query auth token to
+//! authenticate the request with the indexer.
+
+use alloy_primitives::Address;
+use inner_client::Client as PaginatedIndexerSubgraphClient;
+use serde::Deserialize;
+use thegraph_core::types::DeploymentId;
+use thegraph_graphql_http::graphql::Document;
+use url::Url;
+
+use super::paginated_client::PaginatedClient;
+
+mod inner_client;
+mod queries;
+
+/// Builds a URL to query an indexer's subgraph.
+fn indexer_subgraph_url(base: &Url, deployment: &DeploymentId) -> anyhow::Result<Url> {
+    base.join(&format!("subgraphs/id/{}", deployment))
+        .map_err(Into::into)
+}
+
+/// A client that fetches data from a list of candidate indexers.
+///
+/// The client will try to fetch data from each candidate in the order they were
+/// provided. If a candidate fails to fetch the data, the client will try the
+/// next candidate in the list.
+///
+/// The client will return an error if all candidates fail to fetch the data.
+pub struct Client {
+    inner: PaginatedIndexerSubgraphClient,
+    candidates: Vec<SubgraphCandidate>,
+}
+
+impl Client {
+    pub fn new(
+        client: reqwest::Client,
+        subgraph: DeploymentId,
+        candidates: impl IntoIterator<Item = (Address, (Url, String))>,
+    ) -> Self {
+        let inner = PaginatedIndexerSubgraphClient::new(client);
+        let candidates = candidates
+            .into_iter()
+            .filter_map(|(id, (url, auth))| {
+                let url = indexer_subgraph_url(&url, &subgraph).ok()?;
+                Some(SubgraphCandidate { id, url, auth })
+            })
+            .collect();
+
+        Self { inner, candidates }
+    }
+}
+
+impl PaginatedClient for Client {
+    async fn paginated_query<T>(&self, query: Document, page_size: usize) -> Result<Vec<T>, String>
+    where
+        T: for<'de> Deserialize<'de> + Send,
+    {
+        for indexer in self.candidates.iter() {
+            let result = self
+                .inner
+                .paginated_query(indexer.url.clone(), &indexer.auth, query.clone(), page_size)
+                .await;
+
+            match result {
+                Err(err) => {
+                    tracing::warn!(
+                        indexer=%indexer.id,
+                        error=?err,
+                        "Failed to fetch network subgraph from indexer",
+                    );
+                }
+                Ok(result) if result.is_empty() => {
+                    tracing::warn!(
+                        indexer=%indexer.id,
+                        "Indexer returned an empty response",
+                    );
+                }
+                Ok(result) => return Ok(result),
+            }
+        }
+
+        Err("no candidate indexers left".to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SubgraphCandidate {
+    id: Address,
+    url: Url,
+    auth: String,
+}

--- a/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client/inner_client.rs
+++ b/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client/inner_client.rs
@@ -1,0 +1,266 @@
+use std::sync::{atomic::AtomicU64, Arc};
+
+use alloy_primitives::aliases::BlockNumber;
+use serde::de::Deserialize;
+use thegraph_core::types::BlockPointer;
+use thegraph_graphql_http::{graphql::Document, http_client::ResponseError};
+use url::Url;
+
+use super::queries::{
+    meta::send_bootstrap_meta_query,
+    page::{send_subgraph_page_query, BlockHeight, SubgraphPageQueryResponseOpaqueEntry},
+};
+
+/// Error message returned by the indexer typically when a reorg happens.
+const SUBGRAPH_REORG_ERROR: &str = "no block with that hash found";
+
+/// Errors that can occur while sending a paginated query.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum PaginatedQueryError {
+    /// The bootstrap meta query failed.
+    #[error("bootstrap meta query failed: {0}")]
+    BootstrapMetaQueryFailed(String),
+
+    /// The page response was empty.
+    ///
+    /// A page query response should always contain at least the 'meta' field response. If the
+    /// response is empty, it means that the subgraph is not returning any data.
+    #[error("empty response")]
+    EmptyResponse,
+
+    /// A reorg was detected.
+    ///
+    /// The indexer responded with an error message indicating that a reorg was detected.
+    #[error("reorg detected")]
+    ReorgDetected,
+
+    /// An error occurred while sending one of the requests.
+    #[error("request error: {0}")]
+    RequestError(String),
+
+    /// An error occurred while processing the query.
+    ///
+    /// This error contains the error messages returned by the indexer when an error occurred while
+    /// processing one of the page requests.
+    #[error("response error: {0:?}")]
+    ResponseError(Vec<String>),
+
+    /// Response deserialization error.
+    ///
+    /// An error occurred while deserializing the response.
+    #[error("deserialization error: {0}")]
+    DeserializationError(String),
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_paginated_query<T>(
+    client: reqwest::Client,
+    subgraph_url: Url,
+    auth: &str,
+    query: Document,
+    page_size: usize,
+    mut block_height: BlockHeight,
+) -> anyhow::Result<(Vec<T>, Option<BlockPointer>)>
+where
+    T: for<'de> Deserialize<'de> + Send,
+{
+    debug_assert_ne!(page_size, 0, "page size must be greater than 0");
+
+    // Block at which the query is executed.
+    let mut block_pointer: Option<BlockPointer> = None;
+
+    // The last id of the previous batch.
+    let mut last_id: Option<String> = None;
+
+    // Vector to store the results of the paginated query.
+    let mut results = Vec::new();
+
+    loop {
+        tracing::trace!(
+            last_id = %last_id.as_deref().unwrap_or("none"),
+            "sending page query request"
+        );
+
+        let response = send_subgraph_page_query(
+            &client,
+            subgraph_url.clone(),
+            auth,
+            query.clone(),
+            block_height,
+            page_size,
+            last_id,
+        )
+        .await
+        .map_err(PaginatedQueryError::RequestError)?;
+
+        let resp = match response {
+            Ok(data) => data,
+            Err(err) => {
+                return match err {
+                    ResponseError::Empty => Err(PaginatedQueryError::EmptyResponse.into()),
+                    ResponseError::Failure { errors } => {
+                        // Check if the error message contains the reorg error message.
+                        if errors
+                            .iter()
+                            .any(|err| err.message.contains(SUBGRAPH_REORG_ERROR))
+                        {
+                            tracing::debug!(errors=?errors, "reorg detected");
+                            return Err(PaginatedQueryError::ReorgDetected.into());
+                        }
+
+                        let errors = errors
+                            .into_iter()
+                            .map(|err| err.message)
+                            .collect::<Vec<String>>();
+                        Err(PaginatedQueryError::ResponseError(errors).into())
+                    }
+                };
+            }
+        };
+
+        // Return if the page response was empty (no results).
+        if resp.results.is_empty() {
+            return Ok((results, block_pointer));
+        }
+
+        // Extract the page's last entry ID from the response.
+        last_id = {
+            let raw_data = resp.results.last().unwrap().get();
+            match serde_json::from_str::<SubgraphPageQueryResponseOpaqueEntry>(raw_data) {
+                Ok(item) => Some(item.id),
+                Err(err) => {
+                    tracing::debug!(error = %err, "failed to extract 'id' for last page entry");
+                    return Err(PaginatedQueryError::DeserializationError(
+                        "failed to extract 'id' for last page entry".to_string(),
+                    )
+                    .into());
+                }
+            }
+        };
+
+        tracing::trace!(
+            block_number = %resp.meta.block.number,
+            block_hash = %resp.meta.block.hash,
+            page_items_count = %resp.results.len(),
+            page_items_last_id = %last_id.as_deref().unwrap_or_default(),
+            "received page query response"
+        );
+
+        block_height = BlockHeight::Hash(resp.meta.block.hash);
+        block_pointer = Some(resp.meta.block);
+
+        // Deserialize the response data and push them to the results vector
+        for entity in resp.results {
+            match serde_json::from_str::<T>(entity.get()) {
+                Ok(data) => results.push(data),
+                Err(err) => {
+                    return Err(PaginatedQueryError::DeserializationError(err.to_string()).into());
+                }
+            }
+        }
+    }
+}
+
+/// A client for interacting with a subgraph.
+#[derive(Clone)]
+pub struct Client {
+    http_client: reqwest::Client,
+
+    /// The latest block number that the subgraph has progressed to.
+    ///
+    /// By default, this value is 0, and is updated after each paginated query.
+    latest_block: Arc<AtomicU64>,
+}
+
+impl Client {
+    /// Create a new client with default settings.
+    ///
+    /// The default settings are:
+    /// - No authentication token
+    /// - Latest block number of 0
+    pub fn new(http_client: reqwest::Client) -> Self {
+        Self {
+            http_client,
+            latest_block: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Get the latest block number.
+    fn latest_block(&self) -> BlockNumber {
+        self.latest_block.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Update the client's latest block number.
+    ///
+    /// The function ensures that the latest block number is always increasing
+    ///
+    /// Returns the latest block number.
+    fn update_latest_block(&self, new_value: BlockNumber) -> BlockNumber {
+        // Ensure that the latest block number is always increasing
+        self.latest_block
+            .fetch_max(new_value, std::sync::atomic::Ordering::Relaxed)
+            .max(new_value)
+    }
+
+    /// Send a paginated query to the subgraph.
+    ///
+    /// The query is sent with a page size of `page_size` and the latest block number that the
+    /// subgraph has progressed to.
+    ///
+    /// In the case of a reorg, the function will return an error.
+    pub async fn paginated_query<T>(
+        &self,
+        subgraph_url: Url,
+        auth: &str,
+        query: Document,
+        page_size: usize,
+    ) -> anyhow::Result<Vec<T>>
+    where
+        T: for<'de> Deserialize<'de> + Send,
+    {
+        // Send a bootstrap meta query if the latest block number is 0.
+        //
+        // Graph-node is rejecting values of `number_gte:0` on subgraphs with a larger `startBlock`.
+        // This forces us to request the latest block number from the subgraph before sending the
+        // paginated query.
+        let mut latest_block = self.latest_block();
+        if latest_block == 0 {
+            tracing::debug!("sending bootstrap meta query");
+
+            let bootstrap_block = send_bootstrap_meta_query(&self.http_client, &subgraph_url, auth)
+                .await
+                .map_err(PaginatedQueryError::BootstrapMetaQueryFailed)?;
+
+            tracing::debug!(
+                block_number = bootstrap_block.meta.block.number,
+                block_hash = %bootstrap_block.meta.block.hash,
+                "received bootstrap meta query response"
+            );
+
+            // Update the latest block number
+            latest_block = self.update_latest_block(bootstrap_block.meta.block.number);
+        }
+
+        // Send the paginated query request
+        tracing::debug!(block_number = %latest_block ,"sending request");
+
+        let (results, block) = send_paginated_query(
+            self.http_client.clone(),
+            subgraph_url.clone(),
+            auth,
+            query,
+            page_size,
+            BlockHeight::NumberGte(latest_block),
+        )
+        .await?;
+
+        // Update the latest block number
+        if let Some(block) = block {
+            self.update_latest_block(block.number);
+        }
+
+        tracing::debug!(total_items_count = %results.len(), "received response");
+
+        Ok(results)
+    }
+}

--- a/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client/queries.rs
+++ b/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client/queries.rs
@@ -1,0 +1,277 @@
+use serde::{de::Error as _, Deserialize};
+use thegraph_core::types::Attestation;
+use thegraph_graphql_http::{
+    http::{
+        request::IntoRequestParameters,
+        response::{Error, ResponseBody},
+    },
+    http_client::{RequestError, ResponseError, ResponseResult},
+};
+use url::Url;
+
+/// Send an authenticated GraphQL query to a subgraph.
+pub async fn send_query<T>(
+    client: &reqwest::Client,
+    url: Url,
+    auth: &str,
+    query: impl IntoRequestParameters + Send,
+) -> anyhow::Result<ResponseResult<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let resp = client
+        .post(url)
+        .bearer_auth(auth)
+        .json(&query.into_request_parameters())
+        .send()
+        .await?;
+
+    process_indexer_graphql_response(resp)
+        .await
+        .map_err(anyhow::Error::from)
+}
+
+/// The payload of an indexer response.
+#[derive(Debug, Deserialize)]
+pub struct IndexerResponsePayload {
+    /// Encapsulates the GraphQL response data.
+    #[serde(rename = "graphQLResponse")]
+    pub data: Option<String>,
+    /// Response attestation.
+    pub attestation: Option<Attestation>,
+    /// Error message.
+    pub error: Option<String>,
+}
+
+async fn process_indexer_graphql_response<ResponseData>(
+    resp: reqwest::Response,
+) -> Result<ResponseResult<ResponseData>, RequestError>
+where
+    ResponseData: serde::de::DeserializeOwned,
+{
+    let status = resp.status();
+
+    // [6.4.1 application/json](https://graphql.github.io/graphql-over-http/draft/#sec-application-json)
+    //
+    // > The server SHOULD use the 200 status code for every response to a well-formed
+    // > GraphQL-over-HTTP request, independent of any GraphQL request error or GraphQL field error
+    // > raised.
+    //
+    // > For compatibility with legacy servers, this specification allows the use of `4xx` or `5xx`
+    // > status codes for a failed well-formed GraphQL-over-HTTP request where the response uses
+    // > the `application/json` media type, but it is **strongly discouraged**.
+    if !status.is_success() && !status.is_client_error() && !status.is_server_error() {
+        return Err(RequestError::ResponseRecvError(status, resp.text().await?));
+    }
+
+    // Receive the response body.
+    let response = resp.bytes().await.map_err(|err| {
+        RequestError::ResponseRecvError(status, format!("Error reading response body: {}", err))
+    })?;
+
+    // Deserialize the response body.
+    let resp: IndexerResponsePayload = serde_json::from_slice(&response).map_err(|error| {
+        RequestError::ResponseDeserializationError {
+            error,
+            response: String::from_utf8_lossy(&response).to_string(),
+        }
+    })?;
+
+    Ok(match (resp.data, resp.attestation, resp.error) {
+        (Some(resp), _, None) => {
+            // Deserialize the encapsulated response from the `graphQLResponse` field
+            let response: ResponseBody<ResponseData> =
+                serde_json::from_str(&resp).map_err(|error| {
+                    RequestError::ResponseDeserializationError {
+                        error,
+                        response: resp.to_string(),
+                    }
+                })?;
+
+            // Check if the encapsulated response contains errors
+            if !response.errors.is_empty() {
+                return Err(RequestError::ResponseDeserializationError {
+                    error: serde_json::Error::custom("response contains errors"),
+                    response: resp.to_string(),
+                });
+            }
+
+            // Extract the `data` field from the response
+            let data = response
+                .data
+                .ok_or_else(|| RequestError::ResponseDeserializationError {
+                    error: serde_json::Error::custom("response data missing"),
+                    response: resp.to_string(),
+                })?;
+
+            Ok(data)
+        }
+
+        // If error is present, return it as a failure
+        // Do not consider partial responses
+        (_, _, Some(error)) => Err(ResponseError::Failure {
+            errors: vec![Error {
+                message: error,
+                locations: vec![],
+                path: vec![],
+            }],
+        }),
+
+        // Error is required for failed responses
+        (None, _, _) => Err(ResponseError::Empty),
+    })
+}
+
+/// Subgraphs sometimes fall behind, be it due to failing or the Graph Node may be having issues.
+/// The `_meta` field can now be added to any query so that it is possible to determine against
+/// which block the query was effectively executed.
+pub mod meta {
+    use serde::Deserialize;
+    use thegraph_core::types::BlockPointer;
+    use url::Url;
+
+    use super::send_query;
+
+    const SUBGRAPH_META_QUERY_DOCUMENT: &str = r#"{ meta: _meta { block { number hash } } }"#;
+
+    #[derive(Debug, Deserialize)]
+    pub struct SubgraphMetaQueryResponse {
+        pub meta: Meta,
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct Meta {
+        pub block: BlockPointer,
+    }
+
+    pub async fn send_bootstrap_meta_query(
+        client: &reqwest::Client,
+        subgraph_url: &Url,
+        auth: &str,
+    ) -> Result<SubgraphMetaQueryResponse, String> {
+        send_query(
+            client,
+            subgraph_url.clone(),
+            auth,
+            SUBGRAPH_META_QUERY_DOCUMENT,
+        )
+        .await
+        .map_err(|err| format!("Error sending subgraph meta query: {}", err))?
+        .map_err(|err| err.to_string())
+    }
+}
+
+pub mod page {
+    use alloy_primitives::{BlockHash, BlockNumber};
+    use serde::{ser::SerializeMap as _, Deserialize, Serialize, Serializer};
+    use serde_json::value::RawValue;
+    use thegraph_graphql_http::{
+        graphql::{Document, IntoDocument, IntoDocumentWithVariables},
+        http_client::ResponseResult,
+    };
+    use url::Url;
+
+    use super::{meta::Meta, send_query};
+
+    /// The block at which the query should be executed.
+    ///
+    /// This is part of the input arguments of the [`SubgraphPageQuery`].
+    #[derive(Clone, Debug, Default)]
+    pub enum BlockHeight {
+        #[default]
+        Latest,
+        Hash(BlockHash),
+        NumberGte(BlockNumber),
+    }
+
+    impl Serialize for BlockHeight {
+        fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+            let mut obj = s.serialize_map(Some(1))?;
+            match self {
+                Self::Latest => (),
+                Self::Hash(hash) => obj.serialize_entry("hash", hash)?,
+                Self::NumberGte(number) => obj.serialize_entry("number_gte", number)?,
+            }
+            obj.end()
+        }
+    }
+
+    /// The arguments of the [`SubgraphPageQuery`] query.
+    #[derive(Clone, Debug, Serialize)]
+    pub struct SubgraphPageQueryVars {
+        /// The block at which the query should be executed.
+        block: BlockHeight,
+        /// The maximum number of entities to fetch.
+        first: usize,
+        /// The ID of the last entity fetched.
+        last: String,
+    }
+
+    pub struct SubgraphPageQuery {
+        query: Document,
+        vars: SubgraphPageQueryVars,
+    }
+
+    impl SubgraphPageQuery {
+        pub fn new(
+            query: impl IntoDocument,
+            block: BlockHeight,
+            first: usize,
+            last: String,
+        ) -> Self {
+            Self {
+                query: query.into_document(),
+                vars: SubgraphPageQueryVars { block, first, last },
+            }
+        }
+    }
+
+    impl IntoDocumentWithVariables for SubgraphPageQuery {
+        type Variables = SubgraphPageQueryVars;
+
+        fn into_document_with_variables(self) -> (Document, Self::Variables) {
+            let query = indoc::formatdoc! {
+                r#"query ($block: Block_height!, $first: Int!, $last: String!) {{
+                    meta: _meta(block: $block) {{ block {{ number hash }} }}
+                    results: {query}
+                }}"#,
+                query = self.query
+            };
+
+            (query.into_document(), self.vars)
+        }
+    }
+
+    #[derive(Debug, Deserialize)]
+    pub struct SubgraphPageQueryResponse {
+        pub meta: Meta,
+        pub results: Vec<Box<RawValue>>,
+    }
+
+    /// An opaque entry in the response of a subgraph page query.
+    ///
+    /// This is used to determine the ID of the last entity fetched.
+    #[derive(Debug, Deserialize)]
+    pub struct SubgraphPageQueryResponseOpaqueEntry {
+        pub id: String,
+    }
+
+    pub async fn send_subgraph_page_query(
+        client: &reqwest::Client,
+        subgraph_url: Url,
+        auth: &str,
+        query: impl IntoDocument,
+        block_height: BlockHeight,
+        batch_size: usize,
+        last: Option<String>,
+    ) -> Result<ResponseResult<SubgraphPageQueryResponse>, String> {
+        send_query(
+            client,
+            subgraph_url,
+            auth,
+            SubgraphPageQuery::new(query, block_height, batch_size, last.unwrap_or_default()),
+        )
+        .await
+        .map_err(|err| format!("Error sending subgraph graphql query: {}", err))
+    }
+}

--- a/graph-gateway/src/network/subgraph_client/paginated_client.rs
+++ b/graph-gateway/src/network/subgraph_client/paginated_client.rs
@@ -1,0 +1,15 @@
+use std::future::Future;
+
+use serde::Deserialize;
+use thegraph_graphql_http::graphql::Document;
+
+/// A trait for clients that can fetch paginated data.
+pub trait PaginatedClient {
+    fn paginated_query<T>(
+        &self,
+        query: Document,
+        page_size: usize,
+    ) -> impl Future<Output = Result<Vec<T>, String>> + Send
+    where
+        T: for<'de> Deserialize<'de> + Send;
+}

--- a/graph-gateway/src/network/subgraph_client/tests/it_fetch_and_deserialize.rs
+++ b/graph-gateway/src/network/subgraph_client/tests/it_fetch_and_deserialize.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use assert_matches::assert_matches;
-use graph_gateway::network::subgraph_client::Client;
-use thegraph_core::client::Client as SubgraphClient;
 use url::Url;
+
+use super::{core_paginated_client::Client as SubgraphClient, Client};
 
 /// Test helper to get the test url from the environment.
 fn test_base_url() -> Url {
@@ -39,14 +39,12 @@ async fn fetch_subgraphs_and_deserialize() {
 
     let network_subgraph_client = {
         let http_client = reqwest::Client::new();
-        let subgraph_client = SubgraphClient::builder(http_client, subgraph_url)
-            .with_auth_token(Some(auth_token))
-            .build();
+        let subgraph_client = SubgraphClient::new(http_client, subgraph_url, Some(auth_token));
         Client::new(subgraph_client, true)
     };
 
     //* When
-    let subgraphs = tokio::time::timeout(Duration::from_secs(10), network_subgraph_client.fetch())
+    let subgraphs = tokio::time::timeout(Duration::from_secs(60), network_subgraph_client.fetch())
         .await
         .expect("Fetching subgraphs timed out");
 
@@ -65,14 +63,12 @@ async fn fetch_subgraph_no_l2_transfer_support_and_deserialize() {
 
     let network_subgraph_client = {
         let http_client = reqwest::Client::new();
-        let subgraph_client = SubgraphClient::builder(http_client, subgraph_url)
-            .with_auth_token(Some(auth_token))
-            .build();
+        let subgraph_client = SubgraphClient::new(http_client, subgraph_url, Some(auth_token));
         Client::new(subgraph_client, false)
     };
 
     //* When
-    let subgraphs = tokio::time::timeout(Duration::from_secs(10), network_subgraph_client.fetch())
+    let subgraphs = tokio::time::timeout(Duration::from_secs(60), network_subgraph_client.fetch())
         .await
         .expect("Fetching subgraphs timed out");
 


### PR DESCRIPTION
This PR removes the Gateway's dependency on the hosted service by adding a graph network subgraph client capable of directly querying an indexer from a configurable list of trusted indexer candidates.

This PR resolves #685 