### PR TITLE
feat: add support for x402 client payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,7 +376,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project 1.1.10",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -409,7 +420,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project 1.1.10",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -685,7 +696,7 @@ checksum = "30bf12879a20e1261cd39c3b101856f52d18886907a826e102538897f0d2b66e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "reqwest 0.12.28",
  "serde_json",
  "tower",
  "tracing",
@@ -1049,6 +1060,28 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
 ]
 
 [[package]]
@@ -1490,6 +1523,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,8 +1600,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -2252,6 +2315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,7 +2436,7 @@ dependencies = [
  "once_cell",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "reqwest",
+ "reqwest 0.12.28",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -2452,7 +2521,7 @@ dependencies = [
  "prost 0.14.3",
  "rand 0.9.2",
  "rdkafka",
- "reqwest",
+ "reqwest 0.12.28",
  "semver 1.0.27",
  "serde",
  "serde_json",
@@ -2471,6 +2540,9 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "x402-axum",
+ "x402-chain-eip155",
+ "x402-types",
 ]
 
 [[package]]
@@ -2537,6 +2609,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3106,6 +3181,60 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -3947,6 +4076,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3978,6 +4127,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4171,6 +4321,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4192,6 +4354,15 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -4243,6 +4414,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,6 +4481,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4327,6 +4567,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4632,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -4407,11 +4665,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.5.1",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4440,6 +4726,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "sasl2-sys"
@@ -4491,6 +4786,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
@@ -4828,6 +5129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,7 +5413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47039e9174267bf71f7ad9ff0af478f31df576d3ec6adcbd88e406cf19546e4a"
 dependencies = [
  "async-trait",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -5570,7 +5877,7 @@ dependencies = [
  "mime",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_with",
@@ -5709,6 +6016,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5741,6 +6058,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -5839,6 +6157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5852,6 +6179,15 @@ name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-core"
@@ -5925,6 +6261,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -5957,6 +6302,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6009,6 +6369,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6027,6 +6393,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6042,6 +6414,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6075,6 +6453,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6090,6 +6474,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6111,6 +6501,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6126,6 +6522,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6183,6 +6585,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x402-axum"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8577ebc8ce69139ba0b368f0b149d63b2f018d6cb3adce0b9a8be4320cd0976a"
+dependencies = [
+ "axum-core",
+ "http 1.4.0",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "url",
+ "x402-types",
+]
+
+[[package]]
+name = "x402-chain-eip155"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3497af3e8f41291db4274f16bc86cd69e40e762bdad25439ddea2044ba8948a7"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "x402-types",
+]
+
+[[package]]
+name = "x402-types"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9791920783dc19ba223634cc7203aac695c58ba7cc38b62f8f00b81eaf47af78"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "base64",
+ "regex",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5563,9 +5563,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6589,9 +6589,8 @@ dependencies = [
 
 [[package]]
 name = "x402-axum"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8577ebc8ce69139ba0b368f0b149d63b2f018d6cb3adce0b9a8be4320cd0976a"
+version = "1.4.6"
+source = "git+https://github.com/edgeandnode/x402-rs?branch=main#168b9bdf0af319718c28577ece11062002ddd15d"
 dependencies = [
  "axum-core",
  "http 1.4.0",
@@ -6607,9 +6606,8 @@ dependencies = [
 
 [[package]]
 name = "x402-chain-eip155"
-version = "1.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3497af3e8f41291db4274f16bc86cd69e40e762bdad25439ddea2044ba8948a7"
+version = "1.4.6"
+source = "git+https://github.com/edgeandnode/x402-rs?branch=main#168b9bdf0af319718c28577ece11062002ddd15d"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -6621,9 +6619,8 @@ dependencies = [
 
 [[package]]
 name = "x402-types"
-version = "1.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9791920783dc19ba223634cc7203aac695c58ba7cc38b62f8f00b81eaf47af78"
+version = "1.4.6"
+source = "git+https://github.com/edgeandnode/x402-rs?branch=main#168b9bdf0af319718c28577ece11062002ddd15d"
 dependencies = [
  "alloy-primitives",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,10 @@ tracing-subscriber = { version = "0.3", features = [
     "json",
 ] }
 url = "2.5.0"
-x402-axum = "1.4"
-x402-types = "1.4"
-x402-chain-eip155 = { version = "1.4", features = ["server"] }
+# TODO: Switch back to crates.io once https://github.com/x402-rs/x402-rs/pull/87 is released
+x402-axum = { git = "https://github.com/edgeandnode/x402-rs", branch = "main" }
+x402-types = { git = "https://github.com/edgeandnode/x402-rs", branch = "main" }
+x402-chain-eip155 = { git = "https://github.com/edgeandnode/x402-rs", branch = "main", features = ["server"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ tracing-subscriber = { version = "0.3", features = [
     "json",
 ] }
 url = "2.5.0"
+x402-axum = "1.4"
+x402-types = "1.4"
+x402-chain-eip155 = { version = "1.4", features = ["server"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/SKILL.md
+++ b/SKILL.md
@@ -13,7 +13,7 @@ Query blockchain data from The Graph Network's decentralized indexers.
 
 Two options for accessing the API:
 
-### Option 1: API Key
+### Option 1: API Key (best for humans)
 
 Get an API key from [Subgraph Studio](https://thegraph.com/studio) and include it in requests.
 
@@ -23,7 +23,7 @@ Get an API key from [Subgraph Studio](https://thegraph.com/studio) and include i
 
 **Header:** `Authorization: Bearer <API_KEY>`
 
-### Option 2: x402 Payment
+### Option 2: x402 Payment (best for agents)
 
 Pay per query with USDC. No API key required.
 
@@ -42,12 +42,72 @@ curl -X POST https://gateway.thegraph.com/api/subgraphs/id/5zvR82QoaXYFyDEKLZ9t6
   -d '{"query": "{ tokens(first: 5) { symbol } }"}'
 ```
 
-### With x402 (using x402-proxy cli)
+### With x402 Payment
+
+Any x402 tooling that supports exact scheme will work with the gateway's x402 endpoints. We recommend to use the official Graph x402 client:
 
 ```bash
-X402_PROXY_WALLET_EVM_KEY="<PAYER_WALLET_PRIVATE_KEY>" \
-npx x402-proxy http://gateway.thegraph.com/api/x402/deployments/id/QmXU9FEf1tUwSjsnGGsuvMHFmGq3CeEi1RiWrNXSQXzkAi \
-  -X POST \
-  --header 'content-type: application/json' \
-  -d '{"query":"{ indexers { id stakedTokens allocations { id } } }"}'
+npm install @graphprotocol/client-x402
 ```
+
+**Option A: Command Line**
+
+```bash
+export X402_PRIVATE_KEY=0xabc123...
+
+npx graphclient-x402 "{ pairs(first: 5) { id } }" \
+  --endpoint https://gateway.thegraph.com/api/x402/subgraphs/id/<SUBGRAPH_ID> \
+  --chain base
+```
+
+**Option B: Programmatic**
+
+```typescript
+import { createGraphQuery } from '@graphprotocol/client-x402'
+
+const query = createGraphQuery({
+  endpoint: 'https://gateway.thegraph.com/api/x402/subgraphs/id/<SUBGRAPH_ID>',
+  chain: 'base',
+})
+
+const result = await query('{ pairs(first: 5) { id } }')
+```
+
+**Option C: Typed SDK (full type safety)**
+
+```bash
+npm install @graphprotocol/client-cli @graphprotocol/client-x402
+```
+
+Configure `.graphclientrc.yml`:
+
+```yaml
+customFetch: '@graphprotocol/client-x402'
+
+sources:
+  - name: uniswap
+    handler:
+      graphql:
+        endpoint: https://gateway.thegraph.com/api/x402/subgraphs/id/<SUBGRAPH_ID>
+
+documents:
+  - ./src/queries/*.graphql
+```
+
+Build and use:
+
+```bash
+export X402_PRIVATE_KEY=0xabc123...
+export X402_CHAIN=base
+npx graphclient build
+```
+
+```typescript
+import { execute, GetPairsDocument } from './.graphclient'
+
+const result = await execute(GetPairsDocument, { first: 5 })
+```
+
+**Environment Variables:**
+- `X402_PRIVATE_KEY`: Wallet private key for payment signing
+- `X402_CHAIN`: `base` (mainnet) or `base-sepolia` (testnet)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,53 @@
+# The Graph Gateway
+
+Query blockchain data from The Graph Network's decentralized indexers.
+
+## Environments
+
+| Environment | Base URL |
+|-------------|----------|
+| Mainnet | `https://gateway.thegraph.com` |
+| Testnet | `https://testnet.gateway.thegraph.com` |
+
+## Authentication
+
+Two options for accessing the API:
+
+### Option 1: API Key
+
+Get an API key from [Subgraph Studio](https://thegraph.com/studio) and include it in requests.
+
+**Endpoints:**
+- `POST /api/subgraphs/id/{subgraph_id}`
+- `POST /api/deployments/id/{deployment_id}`
+
+**Header:** `Authorization: Bearer <API_KEY>`
+
+### Option 2: x402 Payment
+
+Pay per query with USDC. No API key required.
+
+**Endpoints:**
+- `POST /api/x402/subgraphs/id/{subgraph_id}`
+- `POST /api/x402/deployments/id/{deployment_id}`
+
+## Examples
+
+### With API Key
+
+```bash
+curl -X POST https://gateway.thegraph.com/api/subgraphs/id/5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ tokens(first: 5) { symbol } }"}'
+```
+
+### With x402 (using x402-proxy cli)
+
+```bash
+X402_PROXY_WALLET_EVM_KEY="<PAYER_WALLET_PRIVATE_KEY>" \
+npx x402-proxy http://gateway.thegraph.com/api/x402/deployments/id/QmXU9FEf1tUwSjsnGGsuvMHFmGq3CeEi1RiWrNXSQXzkAi \
+  -X POST \
+  --header 'content-type: application/json' \
+  -d '{"query":"{ indexers { id stakedTokens allocations { id } } }"}'
+```

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,6 +203,9 @@ pub struct X402Config {
     /// Price per query in USD (e.g., 0.002 for $0.002 per query)
     #[serde(deserialize_with = "deserialize_not_nan_f64")]
     pub price: NotNan<f64>,
+    /// Optional headers to send with requests to the facilitator (e.g., for authentication)
+    #[serde(default)]
+    pub facilitator_headers: BTreeMap<String, String>,
 }
 
 /// Supported chains for x402 USDC payments.

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,6 +200,9 @@ pub struct X402Config {
     /// Chain for USDC payments (base, base_sepolia)
     #[serde(default = "default_x402_chain")]
     pub chain: X402Chain,
+    /// Price per query in USD (e.g., 0.002 for $0.002 per query)
+    #[serde(deserialize_with = "deserialize_not_nan_f64")]
+    pub price: NotNan<f64>,
 }
 
 /// Supported chains for x402 USDC payments.

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,20 +67,8 @@ pub struct Config {
     pub receipts: Receipts,
     /// Address for the Subgraph Service
     pub subgraph_service: Address,
-}
-
-/// Default network subgraph max lag threshold (120 seconds)
-fn default_network_subgraph_max_lag_seconds() -> u64 {
-    120
-}
-
-/// Deserialize a `NotNan<f64>` from a `f64` and return an error if the value is NaN.
-fn deserialize_not_nan_f64<'de, D>(deserializer: D) -> Result<NotNan<f64>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let value = f64::deserialize(deserializer)?;
-    NotNan::new(value).map_err(serde::de::Error::custom)
+    /// x402 payment support configuration
+    pub x402: Option<X402Config>,
 }
 
 /// API keys configuration.
@@ -198,6 +186,51 @@ pub struct Receipts {
     pub verifier: Address,
     /// Legacy TAP verifier contract address (v1)
     pub legacy_verifier: Address,
+}
+
+/// x402 payment support configuration.
+#[serde_as]
+#[derive(Clone, Deserialize)]
+pub struct X402Config {
+    /// x402 facilitator URL (e.g., "https://x402.org/facilitator")
+    #[serde_as(as = "DisplayFromStr")]
+    pub facilitator_url: Url,
+    /// Wallet address to receive USDC payments
+    pub receiver_address: Address,
+    /// Chain for USDC payments (base, base_sepolia)
+    #[serde(default = "default_x402_chain")]
+    pub chain: X402Chain,
+}
+
+/// Supported chains for x402 USDC payments.
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum X402Chain {
+    #[default]
+    Base,
+    BaseSepolia,
+}
+
+// -----------------------------------------------------------------------------
+// Helper functions
+// -----------------------------------------------------------------------------
+
+/// Default network subgraph max lag threshold (120 seconds)
+fn default_network_subgraph_max_lag_seconds() -> u64 {
+    120
+}
+
+/// Deserialize a `NotNan<f64>` from a `f64` and return an error if the value is NaN.
+fn deserialize_not_nan_f64<'de, D>(deserializer: D) -> Result<NotNan<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = f64::deserialize(deserializer)?;
+    NotNan::new(value).map_err(serde::de::Error::custom)
+}
+
+fn default_x402_chain() -> X402Chain {
+    X402Chain::Base
 }
 
 /// Returns `base` with `_{env}` appended when `env` is `Some` and non-empty, or `base` unchanged

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,6 +257,10 @@ async fn main() {
             "/blocklist",
             routing::get(move || async move { axum::Json(blocklist.borrow().clone()) }),
         )
+        .route(
+            "/SKILL.md",
+            routing::get(|| async { include_str!("../SKILL.md") }),
+        )
         .nest("/api", api);
 
     // x402 payment endpoints at /api/x402/*

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,7 +291,7 @@ async fn main() {
                             .allow_methods([http::Method::OPTIONS, http::Method::POST]),
                     )
                     .layer(RequestTracingLayer::new(format!("{signer_address:?}")))
-                    .layer(create_x402_layer(&x402_config, conf.query_fees_target))
+                    .layer(create_x402_layer(&x402_config))
                     .layer(axum::middleware::from_fn(x402_auth_adapter)),
             );
         router = router.nest("/api/x402", x402_api);

--- a/src/main.rs
+++ b/src/main.rs
@@ -259,6 +259,10 @@ async fn main() {
         )
         .nest("/api", api);
 
+    // x402 payment endpoints at /api/x402/*
+    // Note: This path overlaps with legacy /api/{api_key}/* routes. Axum routes literal
+    // segments before parameters, so /api/x402/* matches here first. This effectively
+    // reserves "x402" as an API key value when x402 is enabled.
     if let Some(x402_config) = conf.x402 {
         let x402_api = Router::new()
             .route(

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use client_query::context::Context;
 use config::{ApiKeys, BlocklistEntry, ExchangeRateProvider};
 use indexer_client::IndexerClient;
 use indexing_performance::IndexingPerformance;
-use middleware::{RequestTracingLayer, RequireAuthorizationLayer, legacy_auth_adapter};
+use middleware::{RequestTracingLayer, RequireAuthorizationLayer, create_x402_layer, legacy_auth_adapter, x402_auth_adapter};
 use network::{indexer_blocklist, subgraph_client::Client as SubgraphClient};
 use prometheus::{self, Encoder as _};
 use rand::RngCore as _;
@@ -230,7 +230,7 @@ async fn main() {
             "/{api_key}/subgraphs/id/{subgraph_id}",
             routing::post(client_query::handle_query),
         )
-        .with_state(ctx)
+        .with_state(ctx.clone())
         .layer(
             // ServiceBuilder works by composing all layers into one such that they run top to
             // bottom, and then the response would bubble back up through the layers in reverse
@@ -246,7 +246,7 @@ async fn main() {
                 .layer(RequireAuthorizationLayer::new(auth_service)),
         );
 
-    let router = Router::new()
+    let mut router = Router::new()
         .route("/", routing::get(|| async { "Ready to roll!" }))
         // This path is required by NGINX ingress controller
         .route("/ready", routing::get(|| async { "Ready" }))
@@ -255,6 +255,37 @@ async fn main() {
             routing::get(move || async move { axum::Json(blocklist.borrow().clone()) }),
         )
         .nest("/api", api);
+
+    if let Some(x402_config) = conf.x402 {
+        let x402_api = Router::new()
+            .route(
+                "/subgraphs/id/{subgraph_id}",
+                routing::post(client_query::handle_query),
+            )
+            .route(
+                "/deployments/id/{deployment_id}",
+                routing::post(client_query::handle_query),
+            )
+            .route(
+                "/deployments/id/{deployment_id}/indexers/id/{indexer}",
+                routing::post(client_query::handle_indexer_query),
+            )
+            .with_state(ctx)
+            .layer(
+                tower::ServiceBuilder::new()
+                    .layer(
+                        CorsLayer::new()
+                            .allow_origin(cors::Any)
+                            .allow_headers(cors::Any)
+                            .allow_methods([http::Method::OPTIONS, http::Method::POST]),
+                    )
+                    .layer(RequestTracingLayer::new(format!("{signer_address:?}")))
+                    .layer(create_x402_layer(&x402_config, conf.query_fees_target))
+                    .layer(axum::middleware::from_fn(x402_auth_adapter)),
+            );
+        router = router.nest("/api/x402", x402_api);
+        tracing::info!("x402 payment endpoints enabled at /api/x402/*");
+    }
 
     // handle graceful shutdown via the axum server instead
     setup_termination.abort();

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,10 @@ use client_query::context::Context;
 use config::{ApiKeys, BlocklistEntry, ExchangeRateProvider};
 use indexer_client::IndexerClient;
 use indexing_performance::IndexingPerformance;
-use middleware::{RequestTracingLayer, RequireAuthorizationLayer, create_x402_layer, legacy_auth_adapter, x402_auth_adapter};
+use middleware::{
+    RequestTracingLayer, RequireAuthorizationLayer, create_x402_layer, legacy_auth_adapter,
+    x402_auth_adapter,
+};
 use network::{indexer_blocklist, subgraph_client::Client as SubgraphClient};
 use prometheus::{self, Encoder as _};
 use rand::RngCore as _;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,7 +1,9 @@
 mod legacy_auth;
 mod request_tracing;
 mod require_auth;
+mod x402_auth;
 
 pub use legacy_auth::legacy_auth_adapter;
 pub use request_tracing::{RequestId, RequestTracingLayer};
 pub use require_auth::RequireAuthorizationLayer;
+pub use x402_auth::{create_layer as create_x402_layer, x402_auth_adapter};

--- a/src/middleware/x402_auth.rs
+++ b/src/middleware/x402_auth.rs
@@ -6,7 +6,6 @@
 
 use axum::{body::Body, extract::Request, http::Response, middleware::Next};
 use base64::Engine;
-use ordered_float::NotNan;
 use x402_axum::{
     StaticPriceTags, X402LayerBuilder, X402Middleware, facilitator_client::FacilitatorClient,
 };
@@ -24,9 +23,8 @@ use crate::{
 /// Creates middleware that manages the x402 payment flow.
 pub fn create_layer(
     config: &X402Config,
-    query_fees_target: NotNan<f64>,
 ) -> X402LayerBuilder<StaticPriceTags<PriceTag>, std::sync::Arc<FacilitatorClient>> {
-    let usdc_amount = (*query_fees_target * 1_000_000.0) as u64;
+    let usdc_amount = (*config.price * 1_000_000.0) as u64;
     let token = match config.chain {
         X402Chain::Base => USDC::base(),
         X402Chain::BaseSepolia => USDC::base_sepolia(),

--- a/src/middleware/x402_auth.rs
+++ b/src/middleware/x402_auth.rs
@@ -1,19 +1,25 @@
-//! x402 payment authentication middleware.
+//! x402 payment middleware
 //!
-//! This middleware handles x402 payment verification and injects `AuthSettings`
-//! for downstream handlers.
+//! Middleware consists of two layers:
+//! - x402 middleware, handling base x402 payments
+//! - x402 auth adapter, extracting payer info and injecting `AuthSettings` request extension for downstream handlers.
 
 use axum::{body::Body, extract::Request, http::Response, middleware::Next};
 use base64::Engine;
 use ordered_float::NotNan;
-use x402_axum::{facilitator_client::FacilitatorClient, StaticPriceTags, X402LayerBuilder, X402Middleware};
+use x402_axum::{
+    StaticPriceTags, X402LayerBuilder, X402Middleware, facilitator_client::FacilitatorClient,
+};
 use x402_chain_eip155::{
     KnownNetworkEip155, V2Eip155Exact,
     v2_eip155_exact::types::{ExactEvmPayload, PaymentPayload},
 };
 use x402_types::{networks::USDC, proto::v2::PriceTag};
 
-use crate::{auth::AuthSettings, config::{X402Chain, X402Config}};
+use crate::{
+    auth::AuthSettings,
+    config::{X402Chain, X402Config},
+};
 
 /// Creates middleware that manages the x402 payment flow.
 pub fn create_layer(

--- a/src/middleware/x402_auth.rs
+++ b/src/middleware/x402_auth.rs
@@ -74,3 +74,76 @@ fn extract_payer_address(headers: &axum::http::HeaderMap) -> Option<String> {
 
     Some(address)
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::http::HeaderMap;
+    use base64::Engine;
+
+    use super::extract_payer_address;
+
+    #[test]
+    fn extract_payer_missing_header() {
+        let headers = HeaderMap::new();
+        assert_eq!(extract_payer_address(&headers), None);
+    }
+
+    #[test]
+    fn extract_payer_invalid_base64() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-payment", "not-valid-base64!!!".parse().unwrap());
+        assert_eq!(extract_payer_address(&headers), None);
+    }
+
+    #[test]
+    fn extract_payer_invalid_json() {
+        let mut headers = HeaderMap::new();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(b"not json");
+        headers.insert("x-payment", encoded.parse().unwrap());
+        assert_eq!(extract_payer_address(&headers), None);
+    }
+
+    #[test]
+    fn extract_payer_valid_eip3009_payload() {
+        // Minimal valid Eip3009 payment payload
+        let payload = serde_json::json!({
+            "x402Version": 2,
+            "accepted": {
+                "scheme": "exact",
+                "network": "eip155:8453",
+                "amount": "100",
+                "payTo": "0x0000000000000000000000000000000000000001",
+                "maxTimeoutSeconds": 300,
+                "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                "extra": {
+                    "assetTransferMethod": "eip3009",
+                    "name": "USDC",
+                    "version": "2"
+                }
+            },
+            "payload": {
+                "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "authorization": {
+                    "from": "0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF",
+                    "to": "0x0000000000000000000000000000000000000001",
+                    "value": "100",
+                    "validAfter": "0",
+                    "validBefore": "1999999999",
+                    "nonce": "0x0000000000000000000000000000000000000000000000000000000000000001"
+                }
+            },
+            "resource": null
+        });
+
+        let mut headers = HeaderMap::new();
+        let encoded =
+            base64::engine::general_purpose::STANDARD.encode(payload.to_string().as_bytes());
+        headers.insert("x-payment", encoded.parse().unwrap());
+
+        let result = extract_payer_address(&headers);
+        assert_eq!(
+            result,
+            Some("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF".to_string())
+        );
+    }
+}

--- a/src/middleware/x402_auth.rs
+++ b/src/middleware/x402_auth.rs
@@ -55,7 +55,6 @@ pub fn create_layer(
     X402Middleware::from_facilitator(Arc::new(client)).with_price_tag(price_tag)
 }
 
-/// Extracts payer address from x402 payment header and inserts AuthSettings.
 /// This adapter middleware extracts the payer address from the x402 payment header,
 /// and adds it to the request as an `AuthSettings` extension.
 ///

--- a/src/middleware/x402_auth.rs
+++ b/src/middleware/x402_auth.rs
@@ -1,0 +1,70 @@
+//! x402 payment authentication middleware.
+//!
+//! This middleware handles x402 payment verification and injects `AuthSettings`
+//! for downstream handlers.
+
+use axum::{body::Body, extract::Request, http::Response, middleware::Next};
+use base64::Engine;
+use ordered_float::NotNan;
+use x402_axum::{facilitator_client::FacilitatorClient, StaticPriceTags, X402LayerBuilder, X402Middleware};
+use x402_chain_eip155::{
+    KnownNetworkEip155, V2Eip155Exact,
+    v2_eip155_exact::types::{ExactEvmPayload, PaymentPayload},
+};
+use x402_types::{networks::USDC, proto::v2::PriceTag};
+
+use crate::{auth::AuthSettings, config::{X402Chain, X402Config}};
+
+/// Creates middleware that manages the x402 payment flow.
+pub fn create_layer(
+    config: &X402Config,
+    query_fees_target: NotNan<f64>,
+) -> X402LayerBuilder<StaticPriceTags<PriceTag>, std::sync::Arc<FacilitatorClient>> {
+    let usdc_amount = (*query_fees_target * 1_000_000.0) as u64;
+    let token = match config.chain {
+        X402Chain::Base => USDC::base(),
+        X402Chain::BaseSepolia => USDC::base_sepolia(),
+    };
+    let price_tag = V2Eip155Exact::price_tag(config.receiver_address, token.amount(usdc_amount));
+    X402Middleware::new(config.facilitator_url.as_str()).with_price_tag(price_tag)
+}
+
+/// Extracts payer address from x402 payment header and inserts AuthSettings.
+/// This adapter middleware extracts the payer address from the x402 payment header,
+/// and adds it to the request as an `AuthSettings` extension.
+///
+/// If the request already has an `AuthSettings` extension, it does nothing.
+/// If the payer address cannot be extracted from the x402 payment header, it defaults to "x402".
+pub async fn x402_auth_adapter(mut request: Request, next: Next) -> Response<Body> {
+    if request.extensions().get::<AuthSettings>().is_some() {
+        return next.run(request).await;
+    }
+
+    let payer = extract_payer_address(request.headers()).unwrap_or_else(|| "x402".into());
+
+    request.extensions_mut().insert(AuthSettings {
+        key: "x402".into(),
+        user: payer,
+        authorized_subgraphs: vec![],
+    });
+
+    next.run(request).await
+}
+
+/// Decode payment header to extract payer address using x402 types.
+fn extract_payer_address(headers: &axum::http::HeaderMap) -> Option<String> {
+    let header = headers.get("x-payment")?;
+
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(header.as_bytes())
+        .ok()?;
+
+    let payment: PaymentPayload = serde_json::from_slice(&decoded).ok()?;
+
+    let address = match payment.payload {
+        ExactEvmPayload::Eip3009(p) => format!("{}", p.authorization.from),
+        ExactEvmPayload::Permit2(p) => p.permit_2_authorization.from.to_string(),
+    };
+
+    Some(address)
+}

--- a/src/middleware/x402_auth.rs
+++ b/src/middleware/x402_auth.rs
@@ -4,8 +4,11 @@
 //! - x402 middleware, handling base x402 payments
 //! - x402 auth adapter, extracting payer info and injecting `AuthSettings` request extension for downstream handlers.
 
+use std::sync::Arc;
+
 use axum::{body::Body, extract::Request, http::Response, middleware::Next};
 use base64::Engine;
+use http::HeaderMap;
 use x402_axum::{
     StaticPriceTags, X402LayerBuilder, X402Middleware, facilitator_client::FacilitatorClient,
 };
@@ -23,14 +26,33 @@ use crate::{
 /// Creates middleware that manages the x402 payment flow.
 pub fn create_layer(
     config: &X402Config,
-) -> X402LayerBuilder<StaticPriceTags<PriceTag>, std::sync::Arc<FacilitatorClient>> {
+) -> X402LayerBuilder<StaticPriceTags<PriceTag>, Arc<FacilitatorClient>> {
     let usdc_amount = (*config.price * 1_000_000.0) as u64;
     let token = match config.chain {
         X402Chain::Base => USDC::base(),
         X402Chain::BaseSepolia => USDC::base_sepolia(),
     };
     let price_tag = V2Eip155Exact::price_tag(config.receiver_address, token.amount(usdc_amount));
-    X402Middleware::new(config.facilitator_url.as_str()).with_price_tag(price_tag)
+
+    // Build facilitator client with optional custom headers
+    let client = FacilitatorClient::try_from(config.facilitator_url.as_str())
+        .expect("Invalid facilitator URL");
+    let client = if config.facilitator_headers.is_empty() {
+        client
+    } else {
+        let mut headers = HeaderMap::new();
+        for (key, value) in &config.facilitator_headers {
+            if let (Ok(name), Ok(val)) = (
+                key.parse::<http::HeaderName>(),
+                value.parse::<http::HeaderValue>(),
+            ) {
+                headers.insert(name, val);
+            }
+        }
+        client.with_headers(headers)
+    };
+
+    X402Middleware::from_facilitator(Arc::new(client)).with_price_tag(price_tag)
 }
 
 /// Extracts payer address from x402 payment header and inserts AuthSettings.


### PR DESCRIPTION
### Changelog
Adds x402 payment support as an alternative and optional payment method for end users. Clients can pay per-query using USDC (on Base or Base Sepolia) instead of API keys. Indexers still get paid with GraphTally.

**New endpoints**
- POST /api/x402/subgraphs/id/{subgraph_id}
- POST /api/x402/deployments/id/{deployment_id}
- POST /api/x402/deployments/id/{deployment_id}/indexers/id/{indexer}

**Flow**
1. Client sends request without payment → receives 402 Payment Required with price info
2. Client sends request with X-Payment header containing signed USDC authorization
3. Gateway verifies payment via facilitator, executes query, pays indexer via TAP

**Configuration**
```
{
  "x402": {
    "facilitator_url": "https://x402.org/facilitator",
    "receiver_address": "0x...",
    "chain": "base",
    "price": 0.002,
    "facilitator_headers": {
      "X-API-Key": "secret"
    }
  }
}
```

Omit x402 config to disable the feature.

**Reporting**
For x402 queries, the same Kafka reporting flow is used as regular API key queries. The only difference is that the `api_key` is hardcoded to `x402`. This means that other components relying on this Kafka topic don't need changes to support it.