### PR TITLE
fix: add optimistic progress to indexing status report

### DIFF
--- a/graph-gateway/src/client_query.rs
+++ b/graph-gateway/src/client_query.rs
@@ -625,7 +625,7 @@ fn build_candidates_list(
             // Infer the indexed range from the indexing progress information
             let range = {
                 let (start, end) = indexing.progress.as_range();
-                start.unwrap_or(0)..=max(end, perf.latest_block + blocks_per_minute)
+                start.unwrap_or(0)..=(max(end, perf.latest_block) + blocks_per_minute)
             };
 
             let number_gte = block_requirements.number_gte.unwrap_or(0);


### PR DESCRIPTION
This avoids an edge case where users receive a block number from an indexer but then fail to make a subsequent query to the same indexer because we think it hasn't hit that block yet.