### PR TITLE
fix: remove extra configuration from network subgraph

### DIFF
--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -13,6 +13,7 @@ use gateway_framework::{
     auth::api_keys::APIKey,
     config::{Hidden, HiddenSecretKey},
 };
+use graph_gateway::network::subgraph_client::indexers_list_paginated_client::TrustedIndexer;
 use ipnetwork::IpNetwork;
 use ordered_float::NotNan;
 use secp256k1::SecretKey;
@@ -213,17 +214,6 @@ impl From<ProofOfIndexingInfo> for ((DeploymentId, BlockNumber), ProofOfIndexing
             info.proof_of_indexing,
         )
     }
-}
-
-#[serde_as]
-#[derive(CustomDebug, Deserialize)]
-pub struct TrustedIndexer {
-    /// network subgraph endpoint
-    #[debug(with = std::fmt::Display::fmt)]
-    #[serde_as(as = "DisplayFromStr")]
-    pub url: Url,
-    /// free query auth token
-    pub auth: Hidden<String>,
 }
 
 /// Load the configuration from a JSON file.

--- a/graph-gateway/src/config.rs
+++ b/graph-gateway/src/config.rs
@@ -59,8 +59,8 @@ pub struct Config {
     /// Minimum indexer-service version that will receive queries
     #[serde_as(as = "DisplayFromStr")]
     pub min_indexer_version: Version,
-    /// Network subgraph discovery service configuration
-    pub network: NetworkSubgraphServiceConfig,
+    /// Indexers used to query the network subgraph
+    pub trusted_indexers: Vec<TrustedIndexer>,
     /// Check payment state of client (disable for testnets)
     pub payment_required: bool,
     /// POI blocklist
@@ -215,27 +215,15 @@ impl From<ProofOfIndexingInfo> for ((DeploymentId, BlockNumber), ProofOfIndexing
     }
 }
 
-/// Network service configuration.
-#[derive(Debug, Deserialize)]
-pub struct NetworkSubgraphServiceConfig {
-    /// Deployment ID of the network subgraph.
-    pub deployment_id: DeploymentId,
-    /// List of network subgraph update candidates.
-    pub indexers: Vec<NetworkSubgraphIndexer>,
-}
-
-/// Network subgraph update candidate.
 #[serde_as]
 #[derive(CustomDebug, Deserialize)]
-pub struct NetworkSubgraphIndexer {
-    /// The indexer's ID.
-    pub id: Address,
-    /// The indexer base URL.
+pub struct TrustedIndexer {
+    /// network subgraph endpoint
     #[debug(with = std::fmt::Display::fmt)]
     #[serde_as(as = "DisplayFromStr")]
     pub url: Url,
-    /// The indexer's free query auth token.
-    pub auth: String,
+    /// free query auth token
+    pub auth: Hidden<String>,
 }
 
 /// Load the configuration from a JSON file.

--- a/graph-gateway/src/lib.rs
+++ b/graph-gateway/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod block_constraints;
 pub mod client_query;
+pub mod config;
 pub mod indexer_client;
 pub mod indexers;
 pub mod indexing_performance;

--- a/graph-gateway/src/lib.rs
+++ b/graph-gateway/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod block_constraints;
 pub mod client_query;
-pub mod config;
 pub mod indexer_client;
 pub mod indexers;
 pub mod indexing_performance;

--- a/graph-gateway/src/main.rs
+++ b/graph-gateway/src/main.rs
@@ -19,6 +19,7 @@ use axum::{
     response::Response,
     routing, Router,
 };
+use config::{ApiKeys, ExchangeRateProvider};
 use ethers::signers::{Signer, Wallet};
 use gateway_framework::{
     auth::AuthContext,
@@ -32,7 +33,6 @@ use gateway_framework::{
 };
 use graph_gateway::{
     client_query::{self, context::Context},
-    config::{self, ApiKeys, ExchangeRateProvider},
     indexer_client::IndexerClient,
     indexing_performance::IndexingPerformance,
     network::{
@@ -58,6 +58,8 @@ use tokio::{
     time::{interval, MissedTickBehavior},
 };
 use tower_http::cors::{self, CorsLayer};
+
+mod config;
 
 #[global_allocator]
 static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;

--- a/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client.rs
+++ b/graph-gateway/src/network/subgraph_client/indexers_list_paginated_client.rs
@@ -3,12 +3,15 @@
 //! The client inserts an `Authorization` header with the indexer's free query auth token to
 //! authenticate the request with the indexer.
 
+use custom_debug::CustomDebug;
+use gateway_framework::config::Hidden;
 use inner_client::Client as PaginatedIndexerSubgraphClient;
 use serde::Deserialize;
+use serde_with::serde_as;
 use thegraph_graphql_http::graphql::Document;
+use url::Url;
 
 use super::paginated_client::PaginatedClient;
-use crate::config::TrustedIndexer;
 
 mod inner_client;
 mod queries;
@@ -20,6 +23,17 @@ mod queries;
 pub struct Client {
     inner: PaginatedIndexerSubgraphClient,
     indexers: Vec<TrustedIndexer>,
+}
+
+#[serde_as]
+#[derive(CustomDebug, Deserialize)]
+pub struct TrustedIndexer {
+    /// network subgraph endpoint
+    #[debug(with = std::fmt::Display::fmt)]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
+    pub url: Url,
+    /// free query auth token
+    pub auth: Hidden<String>,
 }
 
 impl Client {


### PR DESCRIPTION
This removes the overhead of configuring fields that are functionally unused (indexer address), and avoids situations where we may want to query trusted indexers at different deployments.