### PR TITLE
feat: add config option for `network_subgraph_max_lag_seconds` 

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,9 @@ pub struct Config {
     pub min_indexer_version: Version,
     /// Indexers used to query the network subgraph
     pub trusted_indexers: Vec<TrustedIndexer>,
+    /// Maximum acceptable lag (in seconds) for network subgraph responses (default: 120)
+    #[serde(default = "default_network_subgraph_max_lag_seconds")]
+    pub network_subgraph_max_lag_seconds: u64,
     /// Check payment state of client (disable for testnets)
     pub payment_required: bool,
     /// public API port
@@ -58,6 +61,11 @@ pub struct Config {
     #[serde(deserialize_with = "deserialize_not_nan_f64")]
     pub query_fees_target: NotNan<f64>,
     pub receipts: Receipts,
+}
+
+/// Default network subgraph max lag threshold (120 seconds)
+fn default_network_subgraph_max_lag_seconds() -> u64 {
+    120
 }
 
 /// Deserialize a `NotNan<f64>` from a `f64` and return an error if the value is NaN.

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,7 @@ async fn main() {
         indexers: conf.trusted_indexers,
         latest_block: None,
         page_size: 500,
+        max_lag_seconds: conf.network_subgraph_max_lag_seconds,
     };
     let indexer_host_blocklist = match &conf.ip_blocker_db {
         Some(path) => {

--- a/src/network/subgraph_client.rs
+++ b/src/network/subgraph_client.rs
@@ -125,6 +125,7 @@ pub struct Client {
     pub indexers: Vec<TrustedIndexer>,
     pub page_size: usize,
     pub latest_block: Option<Block>,
+    pub max_lag_seconds: u64,
 }
 
 impl Client {
@@ -271,7 +272,8 @@ impl Client {
                     "response block before latest",
                 );
                 ensure!(
-                    (unix_timestamp() / 1_000).saturating_sub(block.timestamp) < 120,
+                    (unix_timestamp() / 1_000).saturating_sub(block.timestamp)
+                        < self.max_lag_seconds,
                     "response too far behind",
                 );
                 query_block = Some(block);


### PR DESCRIPTION
This is mostly relevant for testing on the local-network.