### PR TITLE
Per environment topic suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## IDEs and editors
 /.idea
 /.vscode
+/.claude
 
 ## Rust
 **/*.rs.bk

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ The gateway exports data into the following kafka topics:
 - queries (`gateway_queries`)
 - attestations (`gateway_attestations`)
 
+The gateway also consumes from `gateway_blocklist`.
+
+When multiple gateway environments share a single Kafka cluster, set `kafka_topic_environment` in the
+config to append an environment qualifier to all topic names. For example, setting
+`"kafka_topic_environment": "staging"` produces topics like `gateway_queries_staging`. When unset,
+the default topic names above are used.
+
 Optionally, the [titorelli](https://github.com/edgeandnode/titorelli/) system can do aggregations
 over these topics. For now, this is limited to creating `gateway_indexer_fees_hourly` to improve
 the startup time of the `tap-escrow-manager`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,10 @@ pub struct Config {
     pub exchange_rate_provider: ExchangeRateProvider,
     /// Graph network environment identifier, inserted into Kafka messages
     pub graph_env_id: String,
+    /// Optional environment qualifier appended to Kafka topic names (e.g. "staging" results in
+    /// topics like "gateway_queries_staging"). When absent, default topic names are used.
+    #[serde(default)]
+    pub kafka_topic_environment: Option<String>,
     /// File path of CSV containing rows of `IpNetwork,Country`
     pub ip_blocker_db: Option<PathBuf>,
     /// See https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
@@ -196,6 +200,15 @@ pub struct Receipts {
     pub legacy_verifier: Address,
 }
 
+/// Returns `base` with `_{env}` appended when `env` is `Some` and non-empty, or `base` unchanged
+/// otherwise.
+pub fn topic_name(env: Option<&str>, base: &str) -> String {
+    match env.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(env) => format!("{base}_{env}"),
+        None => base.to_string(),
+    }
+}
+
 /// Load the configuration from a JSON file.
 pub fn load_from_file(path: &Path) -> anyhow::Result<Config> {
     let config_content = std::fs::read_to_string(path)?;
@@ -212,4 +225,59 @@ pub fn load_ip_blocklist_from_file(path: &Path) -> anyhow::Result<HashSet<IpNetw
         .lines()
         .filter_map(|line| line.split_once(',')?.0.parse().ok())
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::topic_name;
+
+    #[test]
+    fn topic_name_no_env() {
+        assert_eq!(topic_name(None, "gateway_queries"), "gateway_queries");
+        assert_eq!(
+            topic_name(None, "gateway_attestations"),
+            "gateway_attestations"
+        );
+        assert_eq!(topic_name(None, "gateway_blocklist"), "gateway_blocklist");
+    }
+
+    #[test]
+    fn topic_name_with_env() {
+        assert_eq!(
+            topic_name(Some("staging"), "gateway_queries"),
+            "gateway_queries_staging",
+        );
+        assert_eq!(
+            topic_name(Some("staging"), "gateway_attestations"),
+            "gateway_attestations_staging",
+        );
+        assert_eq!(
+            topic_name(Some("staging"), "gateway_blocklist"),
+            "gateway_blocklist_staging",
+        );
+    }
+
+    #[test]
+    fn topic_name_env_applies_to_any_base() {
+        assert_eq!(topic_name(Some("mainnet"), "foo"), "foo_mainnet");
+        assert_eq!(topic_name(Some("testnet"), "bar"), "bar_testnet");
+    }
+
+    #[test]
+    fn topic_name_empty_env_treated_as_none() {
+        assert_eq!(topic_name(Some(""), "gateway_queries"), "gateway_queries");
+        assert_eq!(topic_name(Some("  "), "gateway_queries"), "gateway_queries");
+        assert_eq!(
+            topic_name(Some("\t\n"), "gateway_queries"),
+            "gateway_queries"
+        );
+    }
+
+    #[test]
+    fn topic_name_env_is_trimmed() {
+        assert_eq!(
+            topic_name(Some(" staging "), "gateway_queries"),
+            "gateway_queries_staging"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,8 +129,14 @@ async fn main() {
         }
         None => Default::default(),
     };
-    let indexer_blocklist =
-        indexer_blocklist::Blocklist::spawn(conf.blocklist, kafka_consumer.clone());
+    let topic_env = conf.kafka_topic_environment.as_deref();
+    let topic_name = |base: &str| config::topic_name(topic_env, base);
+
+    let indexer_blocklist = indexer_blocklist::Blocklist::spawn(
+        conf.blocklist,
+        kafka_consumer.clone(),
+        topic_name("gateway_blocklist"),
+    );
     let mut network = network::service::spawn(
         http_client.clone(),
         network_subgraph_client,
@@ -167,8 +173,8 @@ async fn main() {
         signer_address,
         conf.graph_env_id,
         reports::Topics {
-            queries: "gateway_queries",
-            attestations: "gateway_attestations",
+            queries: topic_name("gateway_queries"),
+            attestations: topic_name("gateway_attestations"),
         },
         conf.kafka,
     )

--- a/src/network/indexer_blocklist.rs
+++ b/src/network/indexer_blocklist.rs
@@ -15,7 +15,7 @@ pub struct Blocklist {
 }
 
 impl Blocklist {
-    pub fn spawn(init: Vec<BlocklistEntry>, consumer: KafkaConsumer) -> Self {
+    pub fn spawn(init: Vec<BlocklistEntry>, consumer: KafkaConsumer, topic: String) -> Self {
         let (blocklist_tx, blocklist_rx) = watch::channel(Default::default());
         let (poi_tx, poi_rx) = watch::channel(Default::default());
         let (indexer_tx, indexer_rx) = watch::channel(Default::default());
@@ -28,7 +28,7 @@ impl Blocklist {
             actor.add_entry(entry);
         }
         tokio::spawn(async move {
-            actor.run(consumer).await;
+            actor.run(consumer, &topic).await;
         });
         Self {
             blocklist: blocklist_rx,
@@ -45,8 +45,8 @@ struct Actor {
 }
 
 impl Actor {
-    async fn run(&mut self, consumer: KafkaConsumer) {
-        let consumer = match consumer.stream_consumer("gateway_blocklist") {
+    async fn run(&mut self, consumer: KafkaConsumer, topic: &str) {
+        let consumer = match consumer.stream_consumer(topic) {
             Ok(consumer) => consumer,
             Err(blocklist_err) => {
                 tracing::error!(%blocklist_err);

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -35,8 +35,8 @@ pub struct IndexerRequest {
 }
 
 pub struct Topics {
-    pub queries: &'static str,
-    pub attestations: &'static str,
+    pub queries: String,
+    pub attestations: String,
 }
 
 pub struct Reporter {
@@ -164,7 +164,7 @@ impl Reporter {
 
         client_query_msg.encode(&mut self.write_buf).unwrap();
         let record: rdkafka::producer::BaseRecord<(), [u8], ()> =
-            rdkafka::producer::BaseRecord::to(self.topics.queries).payload(&self.write_buf);
+            rdkafka::producer::BaseRecord::to(&self.topics.queries).payload(&self.write_buf);
         self.kafka_producer
             .send(record)
             .map_err(|(err, _)| err)
@@ -202,7 +202,7 @@ impl Reporter {
                 .encode(&mut self.write_buf)
                 .unwrap();
                 let record: rdkafka::producer::BaseRecord<(), [u8], ()> =
-                    rdkafka::producer::BaseRecord::to(self.topics.attestations)
+                    rdkafka::producer::BaseRecord::to(&self.topics.attestations)
                         .payload(&self.write_buf);
                 self.kafka_producer
                     .send(record)


### PR DESCRIPTION
Gateway instances in different environments (testnet, staging) currently publish to the same Kafka topic names. This means consumers like the eligibility oracle node (EON) recieve combined data unless other filtering is performed. With this change, each environment can use distinct topics by setting a single config value.

- Add `kafka_topic_environment` config option that appends an environment suffix to Kafka topic names (e.g. `gateway_queries_staging`)
- When absent, topic names are unchanged — fully backwards-compatible
- Applies to all three topics: `gateway_queries`, `gateway_attestations`, `gateway_blocklist`

Also added `.claude` dir to `.gitignore`.