### PR TITLE
chore(deps): update rust crate thegraph-core to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-dyn-abi"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413902aa18a97569e60f679c23f46a18db1656d87ab4d4e49d0e1e52042f66df"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "derive_more",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.6.18",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc05b04ac331a9f07e3a4036ef7926e49a8bf84a99a1ccfc7e2ab55a5fcbb372"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +107,22 @@ checksum = "26154390b1d205a4a7ac7352aa2eb4f81f391399d4e2f546fb81a2f8bb383f62"
 dependencies = [
  "arrayvec 0.7.4",
  "bytes",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740a25b92e849ed7b0fa013951fe2f64be9af1ad5abe805037b44fb7770c5c47"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve",
+ "k256",
+ "thiserror",
 ]
 
 [[package]]
@@ -124,6 +170,16 @@ dependencies = [
  "quote",
  "syn 2.0.72",
  "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbcba3ca07cf7975f15d871b721fb18031eec8bce51103907f6dcce00b255d98"
+dependencies = [
+ "serde",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -4688,13 +4744,14 @@ dependencies = [
 
 [[package]]
 name = "thegraph-core"
-version = "0.5.7"
-source = "git+https://github.com/edgeandnode/toolshed?rev=db1ab45#db1ab45ccf9d049782bb98fc94f8a068d2ae4d69"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25ab9ed59aefc6b161453c9b219374fa94346c9c74a968ac6c7725c7e826c4"
 dependencies = [
  "alloy-primitives",
+ "alloy-signer",
  "alloy-sol-types",
  "bs58",
- "ethers-core",
  "serde",
  "serde_with",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ alloy-primitives = { version = "0.7.1", features = ["serde"] }
 alloy-sol-types = "0.7.1"
 anyhow = "1.0"
 axum = { git = "https://github.com/tokio-rs/axum", rev = "50c035c", default-features = false, features = [
-  "json",
-  "tokio",
-  "http1",
+    "json",
+    "tokio",
+    "http1",
 ] }
 by_address = "1.2.1"
 cost-model = { git = "https://github.com/graphprotocol/agora", rev = "deacb09" }
@@ -46,9 +46,9 @@ rand = { version = "0.8", features = ["small_rng"] }
 rdkafka = { version = "0.36.2", features = ["gssapi", "tracing"] }
 receipts = { git = "https://github.com/edgeandnode/receipts", rev = "e94e0f1" }
 reqwest = { version = "0.12", default-features = false, features = [
-  "json",
-  "default-tls",
-  "gzip",
+    "json",
+    "default-tls",
+    "gzip",
 ] }
 secp256k1 = { version = "0.29", default-features = false }
 semver = { version = "1.0", features = ["serde"] }
@@ -58,27 +58,27 @@ serde_with = "3.8.1"
 simple-rate-limiter = "1.0"
 snmalloc-rs = "0.3"
 tap_core = { git = "https://github.com/semiotic-ai/timeline-aggregation-protocol", rev = "c179dfe" }
-thegraph-core = { git = "https://github.com/edgeandnode/toolshed", rev = "db1ab45" }
+thegraph-core = { version = "0.6.0", features = ["serde"] }
 thegraph-graphql-http = { version = "0.2.1", features = [
-  "http-client-reqwest",
+    "http-client-reqwest",
 ] }
 thiserror = "1.0.59"
 tokio = { version = "1.38.0", features = [
-  "macros",
-  "parking_lot",
-  "rt-multi-thread",
-  "signal",
-  "sync",
-  "time",
+    "macros",
+    "parking_lot",
+    "rt-multi-thread",
+    "signal",
+    "sync",
+    "time",
 ] }
 toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "toolshed-v0.6.0" }
 tower = "0.4.13"
 tower-http = { version = "0.5.2", features = ["cors"] }
 tracing = { version = "0.1", default-features = false }
 tracing-subscriber = { version = "0.3", features = [
-  "env-filter",
-  "parking_lot",
-  "json",
+    "env-filter",
+    "parking_lot",
+    "json",
 ] }
 url = "2.5.0"
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, bail, ensure};
 use ordered_float::NotNan;
 use serde::Deserialize;
 use serde_with::serde_as;
-use thegraph_core::types::{alloy_primitives::Address, SubgraphId};
+use thegraph_core::{Address, SubgraphId};
 use tokio::sync::watch;
 
 #[derive(Clone, Debug, Default)]

--- a/src/block_constraints.rs
+++ b/src/block_constraints.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::Write as _,
 };
 
-use alloy_primitives::{BlockHash, BlockNumber};
 use anyhow::{anyhow, bail};
 use cost_model::Context;
 use graphql::{
@@ -12,6 +11,7 @@ use graphql::{
 };
 use itertools::Itertools as _;
 use serde_json::{self, json};
+use thegraph_core::{BlockHash, BlockNumber};
 
 use crate::{
     blocks::{BlockConstraint, UnresolvedBlock},

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use alloy_primitives::{BlockHash, BlockNumber, BlockTimestamp};
 use serde::Deserialize;
+use thegraph_core::{BlockHash, BlockNumber, BlockTimestamp};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 pub struct Block {

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -3,7 +3,7 @@ use std::{
     iter,
 };
 
-use thegraph_core::types::IndexerId;
+use thegraph_core::IndexerId;
 
 use crate::blocks::{Block, UnresolvedBlock};
 
@@ -106,12 +106,12 @@ impl Chain {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::{Address, BlockHash, U256};
+    use alloy_primitives::U256;
     use itertools::Itertools;
     use rand::{
         rngs::SmallRng, seq::SliceRandom as _, thread_rng, Rng as _, RngCore as _, SeedableRng,
     };
-    use thegraph_core::types::IndexerId;
+    use thegraph_core::{Address, BlockHash, IndexerId};
     use toolshed::concat_bytes;
 
     use super::{Block, Chain, MAX_LEN};

--- a/src/chains.rs
+++ b/src/chains.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use parking_lot::{RwLock, RwLockReadGuard};
-use thegraph_core::types::IndexerId;
+use thegraph_core::IndexerId;
 use tokio::{
     select, spawn,
     sync::mpsc,

--- a/src/client_query.rs
+++ b/src/client_query.rs
@@ -4,7 +4,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use alloy_primitives::BlockNumber;
 use anyhow::anyhow;
 use axum::{
     body::Bytes,
@@ -22,7 +21,7 @@ use prost::bytes::Buf;
 use rand::{thread_rng, Rng as _};
 use serde::Deserialize;
 use serde_json::value::RawValue;
-use thegraph_core::types::{AllocationId, DeploymentId, IndexerId};
+use thegraph_core::{AllocationId, BlockNumber, DeploymentId, IndexerId};
 use tokio::sync::mpsc;
 use tracing::{info_span, Instrument as _};
 use url::Url;

--- a/src/client_query/attestation_header.rs
+++ b/src/client_query/attestation_header.rs
@@ -2,7 +2,7 @@
 
 use axum::http::{HeaderName, HeaderValue};
 use headers::Error;
-use thegraph_core::types::Attestation;
+use thegraph_core::Attestation;
 
 static GRAPH_ATTESTATION_HEADER_NAME: HeaderName = HeaderName::from_static("graph-attestation");
 
@@ -77,7 +77,7 @@ impl headers::Header for GraphAttestation {
 mod tests {
     use assert_matches::assert_matches;
     use headers::{Header, HeaderValue};
-    use thegraph_core::types::Attestation;
+    use thegraph_core::Attestation;
 
     use super::GraphAttestation;
 

--- a/src/client_query/query_selector.rs
+++ b/src/client_query/query_selector.rs
@@ -7,7 +7,7 @@ use axum::{
     http::request::Parts,
     response::IntoResponse,
 };
-use thegraph_core::types::{DeploymentId, SubgraphId};
+use thegraph_core::{DeploymentId, SubgraphId};
 
 use crate::{errors::Error, graphql};
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::{
     str::FromStr,
 };
 
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{B256, U256};
 use anyhow::Context;
 use custom_debug::CustomDebug;
 use ipnetwork::IpNetwork;
@@ -16,6 +16,7 @@ use secp256k1::SecretKey;
 use semver::Version;
 use serde::Deserialize;
 use serde_with::{serde_as, DeserializeAs, DisplayFromStr};
+use thegraph_core::Address;
 use url::Url;
 
 use crate::{

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,10 +3,9 @@ use std::{
     fmt::{self, Write as _},
 };
 
-use alloy_primitives::BlockNumber;
 use axum::response::{IntoResponse, Response};
 use itertools::Itertools as _;
-use thegraph_core::types::IndexerId;
+use thegraph_core::{BlockNumber, IndexerId};
 
 use crate::{blocks::UnresolvedBlock, graphql};
 

--- a/src/indexer_client.rs
+++ b/src/indexer_client.rs
@@ -1,8 +1,10 @@
-use alloy_primitives::{BlockHash, BlockNumber};
 use alloy_sol_types::Eip712Domain;
 use reqwest::header::AUTHORIZATION;
 use serde::{Deserialize, Serialize};
-use thegraph_core::types::attestation::{self, Attestation};
+use thegraph_core::{
+    attestation::{self, Attestation},
+    BlockHash, BlockNumber,
+};
 use thegraph_graphql_http::http::response::Error as GQLError;
 use url::Url;
 

--- a/src/indexers/cost_models.rs
+++ b/src/indexers/cost_models.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use thegraph_core::types::DeploymentId;
+use thegraph_core::DeploymentId;
 use thegraph_graphql_http::{
     graphql::{Document, IntoDocument, IntoDocumentWithVariables},
     http_client::{RequestError, ReqwestExt, ResponseError},

--- a/src/indexers/indexing_progress.rs
+++ b/src/indexers/indexing_progress.rs
@@ -1,7 +1,6 @@
-use alloy_primitives::BlockNumber;
 use serde::Deserialize;
 use serde_with::serde_as;
-use thegraph_core::types::DeploymentId;
+use thegraph_core::{BlockNumber, DeploymentId};
 use thegraph_graphql_http::{
     graphql::{Document, IntoDocument, IntoDocumentWithVariables},
     http_client::{RequestError, ReqwestExt as _, ResponseError},

--- a/src/indexers/public_poi.rs
+++ b/src/indexers/public_poi.rs
@@ -1,7 +1,6 @@
-use alloy_primitives::{BlockNumber, B256};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use thegraph_core::types::DeploymentId;
+use thegraph_core::{BlockNumber, DeploymentId, ProofOfIndexing};
 use thegraph_graphql_http::{
     graphql::{Document, IntoDocument, IntoDocumentWithVariables},
     http_client::{RequestError, ReqwestExt, ResponseError},
@@ -17,8 +16,6 @@ const PUBLIC_PROOF_OF_INDEXING_QUERY_DOCUMENT: &str = r#"
             block { number }
         }
     }"#;
-
-pub type ProofOfIndexing = B256;
 
 /// Errors that can occur while fetching the indexer's public POIs.
 #[derive(Clone, Debug, thiserror::Error)]
@@ -169,14 +166,9 @@ pub struct PartialBlockPtr {
 
 #[cfg(test)]
 mod tests {
-    use thegraph_core::deployment_id;
+    use thegraph_core::{deployment_id, poi};
 
-    use super::{ProofOfIndexing, Response};
-
-    /// Test helper to create a valid `ProofOfIndexing` instance from an arbitrary string.
-    fn parse_poi(poi: impl AsRef<str>) -> ProofOfIndexing {
-        poi.as_ref().parse().expect("invalid POI")
-    }
+    use super::Response;
 
     #[test]
     fn deserialize_public_pois_response() {
@@ -212,8 +204,8 @@ mod tests {
         );
         assert_eq!(
             response.public_proofs_of_indexing[0].proof_of_indexing,
-            Some(parse_poi(
-                "0xba8a057796a81e013789789996551bb5b2920fb9947334db956992f7098bd287"
+            Some(poi!(
+                "ba8a057796a81e013789789996551bb5b2920fb9947334db956992f7098bd287"
             ))
         );
         assert_eq!(response.public_proofs_of_indexing[0].block.number, 123);

--- a/src/indexing_performance.rs
+++ b/src/indexing_performance.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, ops::Deref, time::Duration};
 
-use alloy_primitives::BlockNumber;
 use parking_lot::RwLock;
-use thegraph_core::types::{DeploymentId, IndexerId};
+use thegraph_core::{BlockNumber, DeploymentId, IndexerId};
 use tokio::{self, sync::mpsc, time::MissedTickBehavior};
 
 use crate::network::NetworkService;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::{Address, U256};
 use alloy_sol_types::Eip712Domain;
 use axum::{
     body::Body,
@@ -41,7 +40,7 @@ use prometheus::{self, Encoder as _};
 use secp256k1::SecretKey;
 use serde_json::json;
 use simple_rate_limiter::RateLimiter;
-use thegraph_core::types::attestation;
+use thegraph_core::{attestation, Address, ChainId};
 use tokio::{
     net::TcpListener,
     signal::unix::SignalKind,
@@ -85,7 +84,9 @@ async fn main() {
 
     let attestation_domain: &'static Eip712Domain =
         Box::leak(Box::new(attestation::eip712_domain(
-            U256::from_str_radix(&conf.attestations.chain_id, 10)
+            conf.attestations
+                .chain_id
+                .parse::<ChainId>()
                 .expect("failed to parse attestation domain chain_id"),
             conf.attestations.dispute_manager,
         )));

--- a/src/network/indexer_indexing_cost_model_resolver.rs
+++ b/src/network/indexer_indexing_cost_model_resolver.rs
@@ -5,7 +5,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use parking_lot::RwLock;
-use thegraph_core::types::DeploymentId;
+use thegraph_core::DeploymentId;
 use url::Url;
 
 use crate::{

--- a/src/network/indexer_indexing_poi_blocklist.rs
+++ b/src/network/indexer_indexing_poi_blocklist.rs
@@ -9,8 +9,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use alloy_primitives::BlockNumber;
-use thegraph_core::types::{DeploymentId, ProofOfIndexing};
+use thegraph_core::{BlockNumber, DeploymentId, ProofOfIndexing};
 
 use crate::indexers::public_poi::ProofOfIndexingInfo;
 

--- a/src/network/indexer_indexing_poi_resolver.rs
+++ b/src/network/indexer_indexing_poi_resolver.rs
@@ -8,9 +8,8 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use alloy_primitives::BlockNumber;
 use parking_lot::RwLock;
-use thegraph_core::types::{DeploymentId, ProofOfIndexing};
+use thegraph_core::{BlockNumber, DeploymentId, ProofOfIndexing};
 use url::Url;
 
 use crate::{
@@ -216,8 +215,7 @@ mod tests {
     mod it_public_pois_resolution {
         use std::time::Duration;
 
-        use alloy_primitives::BlockNumber;
-        use thegraph_core::deployment_id;
+        use thegraph_core::{deployment_id, BlockNumber};
 
         use super::*;
         use crate::indexers;

--- a/src/network/indexer_indexing_progress_resolver.rs
+++ b/src/network/indexer_indexing_progress_resolver.rs
@@ -2,9 +2,8 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use alloy_primitives::BlockNumber;
 use parking_lot::{Mutex, RwLock};
-use thegraph_core::types::DeploymentId;
+use thegraph_core::{BlockNumber, DeploymentId};
 use url::Url;
 
 use crate::{

--- a/src/network/internal.rs
+++ b/src/network/internal.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, time::Duration};
 
-use thegraph_core::types::{DeploymentId, IndexerId, SubgraphId};
+use thegraph_core::{DeploymentId, IndexerId, SubgraphId};
 
 use self::indexer_processing::IndexerRawInfo;
 pub use self::{

--- a/src/network/internal/indexer_processing.rs
+++ b/src/network/internal/indexer_processing.rs
@@ -1,11 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
-use alloy_primitives::BlockNumber;
 use cost_model::CostModel;
 use custom_debug::CustomDebug;
 use ipnetwork::IpNetwork;
 use semver::Version;
-use thegraph_core::types::{AllocationId, DeploymentId, IndexerId};
+use thegraph_core::{AllocationId, BlockNumber, DeploymentId, IndexerId};
 use tracing::Instrument;
 use url::Url;
 

--- a/src/network/internal/pre_processing.rs
+++ b/src/network/internal/pre_processing.rs
@@ -1,7 +1,7 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use anyhow::{anyhow, ensure};
-use thegraph_core::types::{AllocationId, DeploymentId, IndexerId, SubgraphId};
+use thegraph_core::{AllocationId, DeploymentId, IndexerId, SubgraphId};
 use url::Url;
 
 use crate::network::{

--- a/src/network/internal/snapshot.rs
+++ b/src/network/internal/snapshot.rs
@@ -6,11 +6,10 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use alloy_primitives::BlockNumber;
 use cost_model::CostModel;
 use custom_debug::CustomDebug;
 use semver::Version;
-use thegraph_core::types::{AllocationId, DeploymentId, IndexerId, SubgraphId};
+use thegraph_core::{AllocationId, BlockNumber, DeploymentId, IndexerId, SubgraphId};
 use url::Url;
 
 use super::{DeploymentInfo, SubgraphInfo};

--- a/src/network/internal/state.rs
+++ b/src/network/internal/state.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use ipnetwork::IpNetwork;
-use thegraph_core::types::IndexerId;
+use thegraph_core::IndexerId;
 
 use crate::network::{
     config::VersionRequirements as IndexerVersionRequirements, indexer_host_resolver::HostResolver,

--- a/src/network/internal/subgraph_processing.rs
+++ b/src/network/internal/subgraph_processing.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use alloy_primitives::BlockNumber;
-use thegraph_core::types::{AllocationId, DeploymentId, IndexerId, SubgraphId};
+use thegraph_core::{AllocationId, BlockNumber, DeploymentId, IndexerId, SubgraphId};
 
 use crate::network::errors::{DeploymentError, SubgraphError};
 

--- a/src/network/internal/tests/it_indexer_processing.rs
+++ b/src/network/internal/tests/it_indexer_processing.rs
@@ -3,14 +3,10 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::Address;
 use assert_matches::assert_matches;
 use ipnetwork::IpNetwork;
 use semver::Version;
-use thegraph_core::{
-    allocation_id, deployment_id, indexer_id,
-    types::{IndexerId, ProofOfIndexing},
-};
+use thegraph_core::{allocation_id, deployment_id, indexer_id, poi, Address, IndexerId};
 use tracing_subscriber::{fmt::TestWriter, EnvFilter};
 use url::Url;
 
@@ -66,11 +62,6 @@ fn parse_url(url: impl AsRef<str>) -> Url {
 /// Test helper to get an [`IpNetwork`] from a given string.
 fn parse_ip_network(network: impl AsRef<str>) -> IpNetwork {
     network.as_ref().parse().expect("Invalid IP network")
-}
-
-/// Test helper to get a [`ProofOfIndexing`] from a given string.
-fn parse_poi(poi: impl AsRef<str>) -> ProofOfIndexing {
-    poi.as_ref().parse().expect("Invalid POI")
 }
 
 /// Test helper to build the service config for the tests.
@@ -336,9 +327,7 @@ async fn block_indexing_if_blocked_by_pois_blocklist() {
     let faulty_poi = ProofOfIndexingInfo {
         block_number: 1337,
         deployment_id: deployment_1,
-        proof_of_indexing: parse_poi(
-            "0xf99821910bfe16578caa1c823e99a69091409cd1d9d69f9f83e1a43a770c6fa1",
-        ),
+        proof_of_indexing: poi!("f99821910bfe16578caa1c823e99a69091409cd1d9d69f9f83e1a43a770c6fa1"),
     };
 
     let service = test_service_state(
@@ -428,9 +417,7 @@ async fn do_not_block_indexing_if_poi_not_blocked_by_poi_blocklist() {
         deployment_id: deployment_1,
         // The POI for block 1337 of  the network subgraph arbitrum v1.1.1 is:
         // 0xf99821910bfe16578caa1c823e99a69091409cd1d9d69f9f83e1a43a770c6fa1
-        proof_of_indexing: parse_poi(
-            "0x2b7a6d4ed9fbef02c8aa817dfd9bafb126cadc0f8ebcab736e627ef6d5aab060",
-        ),
+        proof_of_indexing: poi!("2b7a6d4ed9fbef02c8aa817dfd9bafb126cadc0f8ebcab736e627ef6d5aab060"),
     };
 
     let service = test_service_state(
@@ -504,9 +491,7 @@ async fn do_not_block_indexing_if_public_pois_resolution_fails() {
     let faulty_poi = ProofOfIndexingInfo {
         block_number: u64::MAX, // An absurd block number that will cause the POI resolution to fail
         deployment_id: deployment_1,
-        proof_of_indexing: parse_poi(
-            "0xf99821910bfe16578caa1c823e99a69091409cd1d9d69f9f83e1a43a770c6fa1",
-        ),
+        proof_of_indexing: poi!("f99821910bfe16578caa1c823e99a69091409cd1d9d69f9f83e1a43a770c6fa1"),
     };
 
     let service = test_service_state(

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -7,10 +7,9 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::BlockNumber;
 use ipnetwork::IpNetwork;
 use semver::Version;
-use thegraph_core::types::{DeploymentId, IndexerId, SubgraphId};
+use thegraph_core::{BlockNumber, DeploymentId, IndexerId, SubgraphId};
 use tokio::{sync::watch, time::MissedTickBehavior};
 
 use super::{

--- a/src/network/subgraph_client.rs
+++ b/src/network/subgraph_client.rs
@@ -4,12 +4,12 @@
 //! This module contains the logic necessary to query the Graph to get the latest state of the
 //! network subgraph.
 
-use alloy_primitives::{BlockHash, BlockNumber};
 use anyhow::{anyhow, bail, ensure, Context};
 use custom_debug::CustomDebug;
 use serde::{ser::SerializeMap, Deserialize, Serialize, Serializer};
 use serde_json::json;
 use serde_with::serde_as;
+use thegraph_core::{BlockHash, BlockNumber};
 use thegraph_graphql_http::http::response::Error as GqlError;
 use types::Subgraph;
 use url::Url;
@@ -32,10 +32,9 @@ use crate::{
 ///
 /// See: https://github.com/graphprotocol/graph-network-subgraph/blob/master/schema.graphql
 pub mod types {
-    use alloy_primitives::BlockNumber;
     use serde::Deserialize;
     use serde_with::serde_as;
-    use thegraph_core::types::{AllocationId, DeploymentId, IndexerId, SubgraphId};
+    use thegraph_core::{AllocationId, BlockNumber, DeploymentId, IndexerId, SubgraphId};
 
     #[derive(Debug, Clone, Deserialize)]
     #[serde(rename_all = "camelCase")]

--- a/src/receipts.rs
+++ b/src/receipts.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc, time::SystemTime};
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::U256;
 use alloy_sol_types::Eip712Domain;
 use ethers::{core::k256::ecdsa::SigningKey, signers::Wallet};
 use parking_lot::{Mutex, RwLock};
@@ -9,7 +9,7 @@ pub use receipts::QueryStatus as ReceiptStatus;
 use receipts::ReceiptPool;
 use secp256k1::SecretKey;
 use tap_core::{receipt::Receipt as TapReceipt, signed_message::EIP712SignedMessage};
-use thegraph_core::types::AllocationId;
+use thegraph_core::{Address, AllocationId};
 
 /// A receipt for an indexer request.
 #[derive(Debug, Clone)]

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -1,9 +1,8 @@
-use alloy_primitives::Address;
 use anyhow::{anyhow, Context};
 use ordered_float::NotNan;
 use prost::Message;
 use serde_json::json;
-use thegraph_core::types::{AllocationId, DeploymentId, IndexerId};
+use thegraph_core::{Address, AllocationId, DeploymentId, IndexerId};
 use tokio::sync::mpsc;
 use toolshed::concat_bytes;
 

--- a/src/subgraph_studio.rs
+++ b/src/subgraph_studio.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use alloy_primitives::Address;
 use serde::Deserialize;
+use thegraph_core::Address;
 use tokio::{
     sync::watch,
     time::{interval, Duration, MissedTickBehavior},

--- a/src/vouchers.rs
+++ b/src/vouchers.rs
@@ -1,10 +1,11 @@
-use alloy_primitives::{Address, FixedBytes, U256};
+use alloy_primitives::{FixedBytes, U256};
 use axum::{body::Bytes, extract::State, http::StatusCode};
 use lazy_static::lazy_static;
 use receipts::{self, combine_partial_vouchers, receipts_to_partial_voucher, receipts_to_voucher};
 use secp256k1::{PublicKey, Secp256k1, SecretKey};
 use serde::Deserialize;
 use serde_json::json;
+use thegraph_core::Address;
 
 use crate::{
     json::{json_response, JsonResponse},

--- a/tests/it_indexers_status_public_pois.rs
+++ b/tests/it_indexers_status_public_pois.rs
@@ -1,9 +1,8 @@
 use std::time::Duration;
 
-use alloy_primitives::BlockNumber;
 use assert_matches::assert_matches;
 use graph_gateway::indexers;
-use thegraph_core::deployment_id;
+use thegraph_core::{deployment_id, BlockNumber};
 use url::Url;
 
 /// Test helper to get the testnet indexer url from the environment.


### PR DESCRIPTION
This new major version of the _core_ crate breaks the previous public API. The types are now exported in the root module, and some alloy primitive types are also re-exported for compatibility reasons.

This release's most important change is replacing the deprecated `ethers` crate dependencies with the alloy signer crate. This is necessary to resolve #885 