### PR TITLE
feat: dynamic blocklist

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,3 @@
-//! The Graph Gateway configuration.
-
 use std::{
     collections::{BTreeMap, HashSet},
     path::{Path, PathBuf},
@@ -26,9 +24,9 @@ pub struct Config {
     #[serde(default)]
     pub api_keys: Option<ApiKeys>,
     pub attestations: AttestationConfig,
-    /// List of indexer addresses to block. This should only be used temprorarily.
+    /// Blocklist applying to indexers.
     #[serde(default)]
-    pub blocked_indexers: BTreeMap<Address, BlockedIndexer>,
+    pub blocklist: Vec<BlocklistEntry>,
     /// Chain aliases
     #[serde(default)]
     pub chain_aliases: BTreeMap<String, String>,
@@ -53,9 +51,6 @@ pub struct Config {
     pub trusted_indexers: Vec<TrustedIndexer>,
     /// Check payment state of client (disable for testnets)
     pub payment_required: bool,
-    /// POI blocklist
-    #[serde(default)]
-    pub poi_blocklist: Vec<BlockedPoi>,
     /// public API port
     pub port_api: u16,
     /// private metrics port
@@ -96,11 +91,28 @@ pub enum ApiKeys {
     Fixed(Vec<ApiKey>),
 }
 
-#[derive(Deserialize)]
-pub struct BlockedIndexer {
-    /// empty array blocks on all deployments
-    pub deployments: Vec<DeploymentId>,
-    pub reason: String,
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum BlocklistEntry {
+    Poi {
+        deployment: DeploymentId,
+        info: BlocklistInfo,
+        public_poi: B256,
+        block: BlockNumber,
+    },
+    Other {
+        deployment: DeploymentId,
+        info: BlocklistInfo,
+        indexer: Address,
+    },
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+pub struct BlocklistInfo {
+    /// Example query (should be minimal to reproduce bad response)
+    query: Option<String>,
+    /// Bad query response, from the above query executed on indexers with this blocked PoI
+    bad_query_response: Option<String>,
 }
 
 /// Attestation configuration.
@@ -169,17 +181,6 @@ pub struct Receipts {
     pub signer: B256,
     /// TAP verifier contract address
     pub verifier: Address,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct BlockedPoi {
-    pub public_poi: B256,
-    pub deployment: DeploymentId,
-    pub block_number: BlockNumber,
-    /// Example query (should be minimal to reproduce bad response)
-    pub query: Option<String>,
-    /// Bad query response, from the above query executed on indexers with this blocked PoI
-    pub bad_query_response: Option<String>,
 }
 
 /// Load the configuration from a JSON file.

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,8 +110,10 @@ pub enum BlocklistEntry {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BlocklistInfo {
     /// Example query (should be minimal to reproduce bad response)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     query: Option<String>,
     /// Bad query response, from the above query executed on indexers with this blocked PoI
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     bad_query_response: Option<String>,
 }
 
@@ -140,7 +142,7 @@ pub enum ExchangeRateProvider {
 /// Kafka configuration.
 ///
 /// See [`Config`]'s [`kafka`](struct.Config.html#structfield.kafka).
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 pub struct KafkaConfig(BTreeMap<String, String>);
 
 impl Default for KafkaConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,8 @@ async fn main() {
         }
         None => Default::default(),
     };
-    let indexer_blocklist = indexer_blocklist::Blocklist::spawn(conf.blocklist);
+    let indexer_blocklist =
+        indexer_blocklist::Blocklist::spawn(conf.blocklist, conf.kafka.clone().into());
     let mut network = network::service::spawn(
         http_client.clone(),
         network_subgraph_client,
@@ -127,7 +128,6 @@ async fn main() {
         conf.receipts.verifier,
     )));
 
-    // Initialize the auth service
     let auth_service =
         init_auth_service(http_client.clone(), conf.api_keys, conf.payment_required).await;
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -4,6 +4,7 @@ use thegraph_graphql_http::graphql::{IntoDocument as _, IntoDocumentWithVariable
 
 pub mod cost_model;
 pub mod host_filter;
+pub mod indexer_blocklist;
 mod indexer_processing;
 pub mod indexing_progress;
 pub mod poi_filter;

--- a/src/network/indexer_blocklist.rs
+++ b/src/network/indexer_blocklist.rs
@@ -1,0 +1,78 @@
+use std::collections::{HashMap, HashSet};
+
+use thegraph_core::{alloy::primitives::Address, DeploymentId, ProofOfIndexing};
+use tokio::sync::watch;
+
+use crate::config::BlocklistEntry;
+
+#[derive(Clone)]
+pub struct Blocklist {
+    pub blocklist: watch::Receiver<Vec<BlocklistEntry>>,
+    pub poi: watch::Receiver<HashMap<DeploymentId, Vec<(u64, ProofOfIndexing)>>>,
+    pub indexer: watch::Receiver<HashMap<Address, HashSet<DeploymentId>>>,
+}
+
+impl Blocklist {
+    pub fn spawn(init: Vec<BlocklistEntry>) -> Self {
+        let (blocklist_tx, blocklist_rx) = watch::channel(Default::default());
+        let (poi_tx, poi_rx) = watch::channel(Default::default());
+        let (indexer_tx, indexer_rx) = watch::channel(Default::default());
+        let mut actor = Actor {
+            blocklist: blocklist_tx,
+            poi: poi_tx,
+            indexer: indexer_tx,
+        };
+        for entry in init {
+            actor.add_entry(entry);
+        }
+        tokio::spawn(async move {
+            actor.run().await;
+        });
+        Self {
+            blocklist: blocklist_rx,
+            poi: poi_rx,
+            indexer: indexer_rx,
+        }
+    }
+}
+
+struct Actor {
+    pub blocklist: watch::Sender<Vec<BlocklistEntry>>,
+    pub poi: watch::Sender<HashMap<DeploymentId, Vec<(u64, ProofOfIndexing)>>>,
+    pub indexer: watch::Sender<HashMap<Address, HashSet<DeploymentId>>>,
+}
+
+impl Actor {
+    async fn run(&mut self) {
+        todo!();
+    }
+
+    fn add_entry(&mut self, entry: BlocklistEntry) {
+        match entry {
+            BlocklistEntry::Poi {
+                deployment,
+                block,
+                public_poi,
+                ..
+            } => {
+                self.poi.send_modify(move |blocklist| {
+                    blocklist
+                        .entry(deployment)
+                        .or_default()
+                        .push((block, public_poi.into()));
+                });
+            }
+            BlocklistEntry::Other {
+                deployment,
+                indexer,
+                ..
+            } => {
+                self.indexer.send_modify(move |blocklist| {
+                    blocklist.entry(indexer).or_default().insert(deployment);
+                });
+            }
+        };
+        self.blocklist
+            .send_modify(move |blocklist| blocklist.push(entry));
+    }
+}

--- a/src/network/indexer_processing.rs
+++ b/src/network/indexer_processing.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use custom_debug::CustomDebug;
 use thegraph_core::{alloy::primitives::BlockNumber, AllocationId, DeploymentId, IndexerId};
@@ -6,7 +6,6 @@ use tracing::Instrument;
 use url::Url;
 
 use crate::{
-    config::BlockedIndexer,
     errors::UnavailableReason,
     network::{indexing_progress::IndexingProgressResolver, service::InternalState},
 };
@@ -191,29 +190,21 @@ async fn process_indexer_indexings(
     state: &InternalState,
     url: &Url,
     indexings: HashMap<DeploymentId, IndexingRawInfo>,
-    blocklist: Option<&BlockedIndexer>,
+    blocklist: Option<&HashSet<DeploymentId>>,
 ) -> HashMap<DeploymentId, Result<ResolvedIndexingInfo, UnavailableReason>> {
     let mut indexer_indexings: HashMap<DeploymentId, Result<IndexingInfo<(), ()>, _>> = indexings
         .into_iter()
         .map(|(id, info)| (id, Ok(info.into())))
         .collect();
 
-    match blocklist {
-        None => (),
-        Some(blocklist) if blocklist.deployments.is_empty() => {
-            for entry in indexer_indexings.values_mut() {
-                *entry = Err(UnavailableReason::Blocked(blocklist.reason.clone()));
-            }
+    if let Some(blocklist) = blocklist {
+        for deployment in blocklist {
+            indexer_indexings.insert(
+                *deployment,
+                Err(UnavailableReason::Blocked("missing data".to_string())),
+            );
         }
-        Some(blocklist) => {
-            for deployment in &blocklist.deployments {
-                indexer_indexings.insert(
-                    *deployment,
-                    Err(UnavailableReason::Blocked(blocklist.reason.clone())),
-                );
-            }
-        }
-    };
+    }
 
     // ref: df8e647b-1e6e-422a-8846-dc9ee7e0dcc2
     let status_url = url.join("status").unwrap();

--- a/src/network/service.rs
+++ b/src/network/service.rs
@@ -194,6 +194,8 @@ pub fn spawn(
             }
         };
     }
+    let (_, poi_blocklist) = watch::channel(poi_blocklist);
+    let (_, indexer_blocklist) = watch::channel(indexer_blocklist);
 
     let internal_state = InternalState {
         indexer_blocklist,
@@ -216,7 +218,7 @@ pub fn spawn(
 }
 
 pub struct InternalState {
-    pub indexer_blocklist: HashMap<Address, HashSet<DeploymentId>>,
+    pub indexer_blocklist: watch::Receiver<HashMap<Address, HashSet<DeploymentId>>>,
     pub indexer_host_filter: HostFilter,
     pub indexer_version_filter: VersionFilter,
     pub indexer_poi_filer: PoiFilter,


### PR DESCRIPTION
This merges the PoI and indexer blocklists, such that the new blocklist is served via `/blocklist`. Also, a kafka consumer is added to update blocklist entries from the `gateway_blocklist` topic.