### PR TITLE
fix: select deployment outside of indexer-selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "candidate-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=89dc460#89dc460a695a40810fd75038797e40b9604b5802"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=46f4fec#46f4fec835b8fda8a0e5a5f51c51cbedd90d4872"
 dependencies = [
  "arrayvec 0.7.4",
  "ordered-float",
@@ -2450,7 +2450,7 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 [[package]]
 name = "indexer-selection"
 version = "0.1.0"
-source = "git+https://github.com/edgeandnode/candidate-selection?rev=89dc460#89dc460a695a40810fd75038797e40b9604b5802"
+source = "git+https://github.com/edgeandnode/candidate-selection?rev=46f4fec#46f4fec835b8fda8a0e5a5f51c51cbedd90d4872"
 dependencies = [
  "candidate-selection",
  "permutation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 graphql = { git = "https://github.com/edgeandnode/toolshed", tag = "graphql-v0.3.0", default-features = false }
 headers = "0.4.0"
 hex = "0.4"
-indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "89dc460" }
+indexer-selection = { git = "https://github.com/edgeandnode/candidate-selection", rev = "46f4fec" }
 parking_lot = "0.12.3"
 primitive-types = "0.12.2"
 rand = { version = "0.8", features = ["small_rng"] }

--- a/graph-gateway/src/network/service.rs
+++ b/graph-gateway/src/network/service.rs
@@ -51,10 +51,10 @@ pub struct ResolvedSubgraphInfo {
     pub chain: String,
     /// Subgraph start block number.
     pub start_block: BlockNumber,
-
     /// The [`SubgraphId`]s associated with the query selector.
     pub subgraphs: Vec<SubgraphId>,
-
+    /// Subgraph versions, in descending order.
+    pub versions: Vec<DeploymentId>,
     /// A list of [`Indexing`]s for the resolved subgraph versions.
     pub indexings: HashMap<IndexingId, Result<Indexing, ResolutionError>>,
 }
@@ -119,7 +119,6 @@ impl NetworkService {
         let subgraph_chain = subgraph.chain.clone();
         let subgraph_start_block = subgraph.start_block;
 
-        let subgraphs = vec![subgraph.id];
         let indexings = subgraph
             .indexings
             .clone()
@@ -130,7 +129,8 @@ impl NetworkService {
         Ok(Some(ResolvedSubgraphInfo {
             chain: subgraph_chain,
             start_block: subgraph_start_block,
-            subgraphs,
+            subgraphs: vec![subgraph.id],
+            versions: subgraph.versions.clone(),
             indexings,
         }))
     }
@@ -166,6 +166,7 @@ impl NetworkService {
             chain: deployment_chain,
             start_block: deployment_start_block,
             subgraphs,
+            versions: vec![*id],
             indexings,
         }))
     }


### PR DESCRIPTION
This should improve user experience by selecting the subgraph version outside of indexer-selection. Using indexer-selection hasn't been a perfect fit because it considers factors, such as expected latency, that do not line up with expectations for version selection. The downside of this change is that it opens up an abuse vector for indexers that claim a false indexing status. But we have decided it is reasonable to block such indexers.