### PR TITLE
chore(deps): remove dependency on toolshed crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,13 +1807,11 @@ dependencies = [
  "serde_with",
  "snmalloc-rs",
  "tap_core",
- "test-with",
  "thegraph-core",
  "thegraph-graphql-http",
  "thiserror",
  "tokio",
  "tokio-test",
- "toolshed",
  "tower",
  "tower-http",
  "tower-test",
@@ -4058,19 +4056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-with"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3feb483cdf81866d103b411636e52d2e7af915cd9db562a8a6813b89cb55f55e"
-dependencies = [
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.89",
-]
-
-[[package]]
 name = "thegraph-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4322,14 +4307,6 @@ dependencies = [
  "indexmap 2.6.0",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "toolshed"
-version = "0.6.0"
-source = "git+https://github.com/edgeandnode/toolshed?tag=toolshed-v0.6.0#c44cb91e8349c59bb7ff8d4eb086badc8c99491a"
-dependencies = [
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ tokio = { version = "1.38.0", features = [
     "sync",
     "time",
 ] }
-toolshed = { git = "https://github.com/edgeandnode/toolshed", tag = "toolshed-v0.6.0" }
 tower = "0.5.1"
 tower-http = { version = "0.6.1", features = ["cors"] }
 tracing = { version = "0.1", default-features = false }
@@ -81,6 +80,5 @@ url = "2.5.0"
 assert_matches = "1.5.0"
 http-body-util = "0.1.1"
 hyper = "1.3.1"
-test-with = { version = "0.14.0", default-features = false }
 tokio-test = "0.4.4"
 tower-test = "0.4.0"

--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -1,0 +1,14 @@
+// See https://doc.rust-lang.org/std/macro.concat_bytes.html
+#[macro_export]
+macro_rules! concat_bytes {
+    ($len:expr, [$($slices:expr),* $(,)?]) => {
+        {
+            let mut cursor = std::io::Cursor::new([0_u8; $len]);
+            $(
+                std::io::Write::write(&mut cursor, $slices).unwrap();
+            )*
+            assert!(cursor.position() == $len);
+            cursor.into_inner()
+        }
+    }
+}

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -113,9 +113,9 @@ mod tests {
         rngs::SmallRng, seq::SliceRandom as _, thread_rng, Rng as _, RngCore as _, SeedableRng,
     };
     use thegraph_core::{Address, BlockHash, IndexerId};
-    use toolshed::concat_bytes;
 
     use super::{Block, Chain, MAX_LEN};
+    use crate::concat_bytes;
 
     #[test]
     fn chain() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod auth;
 mod block_constraints;
 mod blocks;
 mod budgets;
+mod bytes;
 mod chain;
 mod chains;
 mod client_query;

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -3,9 +3,8 @@ use ordered_float::NotNan;
 use prost::Message;
 use thegraph_core::{Address, AllocationId, DeploymentId, IndexerId};
 use tokio::sync::mpsc;
-use toolshed::concat_bytes;
 
-use crate::{errors, indexer_client::IndexerResponse, receipts::Receipt};
+use crate::{concat_bytes, errors, indexer_client::IndexerResponse, receipts::Receipt};
 
 pub struct ClientRequest {
     pub id: String,


### PR DESCRIPTION
This pull request includes various changes to the project, focusing on removing dependencies and adding a new macro (copied from the `toolshed` crate). These changes will allow us to deprecate and remove the `toolshed` crate. 

The most significant changes are listed below:

Macro addition:

* Added a new `concat_bytes` macro in `src/bytes.rs` to concatenate byte slices. The macro has been copied from the `toolshed` crate as the gateway is the only project using the `toolshed` crate.

Dependency updates:

* Removed the `toolshed` dependency from `Cargo.toml`.
* Removed the unused `test-with` dependency from `Cargo.toml`.