### PR TITLE
fix: validate response staleness before returning to users

### DIFF
--- a/src/client_query/context.rs
+++ b/src/client_query/context.rs
@@ -20,4 +20,5 @@ pub struct Context {
     pub attestation_domain: &'static Eip712Domain,
     pub legacy_attestation_domain: &'static Eip712Domain,
     pub reporter: mpsc::UnboundedSender<reports::ClientRequest>,
+    pub max_response_staleness_seconds: u64,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,6 +51,9 @@ pub struct Config {
     /// Maximum acceptable lag (in seconds) for network subgraph responses (default: 120)
     #[serde(default = "default_network_subgraph_max_lag_seconds")]
     pub network_subgraph_max_lag_seconds: u64,
+    /// Maximum staleness (seconds) for indexer response data (default: 1800)
+    #[serde(default = "default_max_response_staleness_seconds")]
+    pub max_response_staleness_seconds: u64,
     /// Check payment state of client (disable for testnets)
     pub payment_required: bool,
     /// public API port
@@ -68,6 +71,11 @@ pub struct Config {
 /// Default network subgraph max lag threshold (120 seconds)
 fn default_network_subgraph_max_lag_seconds() -> u64 {
     120
+}
+
+/// Default max response staleness threshold (30 minutes)
+fn default_max_response_staleness_seconds() -> u64 {
+    60 * 30
 }
 
 /// Deserialize a `NotNan<f64>` from a `f64` and return an error if the value is NaN.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -100,6 +100,10 @@ pub enum UnavailableReason {
     #[error("too far behind")]
     TooFarBehind,
 
+    /// The indexer response data is too stale.
+    #[error("response too stale: {seconds_behind}s behind")]
+    ResponseTooStale { seconds_behind: u64 },
+
     /// An internal error occurred.
     #[error("internal error: {0}")]
     Internal(&'static str),

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,7 @@ async fn main() {
         attestation_domain,
         legacy_attestation_domain,
         reporter,
+        max_response_staleness_seconds: conf.max_response_staleness_seconds,
     };
 
     let blocklist: watch::Receiver<Vec<BlocklistEntry>> = indexer_blocklist.blocklist;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,6 +15,7 @@ pub struct Metrics {
     pub avg_query_fees: Gauge,
     pub indexer_query: ResponseMetricVecs,
     pub blocks_per_minute: IntGaugeVec,
+    pub stale_responses_rejected: IntCounterVec,
 }
 
 impl Metrics {
@@ -35,6 +36,12 @@ impl Metrics {
                 "gw_blocks_per_minute",
                 "chain blocks per minute",
                 &["chain"]
+            )
+            .unwrap(),
+            stale_responses_rejected: register_int_counter_vec!(
+                "gw_stale_responses_rejected",
+                "indexer responses rejected due to stale data",
+                &["deployment"]
             )
             .unwrap(),
         }


### PR DESCRIPTION
## Motivation

The gateway extracts `probe_block` from indexer responses (containing actual block timestamp) but never validates freshness before returning to users. Indexers can self-report being "fresh" via status endpoint while serving data that is months or even years old. This creates a gap where stale data reaches users despite the gateway having the information needed to detect it.

## Summary

- Adds post-response validation of `probe_block.timestamp` against current time
- Stale responses are rejected and the retry loop continues with other candidates
- Stale blocks are excluded from the chain tracker to avoid polluting block rate estimates
- Configurable staleness threshold (default: 30 minutes)

## Changes

- Add `ResponseTooStale { seconds_behind: u64 }` error variant
- Add `max_response_staleness_seconds` config option (default: 1800 / 30 min)
- Add `gw_stale_responses_rejected` counter metric (labeled by deployment)
- Add `validate_response_staleness()` function that checks probe_block timestamp
- Integrate validation into response handling loop with logging
- Treat staleness rejections as failures in performance feedback
- Skip `chain.notify` for stale-rejected responses to prevent stale blocks from distorting chain head and `blocks_per_minute` estimates

🤖 Generated with [Claude Code](https://claude.com/claude-code)