### PR TITLE
fix(perf): replace query rewrite with graph-indexed header

### DIFF
--- a/src/block_constraints.rs
+++ b/src/block_constraints.rs
@@ -1,55 +1,25 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Write as _,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{anyhow, bail};
 use graphql::{
     IntoStaticValue as _, QueryVariables, StaticValue,
     graphql_parser::{
         parse_query,
-        query::{
-            Definition, FragmentDefinition, OperationDefinition, Selection, SelectionSet, Text,
-            Value,
-        },
+        query::{Definition, OperationDefinition, Selection, Text, Value},
     },
 };
 use itertools::Itertools as _;
-use serde_json::{self, json};
+use serde_json::{self};
 use thegraph_core::alloy::primitives::{BlockHash, BlockNumber};
 
 use crate::{blocks::BlockConstraint, chain::Chain, errors::Error};
 
-pub struct QueryContext<'q> {
-    pub operations: Vec<OperationDefinition<'q, &'q str>>,
-    pub fragments: Vec<FragmentDefinition<'q, &'q str>>,
-    pub variables: QueryVariables,
-}
-
-impl<'q> QueryContext<'q> {
-    pub fn new(query: &'q str, variables: &'q str) -> anyhow::Result<Self> {
-        let variables = {
-            let vars = variables.trim();
-            if ["{}", "null", ""].contains(&vars) {
-                QueryVariables::default()
-            } else {
-                serde_json::from_str(vars).map_err(|_| anyhow!("Failed to parse variables"))?
-            }
-        };
-        let query = parse_query(query).map_err(|_| anyhow!("Failed to parse query"))?;
-        let mut operations = Vec::new();
-        let mut fragments = Vec::new();
-        for definition in query.definitions.into_iter() {
-            match definition {
-                Definition::Fragment(fragment) => fragments.push(fragment),
-                Definition::Operation(operation) => operations.push(operation),
-            }
-        }
-        Ok(Self {
-            variables,
-            fragments,
-            operations,
-        })
+pub fn parse_variables(variables: &str) -> anyhow::Result<QueryVariables> {
+    let vars = variables.trim();
+    if ["{}", "null", ""].contains(&vars) {
+        Ok(QueryVariables::default())
+    } else {
+        serde_json::from_str(vars).map_err(|_| anyhow!("Failed to parse variables"))
     }
 }
 
@@ -65,10 +35,11 @@ pub struct BlockRequirements {
 
 pub fn resolve_block_requirements(
     chain: &Chain,
-    context: &QueryContext,
+    query: &str,
+    variables: &QueryVariables,
     manifest_min_block: BlockNumber,
 ) -> Result<BlockRequirements, Error> {
-    let constraints = block_constraints(context).unwrap_or_default();
+    let constraints = block_constraints(query, variables).unwrap_or_default();
 
     let latest = constraints.iter().any(|c| match c {
         BlockConstraint::Unconstrained | BlockConstraint::NumberGTE(_) => true,
@@ -114,11 +85,22 @@ pub fn resolve_block_requirements(
     })
 }
 
-fn block_constraints(context: &QueryContext) -> Result<BTreeSet<BlockConstraint>, Error> {
+fn block_constraints(
+    query: &str,
+    vars: &QueryVariables,
+) -> Result<BTreeSet<BlockConstraint>, Error> {
+    let query = parse_query::<&str>(query)
+        .map_err(|_| Error::BadQuery(anyhow!("Failed to parse query")))?;
     let mut constraints = BTreeSet::new();
-    let vars = &context.variables;
     // ba6c90f1-3baf-45be-ac1c-f60733404436
-    for operation in &context.operations {
+    for operation in query
+        .definitions
+        .iter()
+        .filter_map(|definition| match definition {
+            Definition::Fragment(_) => None,
+            Definition::Operation(operation) => Some(operation),
+        })
+    {
         let (selection_set, defaults) = match operation {
             OperationDefinition::SelectionSet(selection_set) => {
                 (selection_set, BTreeMap::default())
@@ -162,81 +144,6 @@ fn block_constraints(context: &QueryContext) -> Result<BTreeSet<BlockConstraint>
         }
     }
     Ok(constraints)
-}
-
-pub fn rewrite_query<'q>(ctx: &QueryContext<'q>) -> String {
-    let mut buf: String = Default::default();
-    for fragment in &ctx.fragments {
-        write!(&mut buf, "{fragment}").unwrap();
-    }
-    if contains_introspection(ctx) {
-        for operation in &ctx.operations {
-            write!(&mut buf, "{operation}").unwrap();
-        }
-    } else {
-        let serialize_selection_set =
-            |buf: &mut String, selection_set: &SelectionSet<'q, &'q str>| {
-                buf.push_str("{\n");
-                for selection in &selection_set.items {
-                    match selection {
-                        Selection::Field(field) => {
-                            write!(buf, "  {field}").unwrap();
-                        }
-                        Selection::FragmentSpread(spread) => {
-                            write!(buf, "  {spread}").unwrap();
-                        }
-                        Selection::InlineFragment(fragment) => {
-                            write!(buf, "  {fragment}").unwrap();
-                        }
-                    };
-                }
-                buf.push_str("  _gateway_probe_: _meta { block { hash number timestamp } }\n}\n");
-            };
-        let serialize_operation =
-            |buf: &mut String, operation: &OperationDefinition<'q, &'q str>| {
-                match operation {
-                    OperationDefinition::SelectionSet(selection_set) => {
-                        serialize_selection_set(buf, selection_set);
-                    }
-                    OperationDefinition::Query(query) => {
-                        buf.push_str("query");
-                        if let Some(name) = query.name {
-                            write!(buf, " {name}").unwrap();
-                        }
-                        if !query.variable_definitions.is_empty() {
-                            write!(buf, "({}", query.variable_definitions[0]).unwrap();
-                            for var in &query.variable_definitions[1..] {
-                                write!(buf, ", {var}").unwrap();
-                            }
-                            buf.push(')');
-                        }
-                        debug_assert!(query.directives.is_empty());
-                        buf.push(' ');
-                        serialize_selection_set(buf, &query.selection_set);
-                    }
-                    OperationDefinition::Mutation(_) | OperationDefinition::Subscription(_) => (),
-                };
-            };
-        for operation in &ctx.operations {
-            serialize_operation(&mut buf, operation);
-        }
-    }
-
-    serde_json::to_string(&json!({ "query": buf, "variables": ctx.variables })).unwrap()
-}
-
-fn contains_introspection(ctx: &QueryContext<'_>) -> bool {
-    fn selection_set_has_introspection<'q>(s: &SelectionSet<'q, &'q str>) -> bool {
-        s.items.iter().any(|selection| match selection {
-            Selection::Field(f) => f.name.starts_with("__"), // only check top level
-            Selection::InlineFragment(_) | Selection::FragmentSpread(_) => false,
-        })
-    }
-    ctx.operations.iter().any(|op| match op {
-        OperationDefinition::Query(q) => selection_set_has_introspection(&q.selection_set),
-        OperationDefinition::SelectionSet(s) => selection_set_has_introspection(s),
-        OperationDefinition::Mutation(_) | OperationDefinition::Subscription(_) => false,
-    })
 }
 
 fn field_constraint<'c, T: Text<'c>>(
@@ -387,24 +294,12 @@ mod tests {
             ),
         ];
         for (query, expected) in tests {
-            let context = QueryContext::new(query, "").unwrap();
-            let constraints = block_constraints(&context).map_err(|e| e.to_string());
+            let variables = parse_variables("").unwrap();
+            let constraints = block_constraints(query, &variables).map_err(|e| e.to_string());
             let expected = expected
                 .map(|v| BTreeSet::from_iter(v.iter().cloned()))
                 .map_err(ToString::to_string);
             assert_eq!(constraints, expected);
-        }
-    }
-
-    #[test]
-    fn query_contains_introspection() {
-        let examples = [
-            "{ __schema { queryType { name } } }",
-            "{ __type(name:\"Droid\") { name description } }",
-        ];
-        for example in examples {
-            let context = QueryContext::new(example, "").unwrap();
-            assert!(super::contains_introspection(&context));
         }
     }
 
@@ -414,8 +309,8 @@ mod tests {
         // When $block variable is explicitly set to null, it should be treated as Unconstrained
         let query = "query($b: Block_height) { a(block:$b) }";
         let variables = r#"{"b": null}"#;
-        let context = QueryContext::new(query, variables).unwrap();
-        let constraints = block_constraints(&context).unwrap();
+        let variables = parse_variables(variables).unwrap();
+        let constraints = block_constraints(query, &variables).unwrap();
         let expected = BTreeSet::from_iter([Unconstrained]);
         assert_eq!(constraints, expected);
     }
@@ -426,8 +321,8 @@ mod tests {
         // When $block variable is set to an empty object, it should be treated as Unconstrained
         let query = "query($b: Block_height) { a(block:$b) }";
         let variables = r#"{"b": {}}"#;
-        let context = QueryContext::new(query, variables).unwrap();
-        let constraints = block_constraints(&context).unwrap();
+        let variables = parse_variables(variables).unwrap();
+        let constraints = block_constraints(query, &variables).unwrap();
         let expected = BTreeSet::from_iter([Unconstrained]);
         assert_eq!(constraints, expected);
     }

--- a/src/client_query.rs
+++ b/src/client_query.rs
@@ -18,7 +18,7 @@ use ordered_float::NotNan;
 use prost::bytes::Buf;
 use rand::RngExt as _;
 use serde::Deserialize;
-use serde_json::value::RawValue;
+use serde_json::{json, value::RawValue};
 use thegraph_core::{AllocationId, DeploymentId, IndexerId, alloy::primitives::BlockNumber};
 use thegraph_headers::{HttpBuilderExt as _, graph_attestation::GraphAttestation};
 use tokio::sync::mpsc;
@@ -28,9 +28,7 @@ use url::Url;
 use self::{context::Context, query_selector::QuerySelector};
 use crate::{
     auth::AuthSettings,
-    block_constraints::{
-        BlockRequirements, QueryContext, resolve_block_requirements, rewrite_query,
-    },
+    block_constraints::{BlockRequirements, parse_variables, resolve_block_requirements},
     budgets::USD,
     errors::{Error, IndexerError, IndexerErrors, MissingBlockError, UnavailableReason},
     indexer_client::{IndexerAuth, IndexerResponse},
@@ -100,7 +98,7 @@ pub async fn handle_query(
 
     result.map(
         |IndexerResponse {
-             client_response,
+             response_body,
              attestation,
              ..
          }| {
@@ -113,7 +111,7 @@ pub async fn handle_query(
                 builder = builder.header_typed(GraphAttestation(attestation));
             }
 
-            builder.body(client_response).expect("valid response")
+            builder.body(response_body).expect("valid response")
         },
     )
 }
@@ -181,17 +179,13 @@ async fn run_indexer_queries(
     let one_grt = NotNan::new(1e18).unwrap();
     let grt_per_usd = *ctx.grt_per_usd.borrow();
 
-    // Create the Agora context from the query and variables
-    let variables = client_request
+    let variables_json = client_request
         .variables
         .as_ref()
         .map(ToString::to_string)
         .unwrap_or_default();
-    // We handle these errors here, instead of `handle_query`, because the agora context is tied to
-    // the lifetime of the query body which may need to extend past the client response. Even if
-    // it doesn't, it is relatively difficult to convince the compiler of that.
-    let query_context = match QueryContext::new(&client_request.query, &variables) {
-        Ok(query_context) => query_context,
+    let variables = match parse_variables(&variables_json) {
+        Ok(variables) => variables,
         Err(err) => {
             client_response
                 .try_send(Err(Error::BadQuery(anyhow!("{err}"))))
@@ -217,16 +211,20 @@ async fn run_indexer_queries(
         // Get the estimated blocks per minute for the chain
         let blocks_per_minute = chain_reader.blocks_per_minute();
 
-        let block_requirements =
-            match resolve_block_requirements(&chain_reader, &query_context, subgraph.start_block) {
-                Ok(block_requirements) => block_requirements,
-                Err(err) => {
-                    client_response
-                        .try_send(Err(Error::BadQuery(anyhow!("{err}"))))
-                        .unwrap();
-                    return;
-                }
-            };
+        let block_requirements = match resolve_block_requirements(
+            &chain_reader,
+            &client_request.query,
+            &variables,
+            subgraph.start_block,
+        ) {
+            Ok(block_requirements) => block_requirements,
+            Err(err) => {
+                client_response
+                    .try_send(Err(Error::BadQuery(anyhow!("{err}"))))
+                    .unwrap();
+                return;
+            }
+        };
 
         (chain_head, blocks_per_minute, block_requirements)
     };
@@ -247,16 +245,26 @@ async fn run_indexer_queries(
     indexer_errors.extend(errors);
 
     if tracing::enabled!(tracing::Level::TRACE) {
-        tracing::trace!(client_query = client_request.query, variables);
+        tracing::trace!(
+            client_query = client_request.query,
+            variables = variables_json
+        );
         tracing::trace!(?candidates);
     } else if tracing::enabled!(tracing::Level::DEBUG) && rand::rng().random_bool(0.01) {
         // Log candidates at a low rate to avoid log bloat
-        tracing::debug!(client_query = client_request.query, variables);
+        tracing::debug!(
+            client_query = client_request.query,
+            variables = variables_json
+        );
         tracing::debug!(?candidates);
     }
 
     let client_request_bytes = client_request.query.len() as u32;
-    let indexer_query = rewrite_query(&query_context);
+    let indexer_query = serde_json::to_string(&json!({
+        "query": client_request.query,
+        "variables": variables,
+    }))
+    .unwrap();
     let mut indexer_requests: Vec<reports::IndexerRequest> = Default::default();
     let mut client_response_time: Option<Duration> = None;
     let mut client_response_bytes: Option<u32> = None;
@@ -336,7 +344,7 @@ async fn run_indexer_queries(
                 Ok(response) if client_response_time.is_none() => {
                     let _ = client_response.try_send(Ok(response.clone()));
                     client_response_time = Some(start_time.elapsed());
-                    client_response_bytes = Some(response.client_response.len() as u32);
+                    client_response_bytes = Some(response.response_body.len() as u32);
                 }
                 Ok(_) => (),
                 Err(err) => {
@@ -381,7 +389,7 @@ async fn run_indexer_queries(
 
     for indexer_request in &indexer_requests {
         let latest_block = match &indexer_request.result {
-            Ok(response) => response.probe_block.as_ref().map(|b| b.number),
+            Ok(response) => response.indexed_block.as_ref().map(|b| b.number),
             Err(IndexerError::Unavailable(UnavailableReason::MissingBlock(err))) => err.latest,
             _ => None,
         };
@@ -397,7 +405,7 @@ async fn run_indexer_queries(
             .result
             .as_ref()
             .ok()
-            .and_then(|r| r.probe_block.clone())
+            .and_then(|r| r.indexed_block.clone())
         {
             chain.notify(block, indexer_request.indexer);
         }
@@ -773,13 +781,13 @@ pub async fn handle_indexer_query(
         subgraph: None,
         grt_per_usd,
         request_bytes: indexer_request.request.len() as u32,
-        response_bytes: result.as_ref().map(|r| r.client_response.len() as u32).ok(),
+        response_bytes: result.as_ref().map(|r| r.response_body.len() as u32).ok(),
         indexer_requests: vec![indexer_request],
     });
 
     result.map(
         |IndexerResponse {
-             client_response,
+             response_body,
              attestation,
              ..
          }| {
@@ -792,7 +800,7 @@ pub async fn handle_indexer_query(
                 builder = builder.header_typed(GraphAttestation(attestation));
             }
 
-            builder.body(client_response).expect("valid response")
+            builder.body(response_body).expect("valid response")
         },
     )
 }

--- a/src/indexer_client.rs
+++ b/src/indexer_client.rs
@@ -22,11 +22,10 @@ use crate::{
 
 #[derive(Clone, Debug)]
 pub struct IndexerResponse {
-    pub original_response: String,
+    pub response_body: String,
     pub attestation: Option<Attestation>,
-    pub client_response: String,
     pub errors: Vec<String>,
-    pub probe_block: Option<Block>,
+    pub indexed_block: Option<Block>,
 }
 
 #[derive(Clone)]
@@ -78,6 +77,7 @@ impl IndexerClient {
             .get("graph-indexed")
             .and_then(|v| v.to_str().ok());
         tracing::debug!(indexed_block = indexed_block.unwrap_or("null"));
+        let indexed_block = indexed_block.and_then(parse_graph_indexed_header);
 
         #[derive(Debug, Deserialize)]
         pub struct IndexerResponsePayload {
@@ -94,10 +94,10 @@ impl IndexerClient {
             return Err(BadResponse(err));
         }
 
-        let original_response = payload
+        let response_body = payload
             .graphql_response
             .ok_or_else(|| BadResponse("missing response".into()))?;
-        let (client_response, errors, probe_block) = rewrite_response(&original_response)?;
+        let errors = response_errors(&response_body)?;
         let errors: Vec<String> = errors.into_iter().map(|err| err.message).collect();
 
         errors
@@ -120,7 +120,7 @@ impl IndexerClient {
                         attestation,
                         &allocation,
                         query,
-                        &original_response,
+                        &response_body,
                     ) {
                         return Err(BadResponse(format!("bad attestation: {err}")));
                     }
@@ -144,11 +144,10 @@ impl IndexerClient {
         }
 
         Ok(IndexerResponse {
-            original_response,
+            response_body,
             attestation: payload.attestation,
-            client_response,
             errors,
-            probe_block,
+            indexed_block,
         })
     }
 }
@@ -158,30 +157,12 @@ struct Error {
     message: String,
 }
 
-fn rewrite_response(response: &str) -> Result<(String, Vec<Error>, Option<Block>), IndexerError> {
+fn response_errors(response: &str) -> Result<Vec<Error>, IndexerError> {
     #[derive(Deserialize, Serialize)]
     struct Response {
-        data: Option<ProbedData>,
         #[serde(default)]
         #[serde(skip_serializing_if = "Vec::is_empty")]
         errors: Vec<Error>,
-    }
-    #[derive(Deserialize, Serialize)]
-    struct ProbedData {
-        #[serde(rename = "_gateway_probe_", skip_serializing)]
-        probe: Option<Meta>,
-        #[serde(flatten)]
-        data: serde_json::Value,
-    }
-    #[derive(Deserialize)]
-    struct Meta {
-        block: MaybeBlock,
-    }
-    #[derive(Deserialize)]
-    struct MaybeBlock {
-        number: BlockNumber,
-        hash: BlockHash,
-        timestamp: Option<u64>,
     }
     let mut payload: Response =
         serde_json::from_str(response).map_err(|err| BadResponse(err.to_string()))?;
@@ -192,25 +173,27 @@ fn rewrite_response(response: &str) -> Result<(String, Vec<Error>, Option<Block>
         err.message.shrink_to_fit();
     }
 
-    let block = payload
-        .data
-        .as_mut()
-        .and_then(|data| data.probe.take())
-        .and_then(|meta| {
-            Some(Block {
-                number: meta.block.number,
-                hash: meta.block.hash,
-                timestamp: meta.block.timestamp?,
-            })
-        });
-    let client_response = serde_json::to_string(&payload).unwrap();
-    Ok((client_response, payload.errors, block))
+    Ok(payload.errors)
+}
+
+fn parse_graph_indexed_header(header: &str) -> Option<Block> {
+    #[derive(Deserialize)]
+    struct GraphIndexed {
+        number: BlockNumber,
+        hash: BlockHash,
+        timestamp: Option<u64>,
+    }
+
+    let payload: GraphIndexed = serde_json::from_str(header).ok()?;
+    Some(Block {
+        number: payload.number,
+        hash: payload.hash,
+        timestamp: payload.timestamp?,
+    })
 }
 
 fn check_block_error(err: &str) -> Result<(), MissingBlockError> {
-    // TODO: indexers should *always* report their block status in a header on every query. This
-    // will significantly reduce how brittle this feedback is, and also give a stronger basis for
-    // prediction in the happy path.
+    // Older indexers may still only communicate block availability through GraphQL errors.
     if !err.contains("Failed to decode `block") {
         return Ok(());
     }

--- a/src/network/subgraph_client.rs
+++ b/src/network/subgraph_client.rs
@@ -242,12 +242,11 @@ impl Client {
                 )
                 .await?;
             tracing::trace!(
-                response.original_response,
-                response.client_response,
+                response.response_body,
                 ?response.errors,
             );
             let response: QueryResponse =
-                serde_json::from_str(&response.client_response).context("parse body")?;
+                serde_json::from_str(&response.response_body).context("parse body")?;
             if !response.errors.is_empty() {
                 bail!("{:?}", response.errors);
             }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -180,15 +180,15 @@ impl Reporter {
             ) {
                 continue;
             }
-            if let Some((original_response, attestation)) = indexer_request
+            if let Some((response_body, attestation)) = indexer_request
                 .result
                 .ok()
-                .and_then(|r| Some((r.original_response, r.attestation?)))
+                .and_then(|r| Some((r.response_body, r.attestation?)))
             {
                 const MAX_PAYLOAD_BYTES: usize = 100_000;
                 AttestationProtobuf {
                     request: Some(indexer_request.request).filter(|r| r.len() <= MAX_PAYLOAD_BYTES),
-                    response: Some(original_response).filter(|r| r.len() <= MAX_PAYLOAD_BYTES),
+                    response: Some(response_body).filter(|r| r.len() <= MAX_PAYLOAD_BYTES),
                     allocation: indexer_request.receipt.allocation().0.0.into(),
                     subgraph_deployment: attestation.deployment.0.into(),
                     request_cid: attestation.request_cid.0.into(),


### PR DESCRIPTION
This remove rewrites that insert an additional `_meta` query to probe indexing progress on every query. Assuming sufficient indexer support for the `graph-indexed` header, then this should be a safe removal.

Resolves #900