### PR TITLE
[WIP] feat: modifications to Indexer and Query kafka messages

### DIFF
--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -42,6 +42,7 @@ pub struct Config {
     /// and traceability purposes.
     ///
     /// If not provided a UUID is generated.
+    /// Might need to make sure it remains unique across the decentralized gateways, potentially also require it here
     #[serde(default)]
     pub gateway_id: Option<String>,
     /// Graph network environment identifier, inserted into Kafka messages

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -70,6 +70,7 @@ async fn main() {
     let conf = config::load_from_file(&conf_path).expect("Failed to load config");
 
     // Get the gateway ID from the config or generate a new one.
+    // Might need to make it required on the config and unique across decentralized gateways ?
     let gateway_id = conf
         .gateway_id
         .clone()
@@ -141,6 +142,7 @@ async fn main() {
         Box::leak(Box::new(Budgeter::new(USD(conf.query_fees_target))));
 
     let reporter = reports::Reporter::create(
+        gateway_id,
         conf.graph_env_id,
         conf.query_fees_target,
         "gateway_client_query_results",

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -142,7 +142,7 @@ async fn main() {
         Box::leak(Box::new(Budgeter::new(USD(conf.query_fees_target))));
 
     let reporter = reports::Reporter::create(
-        gateway_id,
+        gateway_id.clone(),
         conf.graph_env_id,
         conf.query_fees_target,
         "gateway_client_query_results",

--- a/graph-gateway/src/reports.rs
+++ b/graph-gateway/src/reports.rs
@@ -231,7 +231,7 @@ impl Reporter {
                 "fee": (indexer_request.receipt.grt_value() as f64 * 1e-18) as f32,
                 "legacy_scalar": matches!(&indexer_request.receipt, Receipt::Legacy(_, _)),
                 "utility": 1.0,
-                "time_behind": indexer_request.seconds_behind,
+                "seconds_behind": indexer_request.seconds_behind,
                 "blocks_behind": indexer_request.blocks_behind,
                 "response_time_ms": indexer_request.response_time_ms,
                 "allocation": &indexer_request.receipt.allocation(),


### PR DESCRIPTION
In order to have the data available for some of the improvements required for the QoS Oracle V2, we need to add some extra fields that are only available at the gateway level, before they get sent through Kafka messages.

We also wanted to include some renames for improved clarity, and add some potential future constrains/considerations to how gateway IDs work.