### PR TITLE
release 21.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "graph-gateway"
-version = "21.2.5"
+version = "21.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4592,9 +4592,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "0d0208408ba0c3df17ed26eb06992cb1a1268d41b2c0e12e65203fbe3972cee5"
 
 [[package]]
 name = "svm-rs"

--- a/graph-gateway/Cargo.toml
+++ b/graph-gateway/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "graph-gateway"
-version = "21.2.5"
+version = "21.3.0"
 
 [dependencies]
 alloy-primitives.workspace = true


### PR DESCRIPTION
# Release Notes
- fix: indexing progress cache, isolate by URL
- fix: remove excess timeout (#851)
- feat: log all response error messages (#852)
- fix: success rate cutoff at fixed time behind chain head (#853, #854)
- fix: select deployment outside of indexer-selection (#857)