### PR TITLE
fix(graph-gateway): use format display to construct the indexer url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,16 +4758,15 @@ dependencies = [
 
 [[package]]
 name = "thegraph-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879d91077d67b457cc80d586d550771ac5b49df3f11ffd47a159fe615a97e661"
+checksum = "beaeffb434bc359006ba96553f2e8db2d1fedd37da988d3c89041fce0bd1fd10"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "bs58",
  "ethers-core",
  "indoc",
- "lazy_static",
  "reqwest 0.12.5",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.116", features = ["raw_value"] }
 serde_with = "3.8.1"
-thegraph-core = "0.5.0"
+thegraph-core = "0.5.6"
 thegraph-graphql-http = "0.2.1"
 thiserror = "1.0.59"
 tokio = { version = "1.38.0", features = [

--- a/graph-gateway/src/indexer_client.rs
+++ b/graph-gateway/src/indexer_client.rs
@@ -41,7 +41,7 @@ impl IndexerClient {
         query: &str,
     ) -> Result<IndexerResponse, IndexerError> {
         let url = url
-            .join(&format!("subgraphs/id/{:?}", deployment))
+            .join(&format!("subgraphs/id/{}", deployment))
             .map_err(|_| Unavailable(UnavailableReason::Internal("bad indexer url")))?;
 
         let result = self


### PR DESCRIPTION
A change in the `DeploymentId` `std::fmt::Debug` trait has uncovered a bug in the graph gateway: We are constructing the indexer client's URL using the `std::fmt::Debug` trait (`"{:?}"`) instead of the `std::fmt::Display` trait (`"{}"`).